### PR TITLE
feat: expand dwarf perf baseline coverage

### DIFF
--- a/.github/workflows/dwarf-perf-history.yml
+++ b/.github/workflows/dwarf-perf-history.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     name: Build DWARF Perf History
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     permissions:
       contents: write
     env:
@@ -86,22 +86,36 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/dwarf-perf/build_corpus.sh
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name main-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name main-rust-parse-stress \
-            --parse-target rust-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          parse_targets=(
+            parse-stress
+            rust-parse-stress
+            cpp-template-stress
+            rust-generic-stress
+            cpp-deep-namespace
+          )
+          combine_args=()
+          primary_json=""
+
+          for target in "${parse_targets[@]}"; do
+            result_json="$DWARF_PERF_RESULTS_DIR/main-${target}.json"
+            ./scripts/dwarf-perf/run_baseline.sh \
+              --skip-build \
+              --results-dir "$DWARF_PERF_RESULTS_DIR" \
+              --result-name "main-${target}" \
+              --runs 10 \
+              --cargo-target-dir "$CARGO_TARGET_DIR" \
+              --parse-target "$target"
+
+            if [[ -z "$primary_json" ]]; then
+              primary_json="$result_json"
+            else
+              combine_args+=(--additional "$result_json")
+            fi
+          done
+
           python3 scripts/dwarf-perf/combine_baselines.py \
-            --primary "$DWARF_PERF_RESULTS_DIR/main-parse-stress.json" \
-            --additional "$DWARF_PERF_RESULTS_DIR/main-rust-parse-stress.json" \
+            --primary "$primary_json" \
+            "${combine_args[@]}" \
             --output "$DWARF_PERF_RESULTS_DIR/main.json"
 
       - name: Restore history state worktree

--- a/.github/workflows/dwarf-perf-regression.yml
+++ b/.github/workflows/dwarf-perf-regression.yml
@@ -23,7 +23,7 @@ jobs:
   regression:
     name: DWARF Perf Regression
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -62,7 +62,7 @@ jobs:
 
           benchmark_changed=false
           if printf '%s\n' "$changed_files" | grep -Eq \
-            '^(scripts/dwarf-perf/corpus/|scripts/dwarf-perf/build_corpus\.sh$|scripts/dwarf-perf/build_corpus_in_container\.sh$|scripts/dwarf-perf/run_baseline\.sh$|scripts/dwarf-perf/generate_parse_stress\.py$|scripts/dwarf-perf/generate_rust_parse_stress\.py$|scripts/dwarf-perf/builder_image_ref\.txt$|scripts/dwarf-perf/compare_baseline\.py$|\.github/workflows/dwarf-perf-regression\.yml$)'; then
+            '^(scripts/dwarf-perf/corpus/|scripts/dwarf-perf/build_corpus\.sh$|scripts/dwarf-perf/build_corpus_in_container\.sh$|scripts/dwarf-perf/run_baseline\.sh$|scripts/dwarf-perf/generate_parse_stress\.py$|scripts/dwarf-perf/generate_rust_parse_stress\.py$|scripts/dwarf-perf/generate_cpp_template_stress\.py$|scripts/dwarf-perf/generate_rust_generic_stress\.py$|scripts/dwarf-perf/generate_cpp_deep_namespace\.py$|scripts/dwarf-perf/builder_image_ref\.txt$|scripts/dwarf-perf/compare_baseline\.py$|\.github/workflows/dwarf-perf-regression\.yml$)'; then
             benchmark_changed=true
           fi
 
@@ -123,99 +123,125 @@ jobs:
           set -euo pipefail
           ./scripts/dwarf-perf/build_corpus.sh
           manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
-          if jq -e '.artifacts[] | select(.name=="rust-parse-stress")' "$manifest" >/dev/null; then
-            echo "has_rust_target=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_rust_target=false" >> "$GITHUB_OUTPUT"
-          fi
+          parse_targets=(
+            parse-stress
+            rust-parse-stress
+            cpp-template-stress
+            rust-generic-stress
+            cpp-deep-namespace
+          )
+          missing_targets=false
+          for target in "${parse_targets[@]}"; do
+            safe_target=${target//-/_}
+            if jq -e --arg target "$target" '.artifacts[] | select(.name==$target)' "$manifest" >/dev/null; then
+              echo "has_${safe_target}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_${safe_target}=false" >> "$GITHUB_OUTPUT"
+              missing_targets=true
+            fi
+          done
+          echo "missing_targets=$missing_targets" >> "$GITHUB_OUTPUT"
 
-      - name: Run base parse-stress baseline
+      - name: Run base baselines
         if: steps.detect.outputs.base_supported == 'true'
         working-directory: base
         run: |
           set -euo pipefail
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --corpus-dir "$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out" \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name base-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
+          parse_targets=(
+            parse-stress
+            rust-parse-stress
+            cpp-template-stress
+            rust-generic-stress
+            cpp-deep-namespace
+          )
 
-      - name: Run base rust-parse-stress baseline
-        if: steps.base_corpus.outputs.has_rust_target == 'true'
-        working-directory: base
-        run: |
-          set -euo pipefail
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --corpus-dir "$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out" \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name base-rust-parse-stress \
-            --parse-target rust-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          for target in "${parse_targets[@]}"; do
+            if ! jq -e --arg target "$target" '.artifacts[] | select(.name==$target)' "$manifest" >/dev/null; then
+              continue
+            fi
 
-      - name: Run head parse-stress baseline with base corpus
+            ./scripts/dwarf-perf/run_baseline.sh \
+              --skip-build \
+              --corpus-dir "$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out" \
+              --results-dir "$DWARF_PERF_RESULTS_DIR" \
+              --result-name "base-${target}" \
+              --runs 10 \
+              --cargo-target-dir "$CARGO_TARGET_DIR" \
+              --parse-target "$target"
+          done
+
+      - name: Run head baselines with base corpus
         if: steps.detect.outputs.base_supported == 'true'
         working-directory: head
         run: |
           set -euo pipefail
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --corpus-dir "$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out" \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name head-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
+          parse_targets=(
+            parse-stress
+            rust-parse-stress
+            cpp-template-stress
+            rust-generic-stress
+            cpp-deep-namespace
+          )
 
-      - name: Run head rust-parse-stress baseline with base corpus
-        if: steps.base_corpus.outputs.has_rust_target == 'true'
-        working-directory: head
-        run: |
-          set -euo pipefail
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --corpus-dir "$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out" \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name head-rust-parse-stress \
-            --parse-target rust-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          for target in "${parse_targets[@]}"; do
+            if ! jq -e --arg target "$target" '.artifacts[] | select(.name==$target)' "$manifest" >/dev/null; then
+              continue
+            fi
+
+            ./scripts/dwarf-perf/run_baseline.sh \
+              --skip-build \
+              --corpus-dir "$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out" \
+              --results-dir "$DWARF_PERF_RESULTS_DIR" \
+              --result-name "head-${target}" \
+              --runs 10 \
+              --cargo-target-dir "$CARGO_TARGET_DIR" \
+              --parse-target "$target"
+          done
 
       - name: Build head corpus for bootstrap targets
-        if: steps.detect.outputs.base_supported != 'true' || steps.base_corpus.outputs.has_rust_target != 'true'
+        if: steps.detect.outputs.base_supported != 'true' || steps.base_corpus.outputs.missing_targets == 'true'
         working-directory: head
         run: |
           set -euo pipefail
           ./scripts/dwarf-perf/build_corpus.sh
 
-      - name: Run head-only parse-stress baseline
-        if: steps.detect.outputs.base_supported != 'true'
+      - name: Run head-only baselines
+        if: steps.detect.outputs.base_supported != 'true' || steps.base_corpus.outputs.missing_targets == 'true'
         working-directory: head
+        env:
+          BASE_SUPPORTED: ${{ steps.detect.outputs.base_supported }}
         run: |
           set -euo pipefail
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --corpus-dir "$GITHUB_WORKSPACE/head/scripts/dwarf-perf/corpus/out" \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name head-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          head_manifest="$GITHUB_WORKSPACE/head/scripts/dwarf-perf/corpus/out/manifest.json"
+          base_manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
+          parse_targets=(
+            parse-stress
+            rust-parse-stress
+            cpp-template-stress
+            rust-generic-stress
+            cpp-deep-namespace
+          )
 
-      - name: Run head-only rust-parse-stress baseline
-        if: steps.detect.outputs.base_supported != 'true' || steps.base_corpus.outputs.has_rust_target != 'true'
-        working-directory: head
-        run: |
-          set -euo pipefail
-          ./scripts/dwarf-perf/run_baseline.sh \
-            --skip-build \
-            --corpus-dir "$GITHUB_WORKSPACE/head/scripts/dwarf-perf/corpus/out" \
-            --results-dir "$DWARF_PERF_RESULTS_DIR" \
-            --result-name head-rust-parse-stress \
-            --parse-target rust-parse-stress \
-            --runs 10 \
-            --cargo-target-dir "$CARGO_TARGET_DIR"
+          for target in "${parse_targets[@]}"; do
+            if ! jq -e --arg target "$target" '.artifacts[] | select(.name==$target)' "$head_manifest" >/dev/null; then
+              continue
+            fi
+
+            if [[ "$BASE_SUPPORTED" == "true" ]] && jq -e --arg target "$target" '.artifacts[] | select(.name==$target)' "$base_manifest" >/dev/null; then
+              continue
+            fi
+
+            ./scripts/dwarf-perf/run_baseline.sh \
+              --skip-build \
+              --corpus-dir "$GITHUB_WORKSPACE/head/scripts/dwarf-perf/corpus/out" \
+              --results-dir "$DWARF_PERF_RESULTS_DIR" \
+              --result-name "head-${target}" \
+              --runs 10 \
+              --cargo-target-dir "$CARGO_TARGET_DIR" \
+              --parse-target "$target"
+          done
 
       - name: Compare baselines
         if: steps.detect.outputs.base_supported == 'true'
@@ -223,7 +249,6 @@ jobs:
         working-directory: head
         env:
           REPORT_ONLY: ${{ steps.detect.outputs.benchmark_changed }}
-          BASE_HAS_RUST_TARGET: ${{ steps.base_corpus.outputs.has_rust_target }}
         run: |
           set +e
 
@@ -253,13 +278,15 @@ jobs:
               )
             fi
 
+            echo "::group::DWARF perf compare: $target"
             python3 scripts/dwarf-perf/compare_baseline.py "${args[@]}"
             target_exit=$?
+            echo "::endgroup::"
 
             {
               echo "### Parse Target: \`$target\`"
               echo
-              sed '1,2d' "$summary_result"
+              sed '1,3d' "$summary_result"
               echo
             } >> "$DWARF_PERF_RESULTS_DIR/summary.md"
 
@@ -272,31 +299,37 @@ jobs:
           } > "$DWARF_PERF_RESULTS_DIR/summary.md"
           overall_exit=0
 
-          compare_target "parse-stress" "parse_stress"
-          parse_exit=$?
-          if [[ "$parse_exit" -ne 0 ]]; then
-            overall_exit="$parse_exit"
-          fi
+          parse_targets=(
+            parse-stress
+            rust-parse-stress
+            cpp-template-stress
+            rust-generic-stress
+            cpp-deep-namespace
+          )
 
-          if [[ "$BASE_HAS_RUST_TARGET" == "true" ]]; then
-            compare_target "rust-parse-stress" "rust_parse_stress"
-            rust_exit=$?
-            if [[ "$rust_exit" -ne 0 ]]; then
-              overall_exit="$rust_exit"
+          for target in "${parse_targets[@]}"; do
+            safe_target=${target//-/_}
+            if [[ -f "$DWARF_PERF_RESULTS_DIR/base-${target}.json" ]]; then
+              compare_target "$target" "$safe_target"
+              target_exit=$?
+              if [[ "$target_exit" -ne 0 ]]; then
+                overall_exit="$target_exit"
+              fi
+              continue
             fi
-          else
+
             {
-              printf '%s\n' '### Parse Target: `rust-parse-stress`'
+              printf '### Parse Target: `%s`\n' "$target"
               printf '\n'
               printf '%s\n' '- Mode: `bootstrap`'
               printf '%s\n' "- Base: \`${BASE_SHA::12}\`"
               printf '%s\n' "- Head: \`${HEAD_SHA::12}\`"
-              printf '%s\n' '- Note: The base revision does not provide the `rust-parse-stress` corpus yet, so threshold comparison was skipped.'
+              printf '%s\n' "- Note: The base revision does not provide the \`$target\` corpus yet, so threshold comparison was skipped."
               printf '\n'
-              printf '%s\n' 'A head-only Rust parse baseline was generated and uploaded as an artifact for inspection.'
+              printf '%s\n' "A head-only baseline for \`$target\` was generated and uploaded as an artifact for inspection."
               printf '\n'
             } >> "$DWARF_PERF_RESULTS_DIR/summary.md"
-          fi
+          done
 
           echo "exit_code=$overall_exit" >> "$GITHUB_OUTPUT"
           exit 0
@@ -312,7 +345,7 @@ jobs:
             printf '%s\n' "- Head: \`${HEAD_SHA::12}\`"
             printf '%s\n' '- Note: The base revision does not contain the DWARF perf baseline tooling yet, so regression gating was skipped.'
             printf '\n'
-            printf '%s\n' 'Head-only baselines for `parse-stress` and `rust-parse-stress` were generated and uploaded as artifacts for inspection.'
+            printf '%s\n' 'Head-only baselines for `parse-stress`, `rust-parse-stress`, `cpp-template-stress`, `rust-generic-stress`, and `cpp-deep-namespace` were generated and uploaded as artifacts for inspection.'
           } > "$DWARF_PERF_RESULTS_DIR/summary.md"
 
       - name: Publish summary

--- a/scripts/dwarf-perf/build_corpus.sh
+++ b/scripts/dwarf-perf/build_corpus.sh
@@ -44,8 +44,10 @@ CONTAINER_OUT_DIR="/workspace${OUT_DIR#"$REPO_ROOT"}"
 env_args=()
 for var_name in \
     DWARF_PERF_CC \
+    DWARF_PERF_CXX \
     DWARF_PERF_DWARF_VERSION \
     DWARF_PERF_CFLAGS \
+    DWARF_PERF_CXXFLAGS \
     DWARF_PERF_LDFLAGS \
     DWARF_PERF_RUSTC \
     DWARF_PERF_RUSTFLAGS \
@@ -57,7 +59,21 @@ for var_name in \
     RUST_PARSE_STRESS_PRESET \
     RUST_PARSE_STRESS_MODULES \
     RUST_PARSE_STRESS_TYPES_PER_MODULE \
-    RUST_PARSE_STRESS_FUNCTIONS_PER_MODULE
+    RUST_PARSE_STRESS_FUNCTIONS_PER_MODULE \
+    CPP_TEMPLATE_STRESS_PRESET \
+    CPP_TEMPLATE_STRESS_UNITS \
+    CPP_TEMPLATE_STRESS_FAMILIES_PER_UNIT \
+    CPP_TEMPLATE_STRESS_INSTANTIATIONS_PER_FAMILY \
+    CPP_TEMPLATE_STRESS_METHODS_PER_FAMILY \
+    RUST_GENERIC_STRESS_PRESET \
+    RUST_GENERIC_STRESS_MODULES \
+    RUST_GENERIC_STRESS_FAMILIES_PER_MODULE \
+    RUST_GENERIC_STRESS_MONOMORPHS_PER_FAMILY \
+    CPP_DEEP_NAMESPACE_PRESET \
+    CPP_DEEP_NAMESPACE_UNITS \
+    CPP_DEEP_NAMESPACE_NAMESPACE_DEPTH \
+    CPP_DEEP_NAMESPACE_BRANCHES_PER_UNIT \
+    CPP_DEEP_NAMESPACE_FUNCTIONS_PER_BRANCH
 do
     if [[ -n "${!var_name:-}" ]]; then
         env_args+=(-e "$var_name")
@@ -78,5 +94,8 @@ echo "Host artifacts:"
 echo "  $OUT_DIR/query-hotspot/query_hotspot"
 echo "  $OUT_DIR/parse-stress/parse_stress"
 echo "  $OUT_DIR/rust-parse-stress/rust_parse_stress"
+echo "  $OUT_DIR/cpp-template-stress/cpp_template_stress"
+echo "  $OUT_DIR/rust-generic-stress/rust_generic_stress"
+echo "  $OUT_DIR/cpp-deep-namespace/cpp_deep_namespace"
 echo "  $OUT_DIR/manifest.json"
 echo

--- a/scripts/dwarf-perf/build_corpus_in_container.sh
+++ b/scripts/dwarf-perf/build_corpus_in_container.sh
@@ -13,19 +13,45 @@ OUT_DIR=$1
 QUERY_OUT_DIR="$OUT_DIR/query-hotspot"
 PARSE_OUT_DIR="$OUT_DIR/parse-stress"
 RUST_PARSE_OUT_DIR="$OUT_DIR/rust-parse-stress"
+CPP_TEMPLATE_OUT_DIR="$OUT_DIR/cpp-template-stress"
+RUST_GENERIC_OUT_DIR="$OUT_DIR/rust-generic-stress"
+CPP_NAMESPACE_OUT_DIR="$OUT_DIR/cpp-deep-namespace"
 WORK_DIR="$OUT_DIR/_build"
 PARSE_SRC_DIR="$WORK_DIR/parse-stress-src"
 PARSE_OBJ_DIR="$WORK_DIR/parse-stress-obj"
 RUST_PARSE_SRC_DIR="$WORK_DIR/rust-parse-stress-src"
+CPP_TEMPLATE_SRC_DIR="$WORK_DIR/cpp-template-stress-src"
+CPP_TEMPLATE_OBJ_DIR="$WORK_DIR/cpp-template-stress-obj"
+RUST_GENERIC_SRC_DIR="$WORK_DIR/rust-generic-stress-src"
+CPP_NAMESPACE_SRC_DIR="$WORK_DIR/cpp-deep-namespace-src"
+CPP_NAMESPACE_OBJ_DIR="$WORK_DIR/cpp-deep-namespace-obj"
 MANIFEST_PATH="$OUT_DIR/manifest.json"
 PARSE_CONFIG_PATH="$PARSE_SRC_DIR/generation_config.json"
 RUST_PARSE_CONFIG_PATH="$RUST_PARSE_SRC_DIR/generation_config.json"
+CPP_TEMPLATE_CONFIG_PATH="$CPP_TEMPLATE_SRC_DIR/generation_config.json"
+RUST_GENERIC_CONFIG_PATH="$RUST_GENERIC_SRC_DIR/generation_config.json"
+CPP_NAMESPACE_CONFIG_PATH="$CPP_NAMESPACE_SRC_DIR/generation_config.json"
 
 CC=${DWARF_PERF_CC:-gcc}
+CXX=${DWARF_PERF_CXX:-g++}
 RUSTC=${DWARF_PERF_RUSTC:-rustc}
 DWARF_VERSION=${DWARF_PERF_DWARF_VERSION:-5}
 COMMON_CFLAGS=(
     -std=c11
+    -Wall
+    -Wextra
+    -Werror
+    -g3
+    -O0
+    "-gdwarf-${DWARF_VERSION}"
+    -fno-omit-frame-pointer
+    -fno-inline
+    -fno-optimize-sibling-calls
+    -ffile-prefix-map=/workspace=/workspace
+    -fdebug-prefix-map=/workspace=/workspace
+)
+COMMON_CXXFLAGS=(
+    -std=c++20
     -Wall
     -Wextra
     -Werror
@@ -47,6 +73,13 @@ else
     EXTRA_CFLAGS=()
 fi
 
+if [[ -n "${DWARF_PERF_CXXFLAGS:-}" ]]; then
+    # shellcheck disable=SC2206
+    EXTRA_CXXFLAGS=(${DWARF_PERF_CXXFLAGS})
+else
+    EXTRA_CXXFLAGS=()
+fi
+
 if [[ -n "${DWARF_PERF_LDFLAGS:-}" ]]; then
     # shellcheck disable=SC2206
     EXTRA_LDFLAGS=(${DWARF_PERF_LDFLAGS})
@@ -63,9 +96,17 @@ fi
 
 PARSE_STRESS_PRESET=${PARSE_STRESS_PRESET:-large}
 RUST_PARSE_STRESS_PRESET=${RUST_PARSE_STRESS_PRESET:-large}
+CPP_TEMPLATE_STRESS_PRESET=${CPP_TEMPLATE_STRESS_PRESET:-large}
+RUST_GENERIC_STRESS_PRESET=${RUST_GENERIC_STRESS_PRESET:-large}
+CPP_DEEP_NAMESPACE_PRESET=${CPP_DEEP_NAMESPACE_PRESET:-large}
 
 if ! command -v "$CC" >/dev/null 2>&1; then
     echo "compiler not found: $CC" >&2
+    exit 1
+fi
+
+if ! command -v "$CXX" >/dev/null 2>&1; then
+    echo "c++ compiler not found: $CXX" >&2
     exit 1
 fi
 
@@ -74,9 +115,61 @@ if ! command -v "$RUSTC" >/dev/null 2>&1; then
     exit 1
 fi
 
-mkdir -p "$QUERY_OUT_DIR" "$PARSE_OUT_DIR" "$RUST_PARSE_OUT_DIR" "$PARSE_SRC_DIR" "$PARSE_OBJ_DIR" "$RUST_PARSE_SRC_DIR"
-rm -rf "$PARSE_SRC_DIR" "$PARSE_OBJ_DIR" "$RUST_PARSE_SRC_DIR"
-mkdir -p "$PARSE_SRC_DIR" "$PARSE_OBJ_DIR" "$RUST_PARSE_SRC_DIR"
+mkdir -p \
+    "$QUERY_OUT_DIR" \
+    "$PARSE_OUT_DIR" \
+    "$RUST_PARSE_OUT_DIR" \
+    "$CPP_TEMPLATE_OUT_DIR" \
+    "$RUST_GENERIC_OUT_DIR" \
+    "$CPP_NAMESPACE_OUT_DIR"
+rm -rf \
+    "$PARSE_SRC_DIR" \
+    "$PARSE_OBJ_DIR" \
+    "$RUST_PARSE_SRC_DIR" \
+    "$CPP_TEMPLATE_SRC_DIR" \
+    "$CPP_TEMPLATE_OBJ_DIR" \
+    "$RUST_GENERIC_SRC_DIR" \
+    "$CPP_NAMESPACE_SRC_DIR" \
+    "$CPP_NAMESPACE_OBJ_DIR"
+mkdir -p \
+    "$PARSE_SRC_DIR" \
+    "$PARSE_OBJ_DIR" \
+    "$RUST_PARSE_SRC_DIR" \
+    "$CPP_TEMPLATE_SRC_DIR" \
+    "$CPP_TEMPLATE_OBJ_DIR" \
+    "$RUST_GENERIC_SRC_DIR" \
+    "$CPP_NAMESPACE_SRC_DIR" \
+    "$CPP_NAMESPACE_OBJ_DIR"
+
+compile_cpp_corpus() {
+    local src_dir=$1
+    local obj_dir=$2
+    local out_bin=$3
+    local -a cpp_objects=()
+
+    mapfile -t cpp_sources < <(find "$src_dir" -name '*.cpp' -print | sort)
+    for source_path in "${cpp_sources[@]}"; do
+        local source_name
+        local object_path
+        source_name=$(basename "$source_path" .cpp)
+        object_path="$obj_dir/${source_name}.o"
+        "$CXX" \
+            "${COMMON_CXXFLAGS[@]}" \
+            "${EXTRA_CXXFLAGS[@]}" \
+            -c \
+            -o "$object_path" \
+            "$source_path"
+        cpp_objects+=("$object_path")
+    done
+
+    "$CXX" \
+        -fno-pie \
+        -no-pie \
+        "${cpp_objects[@]}" \
+        -o "$out_bin" \
+        "${COMMON_LDFLAGS[@]}" \
+        "${EXTRA_LDFLAGS[@]}"
+}
 
 QUERY_SRC="$REPO_ROOT/scripts/dwarf-perf/corpus/src/query-hotspot/query_hotspot.c"
 QUERY_BIN="$QUERY_OUT_DIR/query_hotspot"
@@ -184,16 +277,130 @@ RUST_PARSE_BIN="$RUST_PARSE_OUT_DIR/rust_parse_stress"
     -o "$RUST_PARSE_BIN" \
     "$RUST_PARSE_SRC_DIR/main.rs"
 
+cpp_template_generator_args=(
+    --output-dir "$CPP_TEMPLATE_SRC_DIR"
+    --preset "$CPP_TEMPLATE_STRESS_PRESET"
+)
+
+if [[ -n "${CPP_TEMPLATE_STRESS_UNITS:-}" ]]; then
+    cpp_template_generator_args+=(--units "$CPP_TEMPLATE_STRESS_UNITS")
+fi
+
+if [[ -n "${CPP_TEMPLATE_STRESS_FAMILIES_PER_UNIT:-}" ]]; then
+    cpp_template_generator_args+=(--families-per-unit "$CPP_TEMPLATE_STRESS_FAMILIES_PER_UNIT")
+fi
+
+if [[ -n "${CPP_TEMPLATE_STRESS_INSTANTIATIONS_PER_FAMILY:-}" ]]; then
+    cpp_template_generator_args+=(--instantiations-per-family "$CPP_TEMPLATE_STRESS_INSTANTIATIONS_PER_FAMILY")
+fi
+
+if [[ -n "${CPP_TEMPLATE_STRESS_METHODS_PER_FAMILY:-}" ]]; then
+    cpp_template_generator_args+=(--methods-per-family "$CPP_TEMPLATE_STRESS_METHODS_PER_FAMILY")
+fi
+
+python3 "$REPO_ROOT/scripts/dwarf-perf/generate_cpp_template_stress.py" "${cpp_template_generator_args[@]}"
+
+CPP_TEMPLATE_STRESS_PRESET=$(jq -r '.preset' "$CPP_TEMPLATE_CONFIG_PATH")
+CPP_TEMPLATE_STRESS_UNITS=$(jq -r '.units' "$CPP_TEMPLATE_CONFIG_PATH")
+CPP_TEMPLATE_STRESS_FAMILIES_PER_UNIT=$(jq -r '.families_per_unit' "$CPP_TEMPLATE_CONFIG_PATH")
+CPP_TEMPLATE_STRESS_INSTANTIATIONS_PER_FAMILY=$(jq -r '.instantiations_per_family' "$CPP_TEMPLATE_CONFIG_PATH")
+CPP_TEMPLATE_STRESS_METHODS_PER_FAMILY=$(jq -r '.methods_per_family' "$CPP_TEMPLATE_CONFIG_PATH")
+CPP_TEMPLATE_STRESS_ESTIMATED_SYMBOLS=$(jq -r '.estimated_mangled_symbols' "$CPP_TEMPLATE_CONFIG_PATH")
+CPP_TEMPLATE_STRESS_GENERATED_CPP_FILES=$(jq -r '.generated_cpp_files' "$CPP_TEMPLATE_CONFIG_PATH")
+
+CPP_TEMPLATE_BIN="$CPP_TEMPLATE_OUT_DIR/cpp_template_stress"
+compile_cpp_corpus "$CPP_TEMPLATE_SRC_DIR" "$CPP_TEMPLATE_OBJ_DIR" "$CPP_TEMPLATE_BIN"
+
+rust_generic_generator_args=(
+    --output-dir "$RUST_GENERIC_SRC_DIR"
+    --preset "$RUST_GENERIC_STRESS_PRESET"
+)
+
+if [[ -n "${RUST_GENERIC_STRESS_MODULES:-}" ]]; then
+    rust_generic_generator_args+=(--modules "$RUST_GENERIC_STRESS_MODULES")
+fi
+
+if [[ -n "${RUST_GENERIC_STRESS_FAMILIES_PER_MODULE:-}" ]]; then
+    rust_generic_generator_args+=(--families-per-module "$RUST_GENERIC_STRESS_FAMILIES_PER_MODULE")
+fi
+
+if [[ -n "${RUST_GENERIC_STRESS_MONOMORPHS_PER_FAMILY:-}" ]]; then
+    rust_generic_generator_args+=(--monomorphs-per-family "$RUST_GENERIC_STRESS_MONOMORPHS_PER_FAMILY")
+fi
+
+python3 "$REPO_ROOT/scripts/dwarf-perf/generate_rust_generic_stress.py" "${rust_generic_generator_args[@]}"
+
+RUST_GENERIC_STRESS_PRESET=$(jq -r '.preset' "$RUST_GENERIC_CONFIG_PATH")
+RUST_GENERIC_STRESS_MODULES=$(jq -r '.modules' "$RUST_GENERIC_CONFIG_PATH")
+RUST_GENERIC_STRESS_FAMILIES_PER_MODULE=$(jq -r '.families_per_module' "$RUST_GENERIC_CONFIG_PATH")
+RUST_GENERIC_STRESS_MONOMORPHS_PER_FAMILY=$(jq -r '.monomorphs_per_family' "$RUST_GENERIC_CONFIG_PATH")
+RUST_GENERIC_STRESS_ESTIMATED_SYMBOLS=$(jq -r '.estimated_mangled_symbols' "$RUST_GENERIC_CONFIG_PATH")
+RUST_GENERIC_STRESS_GENERATED_MODULE_FILES=$(jq -r '.generated_module_files' "$RUST_GENERIC_CONFIG_PATH")
+RUST_GENERIC_STRESS_GENERATED_RUST_FILES=$(jq -r '.generated_rust_files' "$RUST_GENERIC_CONFIG_PATH")
+
+RUST_GENERIC_BIN="$RUST_GENERIC_OUT_DIR/rust_generic_stress"
+"$RUSTC" \
+    --edition=2021 \
+    --remap-path-prefix "$REPO_ROOT=/workspace" \
+    -C debuginfo=2 \
+    -C opt-level=0 \
+    -C force-frame-pointers=yes \
+    -C link-dead-code=yes \
+    "${EXTRA_RUSTFLAGS[@]}" \
+    -o "$RUST_GENERIC_BIN" \
+    "$RUST_GENERIC_SRC_DIR/main.rs"
+
+cpp_namespace_generator_args=(
+    --output-dir "$CPP_NAMESPACE_SRC_DIR"
+    --preset "$CPP_DEEP_NAMESPACE_PRESET"
+)
+
+if [[ -n "${CPP_DEEP_NAMESPACE_UNITS:-}" ]]; then
+    cpp_namespace_generator_args+=(--units "$CPP_DEEP_NAMESPACE_UNITS")
+fi
+
+if [[ -n "${CPP_DEEP_NAMESPACE_NAMESPACE_DEPTH:-}" ]]; then
+    cpp_namespace_generator_args+=(--namespace-depth "$CPP_DEEP_NAMESPACE_NAMESPACE_DEPTH")
+fi
+
+if [[ -n "${CPP_DEEP_NAMESPACE_BRANCHES_PER_UNIT:-}" ]]; then
+    cpp_namespace_generator_args+=(--branches-per-unit "$CPP_DEEP_NAMESPACE_BRANCHES_PER_UNIT")
+fi
+
+if [[ -n "${CPP_DEEP_NAMESPACE_FUNCTIONS_PER_BRANCH:-}" ]]; then
+    cpp_namespace_generator_args+=(--functions-per-branch "$CPP_DEEP_NAMESPACE_FUNCTIONS_PER_BRANCH")
+fi
+
+python3 "$REPO_ROOT/scripts/dwarf-perf/generate_cpp_deep_namespace.py" "${cpp_namespace_generator_args[@]}"
+
+CPP_DEEP_NAMESPACE_PRESET=$(jq -r '.preset' "$CPP_NAMESPACE_CONFIG_PATH")
+CPP_DEEP_NAMESPACE_UNITS=$(jq -r '.units' "$CPP_NAMESPACE_CONFIG_PATH")
+CPP_DEEP_NAMESPACE_NAMESPACE_DEPTH=$(jq -r '.namespace_depth' "$CPP_NAMESPACE_CONFIG_PATH")
+CPP_DEEP_NAMESPACE_BRANCHES_PER_UNIT=$(jq -r '.branches_per_unit' "$CPP_NAMESPACE_CONFIG_PATH")
+CPP_DEEP_NAMESPACE_FUNCTIONS_PER_BRANCH=$(jq -r '.functions_per_branch' "$CPP_NAMESPACE_CONFIG_PATH")
+CPP_DEEP_NAMESPACE_ESTIMATED_SYMBOLS=$(jq -r '.estimated_mangled_symbols' "$CPP_NAMESPACE_CONFIG_PATH")
+CPP_DEEP_NAMESPACE_GENERATED_CPP_FILES=$(jq -r '.generated_cpp_files' "$CPP_NAMESPACE_CONFIG_PATH")
+
+CPP_NAMESPACE_BIN="$CPP_NAMESPACE_OUT_DIR/cpp_deep_namespace"
+compile_cpp_corpus "$CPP_NAMESPACE_SRC_DIR" "$CPP_NAMESPACE_OBJ_DIR" "$CPP_NAMESPACE_BIN"
+
 query_sha=$(sha256sum "$QUERY_BIN" | awk '{print $1}')
 parse_sha=$(sha256sum "$PARSE_BIN" | awk '{print $1}')
 rust_parse_sha=$(sha256sum "$RUST_PARSE_BIN" | awk '{print $1}')
+cpp_template_sha=$(sha256sum "$CPP_TEMPLATE_BIN" | awk '{print $1}')
+rust_generic_sha=$(sha256sum "$RUST_GENERIC_BIN" | awk '{print $1}')
+cpp_namespace_sha=$(sha256sum "$CPP_NAMESPACE_BIN" | awk '{print $1}')
 query_size=$(stat -c '%s' "$QUERY_BIN")
 parse_size=$(stat -c '%s' "$PARSE_BIN")
 rust_parse_size=$(stat -c '%s' "$RUST_PARSE_BIN")
+cpp_template_size=$(stat -c '%s' "$CPP_TEMPLATE_BIN")
+rust_generic_size=$(stat -c '%s' "$RUST_GENERIC_BIN")
+cpp_namespace_size=$(stat -c '%s' "$CPP_NAMESPACE_BIN")
 
 jq -n \
     --arg builder_image "${DWARF_PERF_BUILDER_IMAGE_REF:-unspecified}" \
     --arg compiler "$CC" \
+    --arg cpp_compiler "$CXX" \
     --arg rustc "$RUSTC" \
     --arg query_path "query-hotspot/query_hotspot" \
     --arg query_sha "$query_sha" \
@@ -208,11 +415,26 @@ jq -n \
     --arg rust_parse_sha "$rust_parse_sha" \
     --arg rust_parse_generator "scripts/dwarf-perf/generate_rust_parse_stress.py" \
     --arg rust_parse_preset "$RUST_PARSE_STRESS_PRESET" \
+    --arg cpp_template_path "cpp-template-stress/cpp_template_stress" \
+    --arg cpp_template_sha "$cpp_template_sha" \
+    --arg cpp_template_generator "scripts/dwarf-perf/generate_cpp_template_stress.py" \
+    --arg cpp_template_preset "$CPP_TEMPLATE_STRESS_PRESET" \
+    --arg rust_generic_path "rust-generic-stress/rust_generic_stress" \
+    --arg rust_generic_sha "$rust_generic_sha" \
+    --arg rust_generic_generator "scripts/dwarf-perf/generate_rust_generic_stress.py" \
+    --arg rust_generic_preset "$RUST_GENERIC_STRESS_PRESET" \
+    --arg cpp_namespace_path "cpp-deep-namespace/cpp_deep_namespace" \
+    --arg cpp_namespace_sha "$cpp_namespace_sha" \
+    --arg cpp_namespace_generator "scripts/dwarf-perf/generate_cpp_deep_namespace.py" \
+    --arg cpp_namespace_preset "$CPP_DEEP_NAMESPACE_PRESET" \
     --argjson dwarf_version "$DWARF_VERSION" \
     --argjson query_line "$QUERY_MARKER_LINE" \
     --argjson query_size "$query_size" \
     --argjson parse_size "$parse_size" \
     --argjson rust_parse_size "$rust_parse_size" \
+    --argjson cpp_template_size "$cpp_template_size" \
+    --argjson rust_generic_size "$rust_generic_size" \
+    --argjson cpp_namespace_size "$cpp_namespace_size" \
     --argjson parse_units "$PARSE_STRESS_UNITS" \
     --argjson parse_types_per_unit "$PARSE_STRESS_TYPES_PER_UNIT" \
     --argjson parse_functions_per_unit "$PARSE_STRESS_FUNCTIONS_PER_UNIT" \
@@ -224,11 +446,30 @@ jq -n \
     --argjson rust_parse_functions_per_module "$RUST_PARSE_STRESS_FUNCTIONS_PER_MODULE" \
     --argjson rust_parse_generated_module_files "$RUST_PARSE_STRESS_GENERATED_MODULE_FILES" \
     --argjson rust_parse_generated_rust_files "$RUST_PARSE_STRESS_GENERATED_RUST_FILES" \
+    --argjson cpp_template_units "$CPP_TEMPLATE_STRESS_UNITS" \
+    --argjson cpp_template_families_per_unit "$CPP_TEMPLATE_STRESS_FAMILIES_PER_UNIT" \
+    --argjson cpp_template_instantiations_per_family "$CPP_TEMPLATE_STRESS_INSTANTIATIONS_PER_FAMILY" \
+    --argjson cpp_template_methods_per_family "$CPP_TEMPLATE_STRESS_METHODS_PER_FAMILY" \
+    --argjson cpp_template_estimated_symbols "$CPP_TEMPLATE_STRESS_ESTIMATED_SYMBOLS" \
+    --argjson cpp_template_generated_cpp_files "$CPP_TEMPLATE_STRESS_GENERATED_CPP_FILES" \
+    --argjson rust_generic_modules "$RUST_GENERIC_STRESS_MODULES" \
+    --argjson rust_generic_families_per_module "$RUST_GENERIC_STRESS_FAMILIES_PER_MODULE" \
+    --argjson rust_generic_monomorphs_per_family "$RUST_GENERIC_STRESS_MONOMORPHS_PER_FAMILY" \
+    --argjson rust_generic_estimated_symbols "$RUST_GENERIC_STRESS_ESTIMATED_SYMBOLS" \
+    --argjson rust_generic_generated_module_files "$RUST_GENERIC_STRESS_GENERATED_MODULE_FILES" \
+    --argjson rust_generic_generated_rust_files "$RUST_GENERIC_STRESS_GENERATED_RUST_FILES" \
+    --argjson cpp_namespace_units "$CPP_DEEP_NAMESPACE_UNITS" \
+    --argjson cpp_namespace_namespace_depth "$CPP_DEEP_NAMESPACE_NAMESPACE_DEPTH" \
+    --argjson cpp_namespace_branches_per_unit "$CPP_DEEP_NAMESPACE_BRANCHES_PER_UNIT" \
+    --argjson cpp_namespace_functions_per_branch "$CPP_DEEP_NAMESPACE_FUNCTIONS_PER_BRANCH" \
+    --argjson cpp_namespace_estimated_symbols "$CPP_DEEP_NAMESPACE_ESTIMATED_SYMBOLS" \
+    --argjson cpp_namespace_generated_cpp_files "$CPP_DEEP_NAMESPACE_GENERATED_CPP_FILES" \
     '{
         schema_version: 1,
         builder_image: $builder_image,
         compiler: {
             cc: $compiler,
+            cxx: $cpp_compiler,
             rustc: $rustc,
             dwarf_version: $dwarf_version
         },
@@ -279,6 +520,60 @@ jq -n \
                     generated_module_files: $rust_parse_generated_module_files,
                     generated_rust_files: $rust_parse_generated_rust_files
                 }
+            },
+            {
+                name: "cpp-template-stress",
+                kind: "fast-parse",
+                language: "cpp",
+                relative_path: $cpp_template_path,
+                sha256: $cpp_template_sha,
+                size_bytes: $cpp_template_size,
+                generator: {
+                    script: $cpp_template_generator,
+                    preset: $cpp_template_preset,
+                    units: $cpp_template_units,
+                    families_per_unit: $cpp_template_families_per_unit,
+                    instantiations_per_family: $cpp_template_instantiations_per_family,
+                    methods_per_family: $cpp_template_methods_per_family,
+                    estimated_mangled_symbols: $cpp_template_estimated_symbols,
+                    generated_cpp_files: $cpp_template_generated_cpp_files
+                }
+            },
+            {
+                name: "rust-generic-stress",
+                kind: "fast-parse",
+                language: "rust",
+                relative_path: $rust_generic_path,
+                sha256: $rust_generic_sha,
+                size_bytes: $rust_generic_size,
+                generator: {
+                    script: $rust_generic_generator,
+                    preset: $rust_generic_preset,
+                    modules: $rust_generic_modules,
+                    families_per_module: $rust_generic_families_per_module,
+                    monomorphs_per_family: $rust_generic_monomorphs_per_family,
+                    estimated_mangled_symbols: $rust_generic_estimated_symbols,
+                    generated_module_files: $rust_generic_generated_module_files,
+                    generated_rust_files: $rust_generic_generated_rust_files
+                }
+            },
+            {
+                name: "cpp-deep-namespace",
+                kind: "fast-parse",
+                language: "cpp",
+                relative_path: $cpp_namespace_path,
+                sha256: $cpp_namespace_sha,
+                size_bytes: $cpp_namespace_size,
+                generator: {
+                    script: $cpp_namespace_generator,
+                    preset: $cpp_namespace_preset,
+                    units: $cpp_namespace_units,
+                    namespace_depth: $cpp_namespace_namespace_depth,
+                    branches_per_unit: $cpp_namespace_branches_per_unit,
+                    functions_per_branch: $cpp_namespace_functions_per_branch,
+                    estimated_mangled_symbols: $cpp_namespace_estimated_symbols,
+                    generated_cpp_files: $cpp_namespace_generated_cpp_files
+                }
             }
         ]
     }' >"$MANIFEST_PATH"
@@ -287,6 +582,9 @@ echo "Built DWARF perf corpus into $OUT_DIR"
 echo "  query-hotspot: $QUERY_BIN"
 echo "  parse-stress:  $PARSE_BIN"
 echo "  rust-parse-stress: $RUST_PARSE_BIN"
+echo "  cpp-template-stress: $CPP_TEMPLATE_BIN"
+echo "  rust-generic-stress: $RUST_GENERIC_BIN"
+echo "  cpp-deep-namespace: $CPP_NAMESPACE_BIN"
 echo "  manifest:      $MANIFEST_PATH"
 
 if [[ "$(id -u)" -eq 0 && -n "${HOST_UID:-}" && -n "${HOST_GID:-}" ]]; then

--- a/scripts/dwarf-perf/combine_baselines.py
+++ b/scripts/dwarf-perf/combine_baselines.py
@@ -87,6 +87,7 @@ def main() -> int:
     combined = dict(primary)
     combined["primary_parse_target"] = parse_target_name(primary)
     combined["parse_targets"] = parse_targets
+    combined["result_path"] = str(Path(args.output))
 
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/dwarf-perf/compare_baseline.py
+++ b/scripts/dwarf-perf/compare_baseline.py
@@ -35,6 +35,24 @@ class MetricComparison:
     enforced: bool
 
 
+@dataclass(frozen=True)
+class SupplementalMetricRule:
+    name: str
+    json_path: str
+    description: str
+
+
+@dataclass
+class SupplementalMetricComparison:
+    name: str
+    description: str
+    base_ms: float | None
+    head_ms: float | None
+    delta_ms: float | None
+    delta_pct: float | None
+    status: str
+
+
 RULES = [
     MetricRule(
         name="fast_parse_p50",
@@ -67,6 +85,34 @@ RULES = [
         absolute_regression_ms=0.8,
         severity="warn",
         description="Source-line query p95",
+    ),
+]
+
+INDEX_PHASE_RULES = [
+    SupplementalMetricRule(
+        name="index_phase_average",
+        json_path="parse_benchmark.internal_metrics_ms.index_phase.average",
+        description="Index phase average",
+    ),
+    SupplementalMetricRule(
+        name="index_phase_p50",
+        json_path="parse_benchmark.internal_metrics_ms.index_phase.p50",
+        description="Index phase p50",
+    ),
+    SupplementalMetricRule(
+        name="index_phase_p95",
+        json_path="parse_benchmark.internal_metrics_ms.index_phase.p95",
+        description="Index phase p95",
+    ),
+    SupplementalMetricRule(
+        name="index_phase_min",
+        json_path="parse_benchmark.internal_metrics_ms.index_phase.min",
+        description="Index phase min",
+    ),
+    SupplementalMetricRule(
+        name="index_phase_max",
+        json_path="parse_benchmark.internal_metrics_ms.index_phase.max",
+        description="Index phase max",
     ),
 ]
 
@@ -125,6 +171,18 @@ def get_nested(data: dict[str, Any], dotted_path: str) -> float:
     return float(current)
 
 
+def get_nested_optional(data: dict[str, Any], dotted_path: str) -> float | None:
+    current: Any = data
+    for segment in dotted_path.split("."):
+        if not isinstance(current, dict) or segment not in current:
+            return None
+        current = current[segment]
+
+    if current is None:
+        return None
+    return float(current)
+
+
 def compare_metric(
     base_data: dict[str, Any],
     head_data: dict[str, Any],
@@ -169,6 +227,42 @@ def compare_metric(
     )
 
 
+def compare_supplemental_metric(
+    base_data: dict[str, Any],
+    head_data: dict[str, Any],
+    rule: SupplementalMetricRule,
+) -> SupplementalMetricComparison:
+    base_ms = get_nested_optional(base_data, rule.json_path)
+    head_ms = get_nested_optional(head_data, rule.json_path)
+
+    if base_ms is None or head_ms is None:
+        return SupplementalMetricComparison(
+            name=rule.name,
+            description=rule.description,
+            base_ms=base_ms,
+            head_ms=head_ms,
+            delta_ms=None,
+            delta_pct=None,
+            status="missing",
+        )
+
+    delta_ms = head_ms - base_ms
+    if base_ms <= 0.0:
+        delta_pct = math.inf if head_ms > 0.0 else 0.0
+    else:
+        delta_pct = (delta_ms / base_ms) * 100.0
+
+    return SupplementalMetricComparison(
+        name=rule.name,
+        description=rule.description,
+        base_ms=base_ms,
+        head_ms=head_ms,
+        delta_ms=delta_ms,
+        delta_pct=delta_pct,
+        status="available",
+    )
+
+
 def format_delta_pct(delta_pct: float) -> str:
     if math.isinf(delta_pct):
         return "inf"
@@ -184,6 +278,95 @@ def format_metric_row(metric: MetricComparison) -> str:
         f"{metric.delta_ms:+.3f} | {format_delta_pct(metric.delta_pct)} | "
         f"{threshold} | {metric.severity} | {metric.status} |"
     )
+
+
+def format_optional_ms(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.3f}"
+
+
+def format_optional_delta_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return format_delta_pct(value)
+
+
+def format_optional_ms_with_suffix(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.3f}ms"
+
+
+def format_supplemental_metric_row(metric: SupplementalMetricComparison) -> str:
+    return (
+        f"| {metric.description} | {format_optional_ms(metric.base_ms)} | "
+        f"{format_optional_ms(metric.head_ms)} | {format_optional_ms(metric.delta_ms)} | "
+        f"{format_optional_delta_pct(metric.delta_pct)} | {metric.status} |"
+    )
+
+
+def resolve_parse_target_name(
+    base_data: dict[str, Any], head_data: dict[str, Any]
+) -> str:
+    for candidate in [head_data, base_data]:
+        parse_benchmark = candidate.get("parse_benchmark")
+        if isinstance(parse_benchmark, dict):
+            artifact_name = parse_benchmark.get("artifact_name")
+            if isinstance(artifact_name, str) and artifact_name:
+                return artifact_name
+    return "unknown-target"
+
+
+def format_console_metric_line(metric: MetricComparison) -> str:
+    return (
+        f"  [{metric.status:<10}] {metric.description:<22} "
+        f"{metric.base_ms:9.3f}ms -> {metric.head_ms:9.3f}ms "
+        f"({metric.delta_ms:+9.3f}ms, {format_delta_pct(metric.delta_pct):>8})"
+    )
+
+
+def format_console_supplemental_line(metric: SupplementalMetricComparison) -> str:
+    return (
+        f"  [{metric.status:<10}] {metric.description:<22} "
+        f"{format_optional_ms_with_suffix(metric.base_ms):>12} -> "
+        f"{format_optional_ms_with_suffix(metric.head_ms):>12} "
+        f"({format_optional_ms_with_suffix(metric.delta_ms):>12}, "
+        f"{format_optional_delta_pct(metric.delta_pct):>8})"
+    )
+
+
+def build_console_report(
+    parse_target_name: str,
+    metrics: list[MetricComparison],
+    index_phase_metrics: list[SupplementalMetricComparison],
+    base_label: str,
+    head_label: str,
+    report_only: bool,
+    report_only_reason: str,
+    overall_status: str,
+) -> str:
+    mode = "report-only" if report_only else "enforced"
+    lines = [
+        f"DWARF perf regression: {parse_target_name}",
+        f"  mode: {mode}",
+        f"  base: {base_label}",
+        f"  head: {head_label}",
+        f"  verdict: {overall_status}",
+        "  guarded metrics:",
+    ]
+    lines.extend(format_console_metric_line(metric) for metric in metrics)
+    lines.extend(
+        [
+            "  index phase:",
+        ]
+    )
+    lines.extend(
+        format_console_supplemental_line(metric) for metric in index_phase_metrics
+    )
+    if report_only_reason:
+        lines.append(f"  note: {report_only_reason}")
+    return "\n".join(lines)
 
 
 def determine_overall_status(metrics: list[MetricComparison], report_only: bool) -> str:
@@ -205,7 +388,9 @@ def determine_overall_status(metrics: list[MetricComparison], report_only: bool)
 
 
 def build_summary(
+    parse_target_name: str,
     metrics: list[MetricComparison],
+    index_phase_metrics: list[SupplementalMetricComparison],
     base_label: str,
     head_label: str,
     report_only: bool,
@@ -216,6 +401,7 @@ def build_summary(
     lines = [
         "## DWARF Perf Regression",
         "",
+        f"- Parse target: `{parse_target_name}`",
         f"- Mode: `{mode}`",
         f"- Base: `{base_label}`",
         f"- Head: `{head_label}`",
@@ -234,6 +420,18 @@ def build_summary(
     )
 
     lines.extend(format_metric_row(metric) for metric in metrics)
+    lines.extend(
+        [
+            "",
+            "### Index Phase Breakdown",
+            "",
+            "| Metric | Base (ms) | Head (ms) | Delta (ms) | Delta % | Availability |",
+            "| --- | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    lines.extend(
+        format_supplemental_metric_row(metric) for metric in index_phase_metrics
+    )
     lines.extend(["", f"Overall verdict: `{overall_status}`"])
     return "\n".join(lines) + "\n"
 
@@ -246,10 +444,17 @@ def main() -> int:
     metrics = [
         compare_metric(base_data, head_data, rule, args.report_only) for rule in RULES
     ]
+    index_phase_metrics = [
+        compare_supplemental_metric(base_data, head_data, rule)
+        for rule in INDEX_PHASE_RULES
+    ]
     overall_status = determine_overall_status(metrics, args.report_only)
+    parse_target_name = resolve_parse_target_name(base_data, head_data)
 
     summary = build_summary(
+        parse_target_name,
         metrics,
+        index_phase_metrics,
         args.base_label,
         args.head_label,
         args.report_only,
@@ -259,22 +464,32 @@ def main() -> int:
     Path(args.summary_file).write_text(summary)
 
     result = {
-        "schema_version": 1,
+        "schema_version": 2,
         "mode": "report-only" if args.report_only else "enforced",
         "report_only_reason": args.report_only_reason,
+        "parse_target": parse_target_name,
         "base": {"label": args.base_label, "path": args.base},
         "head": {"label": args.head_label, "path": args.head},
         "overall_status": overall_status,
         "metrics": [asdict(metric) for metric in metrics],
+        "supplemental_metrics": {
+            "index_phase": [asdict(metric) for metric in index_phase_metrics]
+        },
     }
     Path(args.result_file).write_text(json.dumps(result, indent=2) + "\n")
 
-    print(f"DWARF perf regression verdict: {overall_status}")
-    for metric in metrics:
-        print(
-            f"  {metric.description}: {metric.base_ms:.3f}ms -> {metric.head_ms:.3f}ms "
-            f"({metric.delta_ms:+.3f}ms, {format_delta_pct(metric.delta_pct)}) [{metric.status}]"
+    print(
+        build_console_report(
+            parse_target_name,
+            metrics,
+            index_phase_metrics,
+            args.base_label,
+            args.head_label,
+            args.report_only,
+            args.report_only_reason,
+            overall_status,
         )
+    )
 
     if args.report_only:
         return 0

--- a/scripts/dwarf-perf/corpus/README.md
+++ b/scripts/dwarf-perf/corpus/README.md
@@ -18,6 +18,15 @@ The corpus is intentionally separate from `e2e-tests/tests/fixtures`:
 - `src/rust-parse-stress/`
   - documentation for the generated Rust large-symbol corpus
   - sources are emitted by `scripts/dwarf-perf/generate_rust_parse_stress.py` during the build
+- `src/cpp-template-stress/`
+  - documentation for the generated C++ template-heavy corpus
+  - sources are emitted by `scripts/dwarf-perf/generate_cpp_template_stress.py` during the build
+- `src/rust-generic-stress/`
+  - documentation for the generated Rust generic-heavy corpus
+  - sources are emitted by `scripts/dwarf-perf/generate_rust_generic_stress.py` during the build
+- `src/cpp-deep-namespace/`
+  - documentation for the generated C++ deep-namespace corpus
+  - sources are emitted by `scripts/dwarf-perf/generate_cpp_deep_namespace.py` during the build
 
 ## Build Flow
 
@@ -46,6 +55,9 @@ The build writes artifacts under `scripts/dwarf-perf/corpus/out/`:
 - `query-hotspot/query_hotspot`
 - `parse-stress/parse_stress`
 - `rust-parse-stress/rust_parse_stress`
+- `cpp-template-stress/cpp_template_stress`
+- `rust-generic-stress/rust_generic_stress`
+- `cpp-deep-namespace/cpp_deep_namespace`
 - `manifest.json`
 
 These generated outputs are ignored by Git through the repository
@@ -60,15 +72,23 @@ End-to-end baseline runner:
 This will:
 
 - build the corpus unless `--skip-build` is passed
-- run the parse benchmark through `dwarf-tool benchmark`
+- run the parse benchmark through `dwarf-tool benchmark` for every built-in fast-parse corpus by default
 - run the query benchmark through `dwarf-tool benchmark-source-line`
 - write a JSON result under `perf-results/`
 
-To switch the parse benchmark to the Rust large-symbol corpus:
+To run only one parse corpus:
 
 ```bash
 ./scripts/dwarf-perf/run_baseline.sh --parse-target rust-parse-stress
 ```
+
+Other built-in parse targets include:
+
+- `parse-stress`
+- `rust-parse-stress`
+- `cpp-template-stress`
+- `rust-generic-stress`
+- `cpp-deep-namespace`
 
 `perf-results/` is also ignored by Git and is intended for local or CI
 benchmark result snapshots.
@@ -107,6 +127,20 @@ The generated parse corpus is deterministic and can be scaled without editing so
 - `RUST_PARSE_STRESS_MODULES`
 - `RUST_PARSE_STRESS_TYPES_PER_MODULE`
 - `RUST_PARSE_STRESS_FUNCTIONS_PER_MODULE`
+- `CPP_TEMPLATE_STRESS_PRESET`
+- `CPP_TEMPLATE_STRESS_UNITS`
+- `CPP_TEMPLATE_STRESS_FAMILIES_PER_UNIT`
+- `CPP_TEMPLATE_STRESS_INSTANTIATIONS_PER_FAMILY`
+- `CPP_TEMPLATE_STRESS_METHODS_PER_FAMILY`
+- `RUST_GENERIC_STRESS_PRESET`
+- `RUST_GENERIC_STRESS_MODULES`
+- `RUST_GENERIC_STRESS_FAMILIES_PER_MODULE`
+- `RUST_GENERIC_STRESS_MONOMORPHS_PER_FAMILY`
+- `CPP_DEEP_NAMESPACE_PRESET`
+- `CPP_DEEP_NAMESPACE_UNITS`
+- `CPP_DEEP_NAMESPACE_NAMESPACE_DEPTH`
+- `CPP_DEEP_NAMESPACE_BRANCHES_PER_UNIT`
+- `CPP_DEEP_NAMESPACE_FUNCTIONS_PER_BRANCH`
 
 Preset defaults:
 
@@ -120,10 +154,31 @@ Rust large-symbol preset defaults:
 - `large`: `64` modules, `24` types/module, `96` worker functions/module
 - `xlarge`: `96` modules, `32` types/module, `160` worker functions/module
 
+C++ template preset defaults:
+
+- `medium`: `8` units, `10` families/unit, `24` instantiations/family, `4` methods/family
+- `large`: `16` units, `16` families/unit, `48` instantiations/family, `4` methods/family
+- `xlarge`: `20` units, `18` families/unit, `56` instantiations/family, `4` methods/family
+
+Rust generic preset defaults:
+
+- `medium`: `8` modules, `10` families/module, `18` monomorphs/family
+- `large`: `16` modules, `16` families/module, `28` monomorphs/family
+- `xlarge`: `20` modules, `18` families/module, `34` monomorphs/family
+
+C++ deep-namespace preset defaults:
+
+- `medium`: `8` units, namespace depth `6`, `12` branches/unit, `16` functions/branch
+- `large`: `16` units, namespace depth `8`, `16` branches/unit, `24` functions/branch
+- `xlarge`: `20` units, namespace depth `10`, `18` branches/unit, `28` functions/branch
+
 Current default:
 
 - `PARSE_STRESS_PRESET=large`
 - `RUST_PARSE_STRESS_PRESET=large`
+- `CPP_TEMPLATE_STRESS_PRESET=large`
+- `RUST_GENERIC_STRESS_PRESET=large`
+- `CPP_DEEP_NAMESPACE_PRESET=large`
 
 The generator now emits:
 
@@ -136,8 +191,10 @@ The generator now emits:
 The compiler and DWARF flavor are also configurable:
 
 - `DWARF_PERF_CC`
+- `DWARF_PERF_CXX`
 - `DWARF_PERF_DWARF_VERSION`
 - `DWARF_PERF_CFLAGS`
+- `DWARF_PERF_CXXFLAGS`
 - `DWARF_PERF_LDFLAGS`
 - `DWARF_PERF_RUSTC`
 - `DWARF_PERF_RUSTFLAGS`
@@ -145,6 +202,7 @@ The compiler and DWARF flavor are also configurable:
 Compiler default:
 
 - `DWARF_PERF_CC=gcc`
+- `DWARF_PERF_CXX=g++`
 - `DWARF_PERF_RUSTC=rustc`
 
 `gcc` is the default because the current `dwarf-tool` query flows resolve the `query-hotspot`
@@ -154,3 +212,12 @@ The Rust parse corpus is intentionally tuned for DWARF density rather than runti
 performance. It keeps debug info in the binary, references a broad slice of `std`,
 and compiles with `-C link-dead-code=yes` so it is useful for fast-index pressure
 tests.
+
+The new comparison groups focus on mangled-symbol coverage from three angles:
+
+- `cpp-template-stress`: larger C++ template instantiation sets, roughly `50K-100K`
+  mangled symbols on the default preset
+- `rust-generic-stress`: Rust generic monomorphization, roughly `20K-50K`
+  mangled symbols on the default preset
+- `cpp-deep-namespace`: long hierarchical namespace names, roughly `10K-30K`
+  mangled symbols on the default preset

--- a/scripts/dwarf-perf/corpus/src/cpp-deep-namespace/README.md
+++ b/scripts/dwarf-perf/corpus/src/cpp-deep-namespace/README.md
@@ -1,0 +1,36 @@
+# cpp-deep-namespace
+
+`cpp-deep-namespace` is a generated C++ corpus for deep-namespace DWARF parse
+baselines.
+
+Design goals:
+
+- produce long hierarchical symbol names without relying on template expansion
+- stress fragment extraction and namespace splitting quality separately from
+  template-heavy demangling
+- keep generation deterministic so the same inputs reproduce the same corpus
+
+The generated sources are not committed. Build them through:
+
+```bash
+./scripts/dwarf-perf/build_corpus.sh
+```
+
+The generator lives at:
+
+- `scripts/dwarf-perf/generate_cpp_deep_namespace.py`
+
+Preset scale:
+
+- `medium`: `8` units, namespace depth `6`, `12` branches/unit,
+  `16` functions/branch
+- `large`: `16` units, namespace depth `8`, `16` branches/unit,
+  `24` functions/branch
+- `xlarge`: `20` units, namespace depth `10`, `18` branches/unit,
+  `28` functions/branch
+
+Default preset:
+
+- `large`
+
+The `large` preset targets roughly `10K-30K` mangled symbols.

--- a/scripts/dwarf-perf/corpus/src/cpp-template-stress/README.md
+++ b/scripts/dwarf-perf/corpus/src/cpp-template-stress/README.md
@@ -1,0 +1,37 @@
+# cpp-template-stress
+
+`cpp-template-stress` is a generated C++ corpus for template-heavy DWARF parse
+baselines.
+
+Design goals:
+
+- produce large batches of explicit template instantiations with nested type
+  arguments and non-type template parameters
+- keep mangled names dense enough to make demangling and symbol-map assembly
+  visible in startup profiles
+- keep generation deterministic so the same inputs reproduce the same corpus
+
+The generated sources are not committed. Build them through:
+
+```bash
+./scripts/dwarf-perf/build_corpus.sh
+```
+
+The generator lives at:
+
+- `scripts/dwarf-perf/generate_cpp_template_stress.py`
+
+Preset scale:
+
+- `medium`: `8` units, `10` families/unit, `24` instantiations/family,
+  `4` methods/family
+- `large`: `16` units, `16` families/unit, `48` instantiations/family,
+  `4` methods/family
+- `xlarge`: `20` units, `18` families/unit, `56` instantiations/family,
+  `4` methods/family
+
+Default preset:
+
+- `large`
+
+The `large` preset targets roughly `50K-100K` mangled symbols.

--- a/scripts/dwarf-perf/corpus/src/rust-generic-stress/README.md
+++ b/scripts/dwarf-perf/corpus/src/rust-generic-stress/README.md
@@ -1,0 +1,40 @@
+# rust-generic-stress
+
+`rust-generic-stress` is a generated Rust corpus for generic-heavy DWARF parse
+baselines.
+
+Design goals:
+
+- force broad generic monomorphization across many module-local type families
+- keep symbol names stable and dense enough to expose demangle and index-build
+  costs in the startup path
+- keep generation deterministic so the same inputs reproduce the same crate
+
+The generated sources are not committed. Build them through:
+
+```bash
+./scripts/dwarf-perf/build_corpus.sh
+```
+
+The generator lives at:
+
+- `scripts/dwarf-perf/generate_rust_generic_stress.py`
+
+The build compiles the generated crate with:
+
+- `-C debuginfo=2`
+- `-C opt-level=0`
+- `-C force-frame-pointers=yes`
+- `-C link-dead-code=yes`
+
+Preset scale:
+
+- `medium`: `8` modules, `10` families/module, `18` monomorphs/family
+- `large`: `16` modules, `16` families/module, `28` monomorphs/family
+- `xlarge`: `20` modules, `18` families/module, `34` monomorphs/family
+
+Default preset:
+
+- `large`
+
+The `large` preset targets roughly `20K-50K` mangled symbols.

--- a/scripts/dwarf-perf/generate_cpp_deep_namespace.py
+++ b/scripts/dwarf-perf/generate_cpp_deep_namespace.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Generate a deterministic C++ deep-namespace corpus for DWARF parse baselines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PRESET_CONFIGS = {
+    "medium": {
+        "units": 8,
+        "namespace_depth": 6,
+        "branches_per_unit": 12,
+        "functions_per_branch": 16,
+    },
+    "large": {
+        "units": 16,
+        "namespace_depth": 8,
+        "branches_per_unit": 16,
+        "functions_per_branch": 24,
+    },
+    "xlarge": {
+        "units": 20,
+        "namespace_depth": 10,
+        "branches_per_unit": 18,
+        "functions_per_branch": 28,
+    },
+}
+
+
+@dataclass(frozen=True)
+class CppDeepNamespaceConfig:
+    preset: str
+    units: int
+    namespace_depth: int
+    branches_per_unit: int
+    functions_per_branch: int
+
+
+def build_config(args: argparse.Namespace) -> CppDeepNamespaceConfig:
+    preset = PRESET_CONFIGS[args.preset]
+    units = args.units or preset["units"]
+    namespace_depth = args.namespace_depth or preset["namespace_depth"]
+    branches_per_unit = args.branches_per_unit or preset["branches_per_unit"]
+    functions_per_branch = args.functions_per_branch or preset["functions_per_branch"]
+
+    for field_name, value in [
+        ("units", units),
+        ("namespace_depth", namespace_depth),
+        ("branches_per_unit", branches_per_unit),
+        ("functions_per_branch", functions_per_branch),
+    ]:
+        if value <= 0:
+            raise SystemExit(f"{field_name} must be > 0")
+
+    return CppDeepNamespaceConfig(
+        preset=args.preset,
+        units=units,
+        namespace_depth=namespace_depth,
+        branches_per_unit=branches_per_unit,
+        functions_per_branch=functions_per_branch,
+    )
+
+
+def namespace_path(unit_idx: int, branch_idx: int, depth: int) -> list[str]:
+    fragments = [
+        f"region_{unit_idx:02d}",
+        f"tenant_{branch_idx:02d}",
+        f"service_{(unit_idx + branch_idx) % 23:02d}",
+        f"component_{(unit_idx * 3 + branch_idx) % 29:02d}",
+        f"pipeline_{(unit_idx * 5 + branch_idx * 2) % 31:02d}",
+        f"stage_{(unit_idx + branch_idx * 7) % 37:02d}",
+        f"fragment_{(unit_idx * 11 + branch_idx) % 41:02d}",
+        f"segment_{(unit_idx * 13 + branch_idx * 3) % 43:02d}",
+        f"lane_{(unit_idx * 17 + branch_idx * 5) % 47:02d}",
+        f"leaf_{(unit_idx * 19 + branch_idx * 7) % 53:02d}",
+    ]
+    return fragments[:depth]
+
+
+def render_main(config: CppDeepNamespaceConfig) -> str:
+    declarations = [
+        f'extern "C" std::uint64_t cpp_deep_namespace_unit_{unit_idx:02d}_accumulate();'
+        for unit_idx in range(config.units)
+    ]
+    call_table = ", ".join(
+        f"cpp_deep_namespace_unit_{unit_idx:02d}_accumulate"
+        for unit_idx in range(config.units)
+    )
+    return "\n".join(
+        [
+            "#include <cstddef>",
+            "#include <cstdint>",
+            "#include <cstdio>",
+            "",
+            *declarations,
+            "",
+            "using cpp_namespace_runner_t = std::uint64_t (*)();",
+            "",
+            f"static cpp_namespace_runner_t kCppNamespaceRunners[{config.units}] = {{{call_table}}};",
+            "",
+            "int main() {",
+            "    std::uint64_t total = 0u;",
+            "    for (std::size_t idx = 0; idx < (sizeof(kCppNamespaceRunners) / sizeof(kCppNamespaceRunners[0])); ++idx) {",
+            "        total ^= kCppNamespaceRunners[idx]();",
+            "    }",
+            '    std::printf("cpp-deep-namespace:%llu\\n", static_cast<unsigned long long>(total));',
+            "    return total == 0u ? 1 : 0;",
+            "}",
+            "",
+        ]
+    )
+
+
+def render_branch(config: CppDeepNamespaceConfig, unit_idx: int, branch_idx: int) -> tuple[list[str], str]:
+    path = namespace_path(unit_idx, branch_idx, config.namespace_depth)
+    namespace_name = "::".join(path)
+    lines = [
+        f"namespace {namespace_name} {{",
+        "",
+        f"struct branch_ledger_{unit_idx:02d}_{branch_idx:02d} {{",
+        "    static __attribute__((noinline)) std::uint64_t fold(std::uint64_t seed) {",
+        f"        return seed ^ {((unit_idx + 1) * 97) + (branch_idx * 13)}u;",
+        "    }",
+        "",
+        "    static __attribute__((noinline)) std::uint64_t sweep(std::uint64_t seed) {",
+        f"        return (seed << 1) ^ (seed >> 3) ^ {((unit_idx + 1) * 131) + (branch_idx * 17)}u;",
+        "    }",
+        "};",
+        "",
+    ]
+
+    sample_call = (
+        f"{namespace_name}::operation_{branch_idx:02d}_000"
+        f"({(unit_idx + 1) * (branch_idx + 3)}u)"
+    )
+    for fn_idx in range(config.functions_per_branch):
+        bias = ((unit_idx + 3) * 0x51) + (branch_idx * 0x17) + fn_idx
+        lines.extend(
+            [
+                "__attribute__((noinline)) std::uint64_t "
+                f"operation_{branch_idx:02d}_{fn_idx:03d}(std::uint64_t seed) {{",
+                f"    std::uint64_t total = branch_ledger_{unit_idx:02d}_{branch_idx:02d}::fold(seed + {bias}u);",
+                f"    total ^= branch_ledger_{unit_idx:02d}_{branch_idx:02d}::sweep(seed ^ {bias + 11}u);",
+                f"    return total ^ {(branch_idx + 1) * (fn_idx + 5)}u;",
+                "}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            f"}}  // namespace {namespace_name}",
+            "",
+        ]
+    )
+    return lines, sample_call
+
+
+def render_unit_source(config: CppDeepNamespaceConfig, unit_idx: int) -> str:
+    lines = [
+        "#include <cstdint>",
+        "",
+    ]
+    sample_calls: list[str] = []
+    for branch_idx in range(config.branches_per_unit):
+        branch_lines, sample_call = render_branch(config, unit_idx, branch_idx)
+        lines.extend(branch_lines)
+        sample_calls.append(sample_call)
+
+    lines.extend(
+        [
+            f'extern "C" std::uint64_t cpp_deep_namespace_unit_{unit_idx:02d}_accumulate() {{',
+            f"    std::uint64_t total = {unit_idx + 1}u;",
+        ]
+    )
+    for call in sample_calls:
+        lines.append(f"    total ^= {call};")
+    lines.extend(
+        [
+            "    return total;",
+            "}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_outputs(output_dir: Path, config: CppDeepNamespaceConfig) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "main.cpp").write_text(render_main(config), encoding="utf-8")
+    for unit_idx in range(config.units):
+        (output_dir / f"unit_{unit_idx:02d}.cpp").write_text(
+            render_unit_source(config, unit_idx),
+            encoding="utf-8",
+        )
+
+    estimated_symbols = (
+        config.units * config.branches_per_unit * config.functions_per_branch * 3
+    )
+    generation_config = {
+        "preset": config.preset,
+        "units": config.units,
+        "namespace_depth": config.namespace_depth,
+        "branches_per_unit": config.branches_per_unit,
+        "functions_per_branch": config.functions_per_branch,
+        "estimated_mangled_symbols": estimated_symbols,
+        "generated_cpp_files": config.units + 1,
+    }
+    (output_dir / "generation_config.json").write_text(
+        json.dumps(generation_config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a deterministic C++ deep-namespace DWARF corpus."
+    )
+    parser.add_argument("--output-dir", required=True, help="Directory to write generated C++ files")
+    parser.add_argument(
+        "--preset",
+        choices=sorted(PRESET_CONFIGS.keys()),
+        default="large",
+        help="Named scale preset",
+    )
+    parser.add_argument("--units", type=int, help="Override translation unit count")
+    parser.add_argument(
+        "--namespace-depth",
+        type=int,
+        help="Override namespace nesting depth",
+    )
+    parser.add_argument(
+        "--branches-per-unit",
+        type=int,
+        help="Override namespace branches per translation unit",
+    )
+    parser.add_argument(
+        "--functions-per-branch",
+        type=int,
+        help="Override functions per deep namespace branch",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = build_config(args)
+    write_outputs(Path(args.output_dir), config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dwarf-perf/generate_cpp_template_stress.py
+++ b/scripts/dwarf-perf/generate_cpp_template_stress.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate a deterministic C++ template-heavy corpus for DWARF parse baselines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PRESET_CONFIGS = {
+    "medium": {
+        "units": 8,
+        "families_per_unit": 10,
+        "instantiations_per_family": 24,
+        "methods_per_family": 4,
+    },
+    "large": {
+        "units": 16,
+        "families_per_unit": 16,
+        "instantiations_per_family": 48,
+        "methods_per_family": 4,
+    },
+    "xlarge": {
+        "units": 20,
+        "families_per_unit": 18,
+        "instantiations_per_family": 56,
+        "methods_per_family": 4,
+    },
+}
+
+
+@dataclass(frozen=True)
+class CppTemplateStressConfig:
+    preset: str
+    units: int
+    families_per_unit: int
+    instantiations_per_family: int
+    methods_per_family: int
+
+
+def build_config(args: argparse.Namespace) -> CppTemplateStressConfig:
+    preset = PRESET_CONFIGS[args.preset]
+    units = args.units or preset["units"]
+    families_per_unit = args.families_per_unit or preset["families_per_unit"]
+    instantiations_per_family = (
+        args.instantiations_per_family or preset["instantiations_per_family"]
+    )
+    methods_per_family = args.methods_per_family or preset["methods_per_family"]
+
+    for field_name, value in [
+        ("units", units),
+        ("families_per_unit", families_per_unit),
+        ("instantiations_per_family", instantiations_per_family),
+        ("methods_per_family", methods_per_family),
+    ]:
+        if value <= 0:
+            raise SystemExit(f"{field_name} must be > 0")
+
+    return CppTemplateStressConfig(
+        preset=args.preset,
+        units=units,
+        families_per_unit=families_per_unit,
+        instantiations_per_family=instantiations_per_family,
+        methods_per_family=methods_per_family,
+    )
+
+
+def uint64_literal(value: int) -> str:
+    return f"0x{value:016x}ull"
+
+
+def type_expr(unit_idx: int, family_idx: int, inst_idx: int, branch: int) -> str:
+    root_tag = (unit_idx * 4096) + (family_idx * 97) + (inst_idx * 7) + branch
+    left_leaf = (
+        f"lane_pack<tag<{root_tag % 257}>, {(inst_idx % 4) + 2}, "
+        f"{((family_idx + branch) % 5) + 2}>"
+    )
+    middle_leaf = (
+        f"lane_pack<tag<{(root_tag + 19) % 257}>, {((family_idx + inst_idx) % 5) + 2}, "
+        f"{((unit_idx + branch) % 6) + 2}>"
+    )
+    right_leaf = (
+        f"lane_pack<tag<{(root_tag + 53) % 257}>, {((family_idx + 2 * branch) % 4) + 2}, "
+        f"{((inst_idx + branch) % 6) + 2}>"
+    )
+    return (
+        f"composite_node<{left_leaf}, "
+        f"composite_node<{middle_leaf}, {right_leaf}, {((inst_idx + branch) % 9) + 2}>, "
+        f"{((family_idx + inst_idx + branch) % 11) + 3}>"
+    )
+
+
+def render_main(config: CppTemplateStressConfig) -> str:
+    declarations = [
+        f'extern "C" std::uint64_t cpp_template_stress_unit_{unit_idx:02d}_accumulate();'
+        for unit_idx in range(config.units)
+    ]
+    call_table = ", ".join(
+        f"cpp_template_stress_unit_{unit_idx:02d}_accumulate"
+        for unit_idx in range(config.units)
+    )
+    return "\n".join(
+        [
+            "#include <cstddef>",
+            "#include <cstdint>",
+            "#include <cstdio>",
+            "",
+            *declarations,
+            "",
+            "using cpp_template_runner_t = std::uint64_t (*)();",
+            "",
+            f"static cpp_template_runner_t kCppTemplateRunners[{config.units}] = {{{call_table}}};",
+            "",
+            "int main() {",
+            "    std::uint64_t total = 0u;",
+            "    for (std::size_t idx = 0; idx < (sizeof(kCppTemplateRunners) / sizeof(kCppTemplateRunners[0])); ++idx) {",
+            "        total ^= kCppTemplateRunners[idx]();",
+            "    }",
+            '    std::printf("cpp-template-stress:%llu\\n", static_cast<unsigned long long>(total));',
+            "    return total == 0u ? 1 : 0;",
+            "}",
+            "",
+        ]
+    )
+
+
+def render_unit_source(config: CppTemplateStressConfig, unit_idx: int) -> str:
+    namespace_name = f"dwarf::perf::cpp_template_stress::unit_{unit_idx:02d}"
+    lines = [
+        "#include <array>",
+        "#include <cstddef>",
+        "#include <cstdint>",
+        "#include <tuple>",
+        "#include <type_traits>",
+        "",
+        f"namespace {namespace_name} {{",
+        "",
+        "template <std::size_t Id>",
+        "struct tag {};",
+        "",
+        "template <typename Tag, std::size_t Width, std::size_t Depth>",
+        "struct lane_pack {",
+        "    std::array<std::uint64_t, Width> lanes{};",
+        "    static constexpr std::size_t k_width = Width;",
+        "    static constexpr std::size_t k_depth = Depth;",
+        "};",
+        "",
+        "template <typename Left, typename Right, std::size_t Rank>",
+        "struct composite_node {",
+        "    using left = Left;",
+        "    using right = Right;",
+        "    static constexpr std::size_t k_rank = Rank;",
+        "};",
+        "",
+        "template <typename Left, typename Right, std::size_t Depth, std::uint64_t Salt>",
+        "struct lattice {",
+    ]
+
+    for method_idx in range(config.methods_per_family):
+        lines.append(
+            f"    static __attribute__((noinline)) std::uint64_t step_{method_idx}(std::uint64_t seed);"
+        )
+
+    lines.extend(
+        [
+            "};",
+            "",
+        ]
+    )
+
+    for method_idx in range(config.methods_per_family):
+        rotate_bits = ((unit_idx + method_idx) % 23) + 5
+        lines.extend(
+            [
+                "template <typename Left, typename Right, std::size_t Depth, std::uint64_t Salt>",
+                f"std::uint64_t lattice<Left, Right, Depth, Salt>::step_{method_idx}(std::uint64_t seed) {{",
+                "    using stitched = std::tuple<Left, Right, composite_node<Left, Right, Depth>>;",
+                "    constexpr std::uint64_t layout =",
+                "        static_cast<std::uint64_t>(sizeof(stitched) + alignof(Left) + alignof(Right));",
+                "    std::uint64_t total = seed ^ Salt ^ layout;",
+                f"    total ^= static_cast<std::uint64_t>(Depth + {method_idx + 1});",
+                f"    total = (total << {rotate_bits}) | (total >> {64 - rotate_bits});",
+                "    return (total << 1) ^ (total >> 3) ^ static_cast<std::uint64_t>(layout * 17u);",
+                "}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "template <typename Left, typename Right, std::size_t Depth, std::uint64_t Salt>",
+            "__attribute__((noinline)) std::uint64_t drive(std::uint64_t seed) {",
+            "    std::uint64_t total = seed ^ Salt;",
+        ]
+    )
+    for method_idx in range(config.methods_per_family):
+        lines.append(
+            f"    total ^= lattice<Left, Right, Depth, Salt>::step_{method_idx}(seed + {method_idx + 1}u);"
+        )
+    lines.extend(
+        [
+            "    return total;",
+            "}",
+            "",
+        ]
+    )
+
+    sample_calls: list[str] = []
+    for family_idx in range(config.families_per_unit):
+        for inst_idx in range(config.instantiations_per_family):
+            alias_name = f"family_{family_idx:02d}_{inst_idx:03d}"
+            left_alias = f"{alias_name}_left"
+            right_alias = f"{alias_name}_right"
+            depth = ((inst_idx + family_idx) % 13) + 2
+            salt = (
+                ((unit_idx + 1) * 0x9E37_79B1)
+                ^ ((family_idx + 3) * 0xC2B2_AE35)
+                ^ ((inst_idx + 11) * 0x1656_6671)
+            ) & 0xFFFF_FFFF_FFFF_FFFF
+            lines.extend(
+                [
+                    f"using {left_alias} = {type_expr(unit_idx, family_idx, inst_idx, 0)};",
+                    f"using {right_alias} = {type_expr(unit_idx, family_idx, inst_idx, 1)};",
+                    (
+                        f"template struct lattice<{left_alias}, {right_alias}, {depth}, "
+                        f"{uint64_literal(salt)}>;"
+                    ),
+                    (
+                        f"template std::uint64_t drive<{left_alias}, {right_alias}, {depth}, "
+                        f"{uint64_literal(salt)}>(std::uint64_t seed);"
+                    ),
+                    "",
+                ]
+            )
+            if inst_idx == 0:
+                sample_calls.append(
+                    f"    total ^= drive<{left_alias}, {right_alias}, {depth}, {uint64_literal(salt)}>({family_idx + 3}u);"
+                )
+
+    lines.extend(
+        [
+            f'}}  // namespace {namespace_name}',
+            "",
+            f'extern "C" std::uint64_t cpp_template_stress_unit_{unit_idx:02d}_accumulate() {{',
+            f"    using namespace {namespace_name};",
+            f"    std::uint64_t total = {unit_idx + 1}u;",
+            *sample_calls,
+            "    return total;",
+            "}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_outputs(output_dir: Path, config: CppTemplateStressConfig) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "main.cpp").write_text(render_main(config), encoding="utf-8")
+
+    for unit_idx in range(config.units):
+        (output_dir / f"unit_{unit_idx:02d}.cpp").write_text(
+            render_unit_source(config, unit_idx),
+            encoding="utf-8",
+        )
+
+    estimated_symbols = (
+        config.units
+        * config.families_per_unit
+        * config.instantiations_per_family
+        * (config.methods_per_family + 1)
+    )
+    generation_config = {
+        "preset": config.preset,
+        "units": config.units,
+        "families_per_unit": config.families_per_unit,
+        "instantiations_per_family": config.instantiations_per_family,
+        "methods_per_family": config.methods_per_family,
+        "estimated_mangled_symbols": estimated_symbols,
+        "generated_cpp_files": config.units + 1,
+    }
+    (output_dir / "generation_config.json").write_text(
+        json.dumps(generation_config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a deterministic C++ template-heavy DWARF corpus."
+    )
+    parser.add_argument("--output-dir", required=True, help="Directory to write generated C++ files")
+    parser.add_argument(
+        "--preset",
+        choices=sorted(PRESET_CONFIGS.keys()),
+        default="large",
+        help="Named scale preset",
+    )
+    parser.add_argument("--units", type=int, help="Override translation unit count")
+    parser.add_argument(
+        "--families-per-unit",
+        type=int,
+        help="Override template family count per translation unit",
+    )
+    parser.add_argument(
+        "--instantiations-per-family",
+        type=int,
+        help="Override explicit instantiations per template family",
+    )
+    parser.add_argument(
+        "--methods-per-family",
+        type=int,
+        help="Override generated methods per template family",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = build_config(args)
+    write_outputs(Path(args.output_dir), config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dwarf-perf/generate_rust_generic_stress.py
+++ b/scripts/dwarf-perf/generate_rust_generic_stress.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Generate a deterministic Rust generic-heavy corpus for DWARF parse baselines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PRESET_CONFIGS = {
+    "medium": {
+        "modules": 8,
+        "families_per_module": 10,
+        "monomorphs_per_family": 18,
+    },
+    "large": {
+        "modules": 16,
+        "families_per_module": 16,
+        "monomorphs_per_family": 28,
+    },
+    "xlarge": {
+        "modules": 20,
+        "families_per_module": 18,
+        "monomorphs_per_family": 34,
+    },
+}
+
+
+@dataclass(frozen=True)
+class RustGenericStressConfig:
+    preset: str
+    modules: int
+    families_per_module: int
+    monomorphs_per_family: int
+
+
+def build_config(args: argparse.Namespace) -> RustGenericStressConfig:
+    preset = PRESET_CONFIGS[args.preset]
+    modules = args.modules or preset["modules"]
+    families_per_module = args.families_per_module or preset["families_per_module"]
+    monomorphs_per_family = (
+        args.monomorphs_per_family or preset["monomorphs_per_family"]
+    )
+
+    for field_name, value in [
+        ("modules", modules),
+        ("families_per_module", families_per_module),
+        ("monomorphs_per_family", monomorphs_per_family),
+    ]:
+        if value <= 0:
+            raise SystemExit(f"{field_name} must be > 0")
+
+    return RustGenericStressConfig(
+        preset=args.preset,
+        modules=modules,
+        families_per_module=families_per_module,
+        monomorphs_per_family=monomorphs_per_family,
+    )
+
+
+def module_ident(module_idx: int) -> str:
+    return f"module_{module_idx:03d}"
+
+
+def family_ident(module_idx: int, family_idx: int) -> str:
+    return f"Module{module_idx:03d}Family{family_idx:03d}"
+
+
+def variant_ident(module_idx: int, variant_idx: int) -> str:
+    return f"Module{module_idx:03d}Variant{variant_idx:03d}"
+
+
+def family_runner_ident(module_idx: int, family_idx: int) -> str:
+    return f"run_family_{module_idx:03d}_{family_idx:03d}"
+
+
+def render_shared_module() -> str:
+    return "\n".join(
+        [
+            "#![allow(dead_code)]",
+            "",
+            "use std::marker::PhantomData;",
+            "",
+            "pub trait FamilyTag {",
+            "    const KEY: u64;",
+            "    const SHIFT: u32;",
+            "}",
+            "",
+            "pub trait VariantTag {",
+            "    const FACTOR: u64;",
+            "    const ROTATE: u32;",
+            "}",
+            "",
+            "pub struct Pair<A, B>(PhantomData<(A, B)>);",
+            "",
+            "pub struct Envelope<Family, Variant, const DEPTH: usize> {",
+            "    marker: PhantomData<(Family, Variant)>,",
+            "}",
+            "",
+            "impl<Family: FamilyTag, Variant: VariantTag, const DEPTH: usize>",
+            "    Envelope<Family, Variant, DEPTH>",
+            "{",
+            "    #[inline(never)]",
+            "    pub fn fold(seed: u64) -> u64 {",
+            "        let layout = std::mem::size_of::<Pair<Family, Variant>>() as u64;",
+            "        seed.rotate_left(Family::SHIFT % 31)",
+            "            ^ Variant::FACTOR.wrapping_mul((DEPTH as u64) + 17)",
+            "            ^ layout.wrapping_mul(13)",
+            "    }",
+            "",
+            "    #[inline(never)]",
+            "    pub fn twist(seed: u64) -> u64 {",
+            "        let layout = std::mem::align_of::<Pair<Family, Variant>>() as u64;",
+            "        seed.wrapping_add(Family::KEY ^ Variant::FACTOR)",
+            "            .rotate_left(Variant::ROTATE % 31)",
+            "            ^ layout.wrapping_mul((DEPTH as u64) + 29)",
+            "    }",
+            "}",
+            "",
+            "#[inline(never)]",
+            "pub fn dispatch<Family: FamilyTag, Variant: VariantTag, const DEPTH: usize>(seed: u64) -> u64 {",
+            "    Envelope::<Family, Variant, DEPTH>::fold(seed)",
+            "        ^ Envelope::<Family, Variant, DEPTH>::twist(seed ^ Variant::FACTOR)",
+            "}",
+            "",
+            "#[inline(never)]",
+            "pub fn relay<Family: FamilyTag, Variant: VariantTag, const DEPTH: usize>(seed: u64) -> u64 {",
+            "    dispatch::<Family, Variant, DEPTH>(seed.rotate_left((DEPTH as u32) % 31))",
+            "        ^ Envelope::<Family, Variant, DEPTH>::fold(Family::KEY ^ seed)",
+            "}",
+            "",
+        ]
+    )
+
+
+def render_module(config: RustGenericStressConfig, module_idx: int) -> str:
+    lines = [
+        "#![allow(dead_code)]",
+        "",
+        "use crate::shared::{dispatch, relay, FamilyTag, VariantTag};",
+        "",
+    ]
+
+    for family_idx in range(config.families_per_module):
+        family_name = family_ident(module_idx, family_idx)
+        key = ((module_idx + 1) * 0x9E37_79B9_7F4A_7C15) ^ ((family_idx + 3) * 0xBF58_476D_1CE4_E5B9)
+        shift = ((module_idx + family_idx) % 23) + 5
+        lines.extend(
+            [
+                f"pub struct {family_name};",
+                "",
+                f"impl FamilyTag for {family_name} {{",
+                f"    const KEY: u64 = 0x{key & 0xffff_ffff_ffff_ffff:016x};",
+                f"    const SHIFT: u32 = {shift};",
+                "}",
+                "",
+            ]
+        )
+
+    for variant_idx in range(config.monomorphs_per_family):
+        variant_name = variant_ident(module_idx, variant_idx)
+        factor = ((module_idx + 5) * 0x94D0_49BB_1331_11EB) ^ ((variant_idx + 7) * 0xD6E8_FD50_6A1F_1C4D)
+        rotate = ((module_idx * 3 + variant_idx) % 27) + 3
+        lines.extend(
+            [
+                f"pub struct {variant_name};",
+                "",
+                f"impl VariantTag for {variant_name} {{",
+                f"    const FACTOR: u64 = 0x{factor & 0xffff_ffff_ffff_ffff:016x};",
+                f"    const ROTATE: u32 = {rotate};",
+                "}",
+                "",
+            ]
+        )
+
+    family_runners: list[str] = []
+    for family_idx in range(config.families_per_module):
+        runner = family_runner_ident(module_idx, family_idx)
+        family_runners.append(runner)
+        family_name = family_ident(module_idx, family_idx)
+        lines.extend(
+            [
+                "#[inline(never)]",
+                f"pub fn {runner}(seed: u64) -> u64 {{",
+                f"    let mut total = seed ^ {family_idx + 1}u64;",
+            ]
+        )
+        for variant_idx in range(config.monomorphs_per_family):
+            variant_name = variant_ident(module_idx, variant_idx)
+            depth = ((family_idx + variant_idx) % 17) + 3
+            salt = ((family_idx + 1) * 0x517c_c1b7) ^ ((variant_idx + 11) * 0x2722_0a95)
+            lines.extend(
+                [
+                    (
+                        f"    total ^= dispatch::<{family_name}, {variant_name}, {depth}>"
+                        f"(seed.wrapping_add(0x{salt & 0xffff_ffff:08x}u64));"
+                    ),
+                    (
+                        f"    total ^= relay::<{family_name}, {variant_name}, {depth}>"
+                        f"(seed ^ 0x{(salt ^ 0x9e37_79b9) & 0xffff_ffff:08x}u64);"
+                    ),
+                ]
+            )
+        lines.extend(
+            [
+                "    total",
+                "}",
+                "",
+            ]
+        )
+
+    runner_table = ", ".join(family_runners)
+    lines.extend(
+        [
+            (
+                f"static MODULE_RUNNERS: [fn(u64) -> u64; {config.families_per_module}] = "
+                f"[{runner_table}];"
+            ),
+            "",
+            "#[inline(never)]",
+            "pub fn run_module(seed: u64) -> u64 {",
+            f"    let mut total = seed ^ 0x{(((module_idx + 1) * 0x9E37_79B1) & 0xffff_ffff):08x}u64;",
+            "    for (idx, runner) in MODULE_RUNNERS.iter().enumerate() {",
+            "        let module_seed = seed ^ (((idx as u64) + 1).wrapping_mul(0x94d0_49bb_1331_11ebu64));",
+            "        total ^= runner(module_seed);",
+            "    }",
+            "    total",
+            "}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_main(config: RustGenericStressConfig) -> str:
+    module_lines = [f"mod {module_ident(module_idx)};" for module_idx in range(config.modules)]
+    runner_table = ", ".join(
+        f"{module_ident(module_idx)}::run_module" for module_idx in range(config.modules)
+    )
+    return "\n".join(
+        [
+            "#![allow(dead_code)]",
+            "",
+            "mod shared;",
+            *module_lines,
+            "",
+            f"static MODULE_RUNNERS: [fn(u64) -> u64; {config.modules}] = [{runner_table}];",
+            "",
+            "fn main() {",
+            "    let mut total = 0u64;",
+            "    for (idx, runner) in MODULE_RUNNERS.iter().enumerate() {",
+            "        let seed = 0x9e37_79b9_7f4a_7c15u64",
+            "            ^ (((idx as u64) + 1).wrapping_mul(0xbf58_476d_1ce4_e5b9u64));",
+            "        total ^= runner(seed);",
+            "    }",
+            '    println!("rust-generic-stress:{}", total);',
+            "}",
+            "",
+        ]
+    )
+
+
+def write_outputs(output_dir: Path, config: RustGenericStressConfig) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "shared.rs").write_text(render_shared_module(), encoding="utf-8")
+    (output_dir / "main.rs").write_text(render_main(config), encoding="utf-8")
+
+    for module_idx in range(config.modules):
+        (output_dir / f"{module_ident(module_idx)}.rs").write_text(
+            render_module(config, module_idx),
+            encoding="utf-8",
+        )
+
+    estimated_symbols = (
+        config.modules
+        * config.families_per_module
+        * config.monomorphs_per_family
+        * 4
+    )
+    generation_config = {
+        "preset": config.preset,
+        "modules": config.modules,
+        "families_per_module": config.families_per_module,
+        "monomorphs_per_family": config.monomorphs_per_family,
+        "estimated_mangled_symbols": estimated_symbols,
+        "generated_module_files": config.modules,
+        "generated_rust_files": config.modules + 2,
+    }
+    (output_dir / "generation_config.json").write_text(
+        json.dumps(generation_config, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a deterministic Rust generic-heavy DWARF corpus."
+    )
+    parser.add_argument("--output-dir", required=True, help="Directory to write generated Rust files")
+    parser.add_argument(
+        "--preset",
+        choices=sorted(PRESET_CONFIGS.keys()),
+        default="large",
+        help="Named scale preset",
+    )
+    parser.add_argument("--modules", type=int, help="Override module count")
+    parser.add_argument(
+        "--families-per-module",
+        type=int,
+        help="Override generic family count per module",
+    )
+    parser.add_argument(
+        "--monomorphs-per-family",
+        type=int,
+        help="Override monomorphized variants per family",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = build_config(args)
+    write_outputs(Path(args.output_dir), config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dwarf-perf/publish_history.py
+++ b/scripts/dwarf-perf/publish_history.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import math
 import shutil
 from pathlib import Path
 from typing import Any
 
 MAX_HISTORY_ENTRIES = 500
+PREFERRED_PARSE_TARGETS = [
+    "parse-stress",
+    "rust-parse-stress",
+    "cpp-template-stress",
+    "rust-generic-stress",
+    "cpp-deep-namespace",
+]
 
 
 def parse_args() -> argparse.Namespace:
@@ -47,27 +55,72 @@ def format_metric(value: float) -> str:
     return f"{value:.3f}"
 
 
-def extract_parse_targets(
+def coerce_parse_target_detail(parse_info: Any) -> dict[str, Any]:
+    if not isinstance(parse_info, dict):
+        return {"metrics_ms": {}, "internal_metrics_ms": {}}
+
+    metrics = parse_info.get("metrics_ms")
+    internal = parse_info.get("internal_metrics_ms")
+    if isinstance(metrics, dict) or isinstance(internal, dict):
+        return {
+            "metrics_ms": metrics if isinstance(metrics, dict) else {},
+            "internal_metrics_ms": internal if isinstance(internal, dict) else {},
+        }
+
+    return {
+        "metrics_ms": parse_info,
+        "internal_metrics_ms": {},
+    }
+
+
+def extract_parse_target_details(
     baseline_or_entry: dict[str, Any],
-) -> dict[str, dict[str, float]]:
+) -> dict[str, dict[str, Any]]:
+    parse_targets = baseline_or_entry.get("parse_targets")
+    if isinstance(parse_targets, dict):
+        details = {
+            target: coerce_parse_target_detail(parse_info)
+            for target, parse_info in parse_targets.items()
+        }
+        if details:
+            return details
+
     metrics = baseline_or_entry.get("metrics")
     if isinstance(metrics, dict):
+        fast_parse_targets_detail = metrics.get("fast_parse_targets_detail")
+        if isinstance(fast_parse_targets_detail, dict):
+            details = {
+                target: coerce_parse_target_detail(parse_info)
+                for target, parse_info in fast_parse_targets_detail.items()
+            }
+            if details:
+                return details
+
         fast_parse_targets = metrics.get("fast_parse_targets_ms")
         if isinstance(fast_parse_targets, dict):
-            return fast_parse_targets
+            return {
+                target: {"metrics_ms": parse_info, "internal_metrics_ms": {}}
+                for target, parse_info in fast_parse_targets.items()
+            }
+
         fast_parse = metrics.get("fast_parse_ms")
         if isinstance(fast_parse, dict):
-            return {"parse-stress": fast_parse}
-
-    if "parse_targets" in baseline_or_entry:
-        return {
-            target: parse_info["metrics_ms"]
-            for target, parse_info in baseline_or_entry["parse_targets"].items()
-        }
+            return {"parse-stress": {"metrics_ms": fast_parse, "internal_metrics_ms": {}}}
 
     parse_benchmark = baseline_or_entry["parse_benchmark"]
     return {
-        parse_benchmark.get("artifact_name", "parse-stress"): parse_benchmark["metrics_ms"]
+        parse_benchmark.get("artifact_name", "parse-stress"): coerce_parse_target_detail(
+            parse_benchmark
+        )
+    }
+
+
+def extract_parse_targets(
+    baseline_or_entry: dict[str, Any],
+) -> dict[str, dict[str, float]]:
+    return {
+        target: parse_info["metrics_ms"]
+        for target, parse_info in extract_parse_target_details(baseline_or_entry).items()
     }
 
 
@@ -82,8 +135,110 @@ def metric_or_dash(
     return format_metric(float(metrics[percentile]))
 
 
+def ordered_parse_targets(*parse_target_maps: dict[str, dict[str, float]]) -> list[str]:
+    present_targets = {
+        target for parse_targets in parse_target_maps for target in parse_targets.keys()
+    }
+    ordered = [target for target in PREFERRED_PARSE_TARGETS if target in present_targets]
+    extras = sorted(present_targets - set(PREFERRED_PARSE_TARGETS))
+    return ordered + extras
+
+
+def nested_metric(data: dict[str, Any], dotted_path: str) -> float | None:
+    current: Any = data
+    for segment in dotted_path.split("."):
+        if not isinstance(current, dict) or segment not in current:
+            return None
+        current = current[segment]
+    if current is None:
+        return None
+    return float(current)
+
+
+def format_metric_or_dash(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return format_metric(value)
+
+
+def format_metric_with_unit_or_dash(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{format_metric(value)} ms"
+
+
+def delta_metrics(current: float | None, previous: float | None) -> tuple[float | None, float | None]:
+    if current is None or previous is None:
+        return None, None
+    delta_ms = current - previous
+    if previous == 0.0:
+        delta_pct = math.inf if current > 0.0 else 0.0
+    else:
+        delta_pct = (delta_ms / previous) * 100.0
+    return delta_ms, delta_pct
+
+
+def format_delta_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    if math.isinf(value):
+        return "inf"
+    return f"{value:+.2f}%"
+
+
+def delta_css_class(delta_ms: float | None) -> str:
+    if delta_ms is None or delta_ms == 0.0:
+        return "delta-neutral"
+    if delta_ms < 0.0:
+        return "delta-better"
+    return "delta-worse"
+
+
+def render_delta_badge(
+    label: str, current: float | None, previous: float | None
+) -> str:
+    delta_ms, delta_pct = delta_metrics(current, previous)
+    css_class = delta_css_class(delta_ms)
+    if delta_ms is None:
+        content = f"{label}: n/a"
+    else:
+        content = f"{label}: {delta_ms:+.3f} ms ({format_delta_pct(delta_pct)})"
+    return f'<span class="delta {css_class}">{html.escape(content)}</span>'
+
+
+def render_metric_cell(label: str, value: float | None) -> str:
+    return (
+        '<div class="metric">'
+        f"<span>{html.escape(label)}</span>"
+        f"<strong>{html.escape(format_metric_with_unit_or_dash(value))}</strong>"
+        "</div>"
+    )
+
+
+def find_previous_parse_target_detail(
+    history: list[dict[str, Any]], target: str
+) -> dict[str, Any] | None:
+    for entry in history[1:]:
+        details = extract_parse_target_details(entry)
+        if target in details:
+            return details[target]
+    return None
+
+
+def find_previous_query_metrics(history: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for entry in history[1:]:
+        metrics = entry.get("metrics", {}).get("source_line_query_ms")
+        if isinstance(metrics, dict):
+            return metrics
+    return None
+
+
 def build_entry(args: argparse.Namespace, baseline: dict[str, Any], artifact_path: str) -> dict[str, Any]:
-    parse_targets = extract_parse_targets(baseline)
+    parse_target_details = extract_parse_target_details(baseline)
+    parse_targets = {
+        target: parse_info["metrics_ms"]
+        for target, parse_info in parse_target_details.items()
+    }
     primary_parse_target = baseline.get("primary_parse_target")
     if primary_parse_target is None:
         primary_parse_target = baseline["parse_benchmark"].get(
@@ -104,9 +259,12 @@ def build_entry(args: argparse.Namespace, baseline: dict[str, Any], artifact_pat
         "run_attempt": args.run_attempt,
         "run_url": args.run_url,
         "artifact_path": artifact_path,
+        "primary_parse_target": primary_parse_target,
+        "parse_targets": parse_target_details,
         "metrics": {
             "fast_parse_ms": parse_metrics,
             "fast_parse_targets_ms": parse_targets,
+            "fast_parse_targets_detail": parse_target_details,
             "source_line_query_ms": query_metrics,
         },
         "query_result": {
@@ -140,64 +298,165 @@ def prune_stale_run_snapshots(runs_dir: Path, history: list[dict[str, Any]]) -> 
         if snapshot_path.name not in referenced:
             snapshot_path.unlink()
 
-
-def render_summary_cards(latest: dict[str, Any]) -> str:
-    parse_targets = extract_parse_targets(latest)
+def render_summary_cards(latest: dict[str, Any], history: list[dict[str, Any]]) -> str:
+    parse_target_details = extract_parse_target_details(latest)
     query_metrics = latest["metrics"]["source_line_query_ms"]
-    cards = [
-        ("parse-stress P50", metric_or_dash(parse_targets, "parse-stress", "p50")),
-        ("parse-stress P95", metric_or_dash(parse_targets, "parse-stress", "p95")),
-        (
-            "rust-parse-stress P50",
-            metric_or_dash(parse_targets, "rust-parse-stress", "p50"),
-        ),
-        (
-            "rust-parse-stress P95",
-            metric_or_dash(parse_targets, "rust-parse-stress", "p95"),
-        ),
-        ("Query P50", format_metric(query_metrics["p50"])),
-        ("Query P95", format_metric(query_metrics["p95"])),
-    ]
-    return (
-        '<div class="cards">'
-        + "".join(
-            f'<article class="card"><h2>{html.escape(title)}</h2><p>{html.escape(value)} ms</p></article>'
-            for title, value in cards
+    previous_query_metrics = find_previous_query_metrics(history)
+    cards: list[str] = []
+
+    for target in ordered_parse_targets(extract_parse_targets(latest)):
+        latest_detail = parse_target_details[target]
+        previous_detail = find_previous_parse_target_detail(history, target)
+        latest_avg = nested_metric(latest_detail, "metrics_ms.average")
+        latest_p50 = nested_metric(latest_detail, "metrics_ms.p50")
+        latest_p95 = nested_metric(latest_detail, "metrics_ms.p95")
+        latest_index_avg = nested_metric(
+            latest_detail, "internal_metrics_ms.index_phase.average"
         )
-        + "</div>"
+        previous_avg = (
+            nested_metric(previous_detail, "metrics_ms.average")
+            if previous_detail is not None
+            else None
+        )
+        previous_index_avg = (
+            nested_metric(previous_detail, "internal_metrics_ms.index_phase.average")
+            if previous_detail is not None
+            else None
+        )
+
+        cards.append(
+            '<article class="card">'
+            '<p class="eyebrow">Parse Target</p>'
+            f"<h2>{html.escape(target)}</h2>"
+            '<div class="metric-grid">'
+            f"{render_metric_cell('AVG', latest_avg)}"
+            f"{render_metric_cell('P50', latest_p50)}"
+            f"{render_metric_cell('P95', latest_p95)}"
+            f"{render_metric_cell('Index AVG', latest_index_avg)}"
+            "</div>"
+            '<div class="delta-list">'
+            f"{render_delta_badge('vs prev avg', latest_avg, previous_avg)}"
+            f"{render_delta_badge('vs prev index avg', latest_index_avg, previous_index_avg)}"
+            "</div>"
+            "</article>"
+        )
+
+    cards.append(
+        '<article class="card card-query">'
+        '<p class="eyebrow">Source-Line Query</p>'
+        "<h2>query-hotspot</h2>"
+        '<div class="metric-grid">'
+        f"{render_metric_cell('AVG', query_metrics.get('average'))}"
+        f"{render_metric_cell('P50', query_metrics.get('p50'))}"
+        f"{render_metric_cell('P95', query_metrics.get('p95'))}"
+        f"{render_metric_cell('First Run', query_metrics.get('first_run'))}"
+        "</div>"
+        '<div class="delta-list">'
+        f"{render_delta_badge('vs prev avg', query_metrics.get('average'), None if previous_query_metrics is None else previous_query_metrics.get('average'))}"
+        f"{render_delta_badge('vs prev p50', query_metrics.get('p50'), None if previous_query_metrics is None else previous_query_metrics.get('p50'))}"
+        "</div>"
+        "</article>"
     )
 
+    return '<div class="cards">' + "".join(cards) + "</div>"
 
-def render_history_table(history: list[dict[str, Any]]) -> str:
+
+def render_parse_history_sections(history: list[dict[str, Any]]) -> str:
+    parse_target_order = ordered_parse_targets(
+        *(extract_parse_targets(entry) for entry in history)
+    )
+    sections: list[str] = []
+
+    for idx, target in enumerate(parse_target_order):
+        rows: list[str] = []
+        run_count = 0
+        latest_detail: dict[str, Any] | None = None
+
+        for entry in history:
+            parse_target_details = extract_parse_target_details(entry)
+            parse_info = parse_target_details.get(target)
+            if parse_info is None:
+                continue
+
+            run_count += 1
+            if latest_detail is None:
+                latest_detail = parse_info
+
+            rows.append(
+                "<tr>"
+                f"<td>{html.escape(entry['generated_at'])}</td>"
+                f"<td><a href=\"{html.escape(entry['run_url'])}\">{html.escape(entry['sha_short'])}</a></td>"
+                f"<td>{html.escape(entry['event'])}</td>"
+                f"<td>{format_metric_or_dash(nested_metric(parse_info, 'metrics_ms.average'))}</td>"
+                f"<td>{format_metric_or_dash(nested_metric(parse_info, 'metrics_ms.p50'))}</td>"
+                f"<td>{format_metric_or_dash(nested_metric(parse_info, 'metrics_ms.p95'))}</td>"
+                f"<td>{format_metric_or_dash(nested_metric(parse_info, 'internal_metrics_ms.index_phase.average'))}</td>"
+                f"<td>{format_metric_or_dash(nested_metric(parse_info, 'internal_metrics_ms.index_phase.p50'))}</td>"
+                f"<td><a href=\"{html.escape(entry['artifact_path'])}\">json</a></td>"
+                "</tr>"
+            )
+
+        if latest_detail is None:
+            continue
+
+        summary_bits = [
+            f"avg {format_metric_or_dash(nested_metric(latest_detail, 'metrics_ms.average'))} ms",
+            f"p50 {format_metric_or_dash(nested_metric(latest_detail, 'metrics_ms.p50'))} ms",
+            f"p95 {format_metric_or_dash(nested_metric(latest_detail, 'metrics_ms.p95'))} ms",
+            f"index avg {format_metric_or_dash(nested_metric(latest_detail, 'internal_metrics_ms.index_phase.average'))} ms",
+        ]
+        open_attr = " open" if idx == 0 else ""
+        sections.append(
+            f'<details class="history-group"{open_attr}>'
+            "<summary>"
+            f'<span class="summary-title">{html.escape(target)}</span>'
+            f'<span class="summary-meta">{" · ".join(html.escape(bit) for bit in summary_bits)}</span>'
+            f'<span class="summary-count">{run_count} runs</span>'
+            "</summary>"
+            '<div class="table-wrap">'
+            "<table>"
+            "<thead><tr>"
+            "<th>Generated At</th><th>Commit</th><th>Event</th>"
+            "<th>AVG</th><th>P50</th><th>P95</th><th>Index AVG</th><th>Index P50</th><th>Snapshot</th>"
+            "</tr></thead>"
+            f"<tbody>{''.join(rows)}</tbody>"
+            "</table>"
+            "</div>"
+            "</details>"
+        )
+
+    return '<div class="history-groups">' + "".join(sections) + "</div>"
+
+
+def render_query_history_table(history: list[dict[str, Any]]) -> str:
     rows = []
     for entry in history:
-        parse_targets = extract_parse_targets(entry)
         query_metrics = entry["metrics"]["source_line_query_ms"]
+        query_result = entry["query_result"]
         rows.append(
             "<tr>"
             f"<td>{html.escape(entry['generated_at'])}</td>"
             f"<td><a href=\"{html.escape(entry['run_url'])}\">{html.escape(entry['sha_short'])}</a></td>"
             f"<td>{html.escape(entry['event'])}</td>"
-            f"<td>{metric_or_dash(parse_targets, 'parse-stress', 'p50')}</td>"
-            f"<td>{metric_or_dash(parse_targets, 'parse-stress', 'p95')}</td>"
-            f"<td>{metric_or_dash(parse_targets, 'rust-parse-stress', 'p50')}</td>"
-            f"<td>{metric_or_dash(parse_targets, 'rust-parse-stress', 'p95')}</td>"
-            f"<td>{format_metric(query_metrics['p50'])}</td>"
-            f"<td>{format_metric(query_metrics['p95'])}</td>"
+            f"<td>{format_metric(float(query_metrics['average']))}</td>"
+            f"<td>{format_metric(float(query_metrics['p50']))}</td>"
+            f"<td>{format_metric(float(query_metrics['p95']))}</td>"
+            f"<td>{query_result['address_count']}</td>"
+            f"<td>{query_result['total_variables']}</td>"
             f"<td><a href=\"{html.escape(entry['artifact_path'])}\">json</a></td>"
             "</tr>"
         )
 
     return (
+        '<div class="table-wrap">'
         "<table>"
         "<thead><tr>"
         "<th>Generated At</th><th>Commit</th><th>Event</th>"
-        "<th>parse-stress P50</th><th>parse-stress P95</th>"
-        "<th>rust-parse-stress P50</th><th>rust-parse-stress P95</th>"
-        "<th>Query P50</th><th>Query P95</th><th>Snapshot</th>"
+        "<th>AVG</th><th>P50</th><th>P95</th><th>Addresses</th><th>Variables</th><th>Snapshot</th>"
         "</tr></thead>"
         f"<tbody>{''.join(rows)}</tbody>"
         "</table>"
+        "</div>"
     )
 
 
@@ -285,24 +544,130 @@ def render_index(repo: str, latest: dict[str, Any], history: list[dict[str, Any]
       border-radius: 14px;
       padding: 16px 18px;
     }}
-    .card h2 {{
-      font-size: 14px;
+    .eyebrow {{
+      margin: 0 0 8px;
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
       color: var(--muted);
+    }}
+    .card h2 {{
+      font-size: 18px;
+      color: var(--ink);
       margin-bottom: 10px;
     }}
-    .card p {{
-      margin: 0;
-      font-size: 28px;
+    .metric-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 10px;
+      margin-top: 14px;
+    }}
+    .metric {{
+      padding: 12px;
+      border-radius: 12px;
+      background: #fff8ec;
+      border: 1px solid #eadfca;
+    }}
+    .metric span {{
+      display: block;
+      font-size: 12px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 6px;
+    }}
+    .metric strong {{
+      display: block;
+      font-size: 22px;
       color: var(--accent);
+      line-height: 1.15;
+    }}
+    .delta-list {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }}
+    .delta {{
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 12px;
+      line-height: 1.3;
+      border: 1px solid var(--border);
+      background: #f8f1e3;
+      color: var(--muted);
+    }}
+    .delta-better {{
+      background: #edf7ef;
+      border-color: #bedcc4;
+      color: #1f6b36;
+    }}
+    .delta-worse {{
+      background: #fff1eb;
+      border-color: #efc4b4;
+      color: #9a3412;
+    }}
+    .delta-neutral {{
+      background: #f8f1e3;
+      border-color: #dfd6c3;
+      color: var(--muted);
     }}
     .panel {{
       padding: 24px;
       margin-top: 24px;
     }}
+    .panel > p {{
+      color: var(--muted);
+      margin-top: 0;
+    }}
+    .history-groups {{
+      display: grid;
+      gap: 14px;
+      margin-top: 18px;
+    }}
+    .history-group {{
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: #fffdf8;
+      overflow: hidden;
+    }}
+    .history-group summary {{
+      display: grid;
+      grid-template-columns: minmax(0, 220px) 1fr auto;
+      gap: 12px;
+      align-items: center;
+      cursor: pointer;
+      list-style: none;
+      padding: 16px 18px;
+    }}
+    .history-group summary::-webkit-details-marker {{
+      display: none;
+    }}
+    .summary-title {{
+      font-weight: 700;
+      color: var(--ink);
+    }}
+    .summary-meta {{
+      color: var(--muted);
+      font-size: 14px;
+    }}
+    .summary-count {{
+      color: var(--accent);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }}
+    .table-wrap {{
+      overflow-x: auto;
+      border-top: 1px solid var(--border);
+    }}
     table {{
       width: 100%;
+      min-width: 760px;
       border-collapse: collapse;
-      margin-top: 18px;
     }}
     th, td {{
       text-align: left;
@@ -318,6 +683,17 @@ def render_index(repo: str, latest: dict[str, Any], history: list[dict[str, Any]
     a {{
       color: var(--accent);
     }}
+    @media (max-width: 760px) {{
+      main {{
+        padding: 28px 16px 40px;
+      }}
+      .history-group summary {{
+        grid-template-columns: 1fr;
+      }}
+      .metric strong {{
+        font-size: 19px;
+      }}
+    }}
   </style>
 </head>
 <body>
@@ -326,19 +702,24 @@ def render_index(repo: str, latest: dict[str, Any], history: list[dict[str, Any]
       <h1>DWARF Perf History</h1>
       <p>
         Main-branch and scheduled DWARF perf baselines for <strong>{html.escape(repo)}</strong>.
-        This page records the current C parse, Rust parse, and source-line query trends from CI.
+        This page records startup load, index-phase, and source-line query trends across the DWARF perf corpora from CI.
       </p>
       {site_meta}
       {latest_meta}
-      {render_summary_cards(latest)}
+      {render_summary_cards(latest, history)}
     </section>
     <section class="panel">
       <h2>Latest Query Snapshot</h2>
       {query_meta}
     </section>
     <section class="panel">
-      <h2>Recent History</h2>
-      {render_history_table(history)}
+      <h2>Parse History</h2>
+      <p>Each parse corpus keeps its own recent run table, so AVG, P50, P95, and index-phase values stay readable.</p>
+      {render_parse_history_sections(history)}
+    </section>
+    <section class="panel">
+      <h2>Query History</h2>
+      {render_query_history_table(history)}
     </section>
   </main>
 </body>

--- a/scripts/dwarf-perf/run_baseline.sh
+++ b/scripts/dwarf-perf/run_baseline.sh
@@ -10,7 +10,7 @@ CORPUS_DIR="$REPO_ROOT/scripts/dwarf-perf/corpus/out"
 RESULTS_DIR="$REPO_ROOT/perf-results"
 RESULT_NAME=""
 CARGO_TARGET_DIR_VALUE="$REPO_ROOT/.target_tmp/dwarf-perf"
-PARSE_TARGET_NAME="parse-stress"
+PARSE_TARGET_NAME=""
 
 usage() {
     cat <<'EOF'
@@ -22,7 +22,7 @@ Options:
   --results-dir PATH     result directory (default: perf-results)
   --result-name NAME     result file stem (default: timestamp-based)
   --runs N               benchmark runs for parse and query baselines (default: 10)
-  --parse-target NAME    parse artifact name from manifest (default: parse-stress)
+  --parse-target NAME    run only one parse artifact from the manifest
   --cargo-target-dir P   cargo target dir for dwarf-tool (default: .target_tmp/dwarf-perf)
   -h, --help             show this help
 EOF
@@ -118,8 +118,277 @@ display_metric_ms() {
     fi
 }
 
+timestamp_utc() {
+    date -u +"%H:%M:%S"
+}
+
+log_stage() {
+    printf '[%s] %s\n' "$(timestamp_utc)" "$*"
+}
+
+print_parse_summary() {
+    local target_name=$1
+    local binary_path=$2
+
+    echo "Fast parse benchmark:"
+    echo "  meaning: analyzer load + initial DWARF fast-parse/index build"
+    echo "  artifact: $target_name"
+    echo "  binary: $binary_path"
+    echo "  runs: $RUNS"
+    echo "  average: ${PARSE_AVG_MS}ms"
+    echo "  p50: ${PARSE_P50_MS}ms"
+    echo "  p95: ${PARSE_P95_MS}ms"
+    echo "  min: ${PARSE_MIN_MS}ms"
+    echo "  max: ${PARSE_MAX_MS}ms"
+    echo "  internal modules: ${PARSE_INTERNAL_MODULE_COUNT}"
+    echo "  parse phase avg: $(display_metric_ms "$PARSE_PHASE_AVG_MS")"
+    echo "  parse phase p50: $(display_metric_ms "$PARSE_PHASE_P50_MS")"
+    echo "  parse phase p95: $(display_metric_ms "$PARSE_PHASE_P95_MS")"
+    echo "  index phase avg: $(display_metric_ms "$INDEX_PHASE_AVG_MS")"
+    echo "  index phase p50: $(display_metric_ms "$INDEX_PHASE_P50_MS")"
+    echo "  index phase p95: $(display_metric_ms "$INDEX_PHASE_P95_MS")"
+    echo "  internal total avg: $(display_metric_ms "$INTERNAL_TOTAL_AVG_MS")"
+    echo "  internal total p50: $(display_metric_ms "$INTERNAL_TOTAL_P50_MS")"
+    echo "  internal total p95: $(display_metric_ms "$INTERNAL_TOTAL_P95_MS")"
+    echo
+}
+
+print_query_summary() {
+    echo "Source-line query benchmark:"
+    echo "  meaning: source-line lookup + address resolution + variable collection for matched addresses"
+    echo "  source: ${QUERY_SOURCE_ABS}:${QUERY_LINE}"
+    echo "  binary: $QUERY_BINARY"
+    echo "  loading time: ${QUERY_LOADING_MS}ms"
+    echo "  runs: $RUNS"
+    echo "  first run: ${QUERY_FIRST_RUN_MS}ms"
+    echo "  average: ${QUERY_AVG_MS}ms"
+    echo "  p50: ${QUERY_P50_MS}ms"
+    echo "  p95: ${QUERY_P95_MS}ms"
+    echo "  min: ${QUERY_MIN_MS}ms"
+    echo "  max: ${QUERY_MAX_MS}ms"
+    echo
+    echo "Query result snapshot:"
+    echo "  addresses: $QUERY_ADDRESS_COUNT"
+    echo "  total variables: $QUERY_TOTAL_VARS"
+    if [[ -n "$QUERY_FIRST_ADDRESS" ]]; then
+        echo "  first address: $QUERY_FIRST_ADDRESS"
+    fi
+    echo
+}
+
+run_query_benchmark() {
+    local query_output
+    local query_json
+
+    log_stage "Running source-line query benchmark on query-hotspot"
+    query_output=$(CARGO_TARGET_DIR="$CARGO_TARGET_DIR_VALUE" \
+        cargo run -q -p dwarf-tool -- \
+        -t "$QUERY_BINARY" \
+        benchmark-source-line "${QUERY_SOURCE_ABS}:${QUERY_LINE}" \
+        --runs "$RUNS" \
+        --json)
+
+    query_json=$(printf '%s\n' "$query_output" | sed -n '/^{/,$p')
+    QUERY_LOADING_MS=$(require_json_value "query loading time" "$(printf '%s\n' "$query_json" | jq '.loading_time_ms')" "$query_json")
+    QUERY_FIRST_RUN_MS=$(require_json_value "query first run" "$(printf '%s\n' "$query_json" | jq '.benchmark.first_run_ms')" "$query_json")
+    QUERY_AVG_MS=$(require_json_value "query average" "$(printf '%s\n' "$query_json" | jq '.benchmark.average_ms')" "$query_json")
+    QUERY_P50_MS=$(require_json_value "query p50" "$(printf '%s\n' "$query_json" | jq '.benchmark.p50_ms')" "$query_json")
+    QUERY_P95_MS=$(require_json_value "query p95" "$(printf '%s\n' "$query_json" | jq '.benchmark.p95_ms')" "$query_json")
+    QUERY_MIN_MS=$(require_json_value "query min" "$(printf '%s\n' "$query_json" | jq '.benchmark.min_ms')" "$query_json")
+    QUERY_MAX_MS=$(require_json_value "query max" "$(printf '%s\n' "$query_json" | jq '.benchmark.max_ms')" "$query_json")
+    QUERY_TOTAL_VARS=$(require_json_value "query total variables" "$(printf '%s\n' "$query_json" | jq '.total_variables')" "$query_json")
+    QUERY_ADDRESS_COUNT=$(require_json_value "query address count" "$(printf '%s\n' "$query_json" | jq '.address_count')" "$query_json")
+    QUERY_FIRST_ADDRESS=$(printf '%s\n' "$query_json" | jq -r '.first_address // empty')
+    log_stage "Completed source-line query benchmark"
+}
+
+run_parse_benchmark() {
+    local parse_binary=$1
+    local parse_target=$2
+    local progress_label=${3:-}
+    local parse_output
+
+    if [[ -n "$progress_label" ]]; then
+        log_stage "Running fast-parse benchmark ${progress_label} for ${parse_target}"
+    else
+        log_stage "Running fast-parse benchmark for ${parse_target}"
+    fi
+    parse_output=$(CARGO_TARGET_DIR="$CARGO_TARGET_DIR_VALUE" \
+        cargo run -q -p dwarf-tool -- \
+        -t "$parse_binary" \
+        benchmark --runs "$RUNS")
+
+    PARSE_AVG_MS=$(require_json_value "parse average" "$(printf '%s\n' "$parse_output" | awk '/Average load time:/ {gsub("ms","",$4); print $4}')" "$parse_output")
+    PARSE_P50_MS=$(require_json_value "parse p50" "$(printf '%s\n' "$parse_output" | awk '/P50:/ {gsub("ms","",$2); print $2}')" "$parse_output")
+    PARSE_P95_MS=$(require_json_value "parse p95" "$(printf '%s\n' "$parse_output" | awk '/P95:/ {gsub("ms","",$2); print $2}')" "$parse_output")
+    PARSE_MIN_MS=$(require_json_value "parse min" "$(printf '%s\n' "$parse_output" | awk '/Min:/ {gsub("ms","",$2); print $2}')" "$parse_output")
+    PARSE_MAX_MS=$(require_json_value "parse max" "$(printf '%s\n' "$parse_output" | awk '/Max:/ {gsub("ms","",$2); print $2}')" "$parse_output")
+    PARSE_INTERNAL_MODULE_COUNT=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Internal module count:/ {print $4}')")
+    PARSE_PHASE_AVG_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Parse avg:/ {gsub("ms","",$3); print $3}')")
+    PARSE_PHASE_P50_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Parse p50:/ {gsub("ms","",$3); print $3}')")
+    PARSE_PHASE_P95_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Parse p95:/ {gsub("ms","",$3); print $3}')")
+    PARSE_PHASE_MIN_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Parse min:/ {gsub("ms","",$3); print $3}')")
+    PARSE_PHASE_MAX_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Parse max:/ {gsub("ms","",$3); print $3}')")
+    INDEX_PHASE_AVG_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Index avg:/ {gsub("ms","",$3); print $3}')")
+    INDEX_PHASE_P50_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Index p50:/ {gsub("ms","",$3); print $3}')")
+    INDEX_PHASE_P95_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Index p95:/ {gsub("ms","",$3); print $3}')")
+    INDEX_PHASE_MIN_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Index min:/ {gsub("ms","",$3); print $3}')")
+    INDEX_PHASE_MAX_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Index max:/ {gsub("ms","",$3); print $3}')")
+    INTERNAL_TOTAL_AVG_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Internal total avg:/ {gsub("ms","",$4); print $4}')")
+    INTERNAL_TOTAL_P50_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Internal total p50:/ {gsub("ms","",$4); print $4}')")
+    INTERNAL_TOTAL_P95_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Internal total p95:/ {gsub("ms","",$4); print $4}')")
+    INTERNAL_TOTAL_MIN_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Internal total min:/ {gsub("ms","",$4); print $4}')")
+    INTERNAL_TOTAL_MAX_MS=$(optional_json_value "$(printf '%s\n' "$parse_output" | awk '/Internal total max:/ {gsub("ms","",$4); print $4}')")
+    log_stage "Completed fast-parse benchmark for ${parse_target}"
+}
+
+write_baseline_json() {
+    local output_path=$1
+    local target_name=$2
+    local parse_binary=$3
+
+    log_stage "Writing baseline JSON for ${target_name} -> ${output_path}"
+    jq -n \
+        --arg generated_at "$GENERATED_AT" \
+        --arg repo_root "$REPO_ROOT" \
+        --arg corpus_dir "$CORPUS_DIR" \
+        --arg manifest "$MANIFEST_PATH" \
+        --arg results_path "$output_path" \
+        --arg query_binary "$QUERY_BINARY" \
+        --arg parse_binary "$parse_binary" \
+        --arg parse_artifact_name "$target_name" \
+        --arg query_source "$QUERY_SOURCE_ABS" \
+        --arg query_line "$QUERY_LINE" \
+        --arg query_first_address "$QUERY_FIRST_ADDRESS" \
+        --argjson runs "$RUNS" \
+        --argjson parse_avg_ms "$PARSE_AVG_MS" \
+        --argjson parse_p50_ms "$PARSE_P50_MS" \
+        --argjson parse_p95_ms "$PARSE_P95_MS" \
+        --argjson parse_min_ms "$PARSE_MIN_MS" \
+        --argjson parse_max_ms "$PARSE_MAX_MS" \
+        --argjson parse_internal_module_count "$PARSE_INTERNAL_MODULE_COUNT" \
+        --argjson parse_phase_avg_ms "$PARSE_PHASE_AVG_MS" \
+        --argjson parse_phase_p50_ms "$PARSE_PHASE_P50_MS" \
+        --argjson parse_phase_p95_ms "$PARSE_PHASE_P95_MS" \
+        --argjson parse_phase_min_ms "$PARSE_PHASE_MIN_MS" \
+        --argjson parse_phase_max_ms "$PARSE_PHASE_MAX_MS" \
+        --argjson index_phase_avg_ms "$INDEX_PHASE_AVG_MS" \
+        --argjson index_phase_p50_ms "$INDEX_PHASE_P50_MS" \
+        --argjson index_phase_p95_ms "$INDEX_PHASE_P95_MS" \
+        --argjson index_phase_min_ms "$INDEX_PHASE_MIN_MS" \
+        --argjson index_phase_max_ms "$INDEX_PHASE_MAX_MS" \
+        --argjson internal_total_avg_ms "$INTERNAL_TOTAL_AVG_MS" \
+        --argjson internal_total_p50_ms "$INTERNAL_TOTAL_P50_MS" \
+        --argjson internal_total_p95_ms "$INTERNAL_TOTAL_P95_MS" \
+        --argjson internal_total_min_ms "$INTERNAL_TOTAL_MIN_MS" \
+        --argjson internal_total_max_ms "$INTERNAL_TOTAL_MAX_MS" \
+        --argjson query_loading_ms "$QUERY_LOADING_MS" \
+        --argjson query_first_run_ms "$QUERY_FIRST_RUN_MS" \
+        --argjson query_avg_ms "$QUERY_AVG_MS" \
+        --argjson query_p50_ms "$QUERY_P50_MS" \
+        --argjson query_p95_ms "$QUERY_P95_MS" \
+        --argjson query_min_ms "$QUERY_MIN_MS" \
+        --argjson query_max_ms "$QUERY_MAX_MS" \
+        --argjson query_total_variables "$QUERY_TOTAL_VARS" \
+        --argjson query_address_count "$QUERY_ADDRESS_COUNT" \
+        --slurpfile manifest_json "$MANIFEST_PATH" \
+        '{
+            schema_version: 2,
+            generated_at: $generated_at,
+            repo_root: $repo_root,
+            corpus_dir: $corpus_dir,
+            manifest_path: $manifest,
+            result_path: $results_path,
+            parse_benchmark: {
+                description: "Fast parse benchmark: analyzer load plus initial DWARF fast-parse/index build.",
+                artifact_name: $parse_artifact_name,
+                binary: $parse_binary,
+                runs: $runs,
+                metrics_ms: {
+                    average: $parse_avg_ms,
+                    p50: $parse_p50_ms,
+                    p95: $parse_p95_ms,
+                    min: $parse_min_ms,
+                    max: $parse_max_ms
+                },
+                internal_metrics_ms: {
+                    module_count: $parse_internal_module_count,
+                    parse_phase: {
+                        average: $parse_phase_avg_ms,
+                        p50: $parse_phase_p50_ms,
+                        p95: $parse_phase_p95_ms,
+                        min: $parse_phase_min_ms,
+                        max: $parse_phase_max_ms
+                    },
+                    index_phase: {
+                        average: $index_phase_avg_ms,
+                        p50: $index_phase_p50_ms,
+                        p95: $index_phase_p95_ms,
+                        min: $index_phase_min_ms,
+                        max: $index_phase_max_ms
+                    },
+                    internal_total: {
+                        average: $internal_total_avg_ms,
+                        p50: $internal_total_p50_ms,
+                        p95: $internal_total_p95_ms,
+                        min: $internal_total_min_ms,
+                        max: $internal_total_max_ms
+                    }
+                }
+            },
+            query_benchmark: {
+                description: "End-to-end source-line query benchmark: source-line lookup, address resolution, and variable collection for all matched addresses.",
+                binary: $query_binary,
+                source: {
+                    path: $query_source,
+                    line: ($query_line | tonumber)
+                },
+                loading_time_ms: $query_loading_ms,
+                runs: $runs,
+                metrics_ms: {
+                    first_run: $query_first_run_ms,
+                    average: $query_avg_ms,
+                    p50: $query_p50_ms,
+                    p95: $query_p95_ms,
+                    min: $query_min_ms,
+                    max: $query_max_ms
+                }
+            },
+            query_result: {
+                description: "Snapshot of the matched query result for the benchmarked source line.",
+                source: {
+                    path: $query_source,
+                    line: ($query_line | tonumber)
+                },
+                first_address: $query_first_address,
+                address_count: $query_address_count,
+                total_variables: $query_total_variables
+            },
+            corpus_manifest: $manifest_json[0]
+        }' >"$output_path"
+    log_stage "Wrote baseline JSON for ${target_name}"
+}
+
+ordered_parse_targets() {
+    local primary_target=$1
+    shift
+    local target
+
+    printf '%s\n' "$primary_target"
+    for target in "$@"; do
+        if [[ "$target" == "$primary_target" ]]; then
+            continue
+        fi
+        printf '%s\n' "$target"
+    done
+}
+
 if [[ "$BUILD_CORPUS" -eq 1 ]]; then
+    log_stage "Building corpus into ${CORPUS_DIR}"
     "$SCRIPT_DIR/build_corpus.sh" "$CORPUS_DIR"
+    log_stage "Completed corpus build"
+else
+    log_stage "Reusing existing corpus at ${CORPUS_DIR}"
 fi
 
 MANIFEST_PATH="$CORPUS_DIR/manifest.json"
@@ -128,234 +397,106 @@ if [[ ! -f "$MANIFEST_PATH" ]]; then
     exit 1
 fi
 
+log_stage "Loading corpus manifest from ${MANIFEST_PATH}"
 QUERY_SOURCE=$(jq -r '.artifacts[] | select(.name=="query-hotspot") | .source_path' "$MANIFEST_PATH")
 QUERY_LINE=$(jq -r '.artifacts[] | select(.name=="query-hotspot") | .query_anchor.source_line' "$MANIFEST_PATH")
 QUERY_BINARY_REL=$(jq -r '.artifacts[] | select(.name=="query-hotspot") | .relative_path' "$MANIFEST_PATH")
-PARSE_BINARY_REL=$(jq -r --arg parse_target "$PARSE_TARGET_NAME" '.artifacts[] | select(.name==$parse_target) | .relative_path' "$MANIFEST_PATH")
-
-if [[ -z "$PARSE_BINARY_REL" || "$PARSE_BINARY_REL" == "null" ]]; then
-    echo "parse artifact not found in manifest: $PARSE_TARGET_NAME" >&2
-    exit 1
-fi
 
 QUERY_BINARY="$CORPUS_DIR/$QUERY_BINARY_REL"
-PARSE_BINARY="$CORPUS_DIR/$PARSE_BINARY_REL"
 QUERY_SOURCE_ABS="$REPO_ROOT/$QUERY_SOURCE"
 RESULT_PATH="$RESULTS_DIR/$RESULT_NAME.json"
+GENERATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 if [[ ! -f "$QUERY_BINARY" ]]; then
     echo "query binary not found: $QUERY_BINARY" >&2
     exit 1
 fi
 
-if [[ ! -f "$PARSE_BINARY" ]]; then
-    echo "parse binary not found: $PARSE_BINARY" >&2
+run_query_benchmark
+
+if [[ -n "$PARSE_TARGET_NAME" ]]; then
+    log_stage "Single-target mode enabled for ${PARSE_TARGET_NAME}"
+    PARSE_BINARY_REL=$(jq -r --arg parse_target "$PARSE_TARGET_NAME" '.artifacts[] | select(.name==$parse_target) | .relative_path' "$MANIFEST_PATH")
+    if [[ -z "$PARSE_BINARY_REL" || "$PARSE_BINARY_REL" == "null" ]]; then
+        echo "parse artifact not found in manifest: $PARSE_TARGET_NAME" >&2
+        exit 1
+    fi
+
+    PARSE_BINARY="$CORPUS_DIR/$PARSE_BINARY_REL"
+    if [[ ! -f "$PARSE_BINARY" ]]; then
+        echo "parse binary not found: $PARSE_BINARY" >&2
+        exit 1
+    fi
+
+    run_parse_benchmark "$PARSE_BINARY" "$PARSE_TARGET_NAME"
+    write_baseline_json "$RESULT_PATH" "$PARSE_TARGET_NAME" "$PARSE_BINARY"
+    print_parse_summary "$PARSE_TARGET_NAME" "$PARSE_BINARY"
+    print_query_summary
+    log_stage "Finished single-target baseline run"
+    echo "Result JSON: $RESULT_PATH"
+    exit 0
+fi
+
+mapfile -t ALL_PARSE_TARGETS < <(jq -r '.artifacts[] | select(.kind=="fast-parse") | .name' "$MANIFEST_PATH")
+if [[ "${#ALL_PARSE_TARGETS[@]}" -eq 0 ]]; then
+    echo "no fast-parse artifacts found in manifest: $MANIFEST_PATH" >&2
     exit 1
 fi
 
-PARSE_OUTPUT=$(CARGO_TARGET_DIR="$CARGO_TARGET_DIR_VALUE" \
-    cargo run -q -p dwarf-tool -- \
-    -t "$PARSE_BINARY" \
-    benchmark --runs "$RUNS")
+PRIMARY_PARSE_TARGET=${ALL_PARSE_TARGETS[0]}
+for target in "${ALL_PARSE_TARGETS[@]}"; do
+    if [[ "$target" == "parse-stress" ]]; then
+        PRIMARY_PARSE_TARGET=$target
+        break
+    fi
+done
 
-QUERY_OUTPUT=$(CARGO_TARGET_DIR="$CARGO_TARGET_DIR_VALUE" \
-    cargo run -q -p dwarf-tool -- \
-    -t "$QUERY_BINARY" \
-    benchmark-source-line "${QUERY_SOURCE_ABS}:${QUERY_LINE}" \
-    --runs "$RUNS" \
-    --json)
+mapfile -t ORDERED_PARSE_TARGETS < <(ordered_parse_targets "$PRIMARY_PARSE_TARGET" "${ALL_PARSE_TARGETS[@]}")
+log_stage "Default mode enabled: running all fast-parse targets (${#ORDERED_PARSE_TARGETS[@]})"
+log_stage "Primary parse target: ${PRIMARY_PARSE_TARGET}"
 
-PARSE_AVG_MS=$(require_json_value "parse average" "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Average load time:/ {gsub("ms","",$4); print $4}')" "$PARSE_OUTPUT")
-PARSE_P50_MS=$(require_json_value "parse p50" "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/P50:/ {gsub("ms","",$2); print $2}')" "$PARSE_OUTPUT")
-PARSE_P95_MS=$(require_json_value "parse p95" "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/P95:/ {gsub("ms","",$2); print $2}')" "$PARSE_OUTPUT")
-PARSE_MIN_MS=$(require_json_value "parse min" "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Min:/ {gsub("ms","",$2); print $2}')" "$PARSE_OUTPUT")
-PARSE_MAX_MS=$(require_json_value "parse max" "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Max:/ {gsub("ms","",$2); print $2}')" "$PARSE_OUTPUT")
-PARSE_INTERNAL_MODULE_COUNT=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Internal module count:/ {print $4}')")
-PARSE_PHASE_AVG_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Parse avg:/ {gsub("ms","",$3); print $3}')")
-PARSE_PHASE_P50_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Parse p50:/ {gsub("ms","",$3); print $3}')")
-PARSE_PHASE_P95_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Parse p95:/ {gsub("ms","",$3); print $3}')")
-PARSE_PHASE_MIN_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Parse min:/ {gsub("ms","",$3); print $3}')")
-PARSE_PHASE_MAX_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Parse max:/ {gsub("ms","",$3); print $3}')")
-INDEX_PHASE_AVG_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Index avg:/ {gsub("ms","",$3); print $3}')")
-INDEX_PHASE_P50_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Index p50:/ {gsub("ms","",$3); print $3}')")
-INDEX_PHASE_P95_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Index p95:/ {gsub("ms","",$3); print $3}')")
-INDEX_PHASE_MIN_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Index min:/ {gsub("ms","",$3); print $3}')")
-INDEX_PHASE_MAX_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Index max:/ {gsub("ms","",$3); print $3}')")
-INTERNAL_TOTAL_AVG_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Internal total avg:/ {gsub("ms","",$4); print $4}')")
-INTERNAL_TOTAL_P50_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Internal total p50:/ {gsub("ms","",$4); print $4}')")
-INTERNAL_TOTAL_P95_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Internal total p95:/ {gsub("ms","",$4); print $4}')")
-INTERNAL_TOTAL_MIN_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Internal total min:/ {gsub("ms","",$4); print $4}')")
-INTERNAL_TOTAL_MAX_MS=$(optional_json_value "$(printf '%s\n' "$PARSE_OUTPUT" | awk '/Internal total max:/ {gsub("ms","",$4); print $4}')")
-QUERY_JSON=$(printf '%s\n' "$QUERY_OUTPUT" | sed -n '/^{/,$p')
-QUERY_LOADING_MS=$(require_json_value "query loading time" "$(printf '%s\n' "$QUERY_JSON" | jq '.loading_time_ms')" "$QUERY_JSON")
-QUERY_FIRST_RUN_MS=$(require_json_value "query first run" "$(printf '%s\n' "$QUERY_JSON" | jq '.benchmark.first_run_ms')" "$QUERY_JSON")
-QUERY_AVG_MS=$(require_json_value "query average" "$(printf '%s\n' "$QUERY_JSON" | jq '.benchmark.average_ms')" "$QUERY_JSON")
-QUERY_P50_MS=$(require_json_value "query p50" "$(printf '%s\n' "$QUERY_JSON" | jq '.benchmark.p50_ms')" "$QUERY_JSON")
-QUERY_P95_MS=$(require_json_value "query p95" "$(printf '%s\n' "$QUERY_JSON" | jq '.benchmark.p95_ms')" "$QUERY_JSON")
-QUERY_MIN_MS=$(require_json_value "query min" "$(printf '%s\n' "$QUERY_JSON" | jq '.benchmark.min_ms')" "$QUERY_JSON")
-QUERY_MAX_MS=$(require_json_value "query max" "$(printf '%s\n' "$QUERY_JSON" | jq '.benchmark.max_ms')" "$QUERY_JSON")
-QUERY_TOTAL_VARS=$(require_json_value "query total variables" "$(printf '%s\n' "$QUERY_JSON" | jq '.total_variables')" "$QUERY_JSON")
-QUERY_ADDRESS_COUNT=$(require_json_value "query address count" "$(printf '%s\n' "$QUERY_JSON" | jq '.address_count')" "$QUERY_JSON")
-QUERY_FIRST_ADDRESS=$(printf '%s\n' "$QUERY_JSON" | jq -r '.first_address // empty')
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+additional_args=()
+primary_result=""
+target_total=${#ORDERED_PARSE_TARGETS[@]}
+target_idx=0
 
-jq -n \
-    --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-    --arg repo_root "$REPO_ROOT" \
-    --arg corpus_dir "$CORPUS_DIR" \
-    --arg manifest "$MANIFEST_PATH" \
-    --arg results_path "$RESULT_PATH" \
-    --arg query_binary "$QUERY_BINARY" \
-    --arg parse_binary "$PARSE_BINARY" \
-    --arg parse_artifact_name "$PARSE_TARGET_NAME" \
-    --arg query_source "$QUERY_SOURCE_ABS" \
-    --arg query_line "$QUERY_LINE" \
-    --arg query_first_address "$QUERY_FIRST_ADDRESS" \
-    --argjson runs "$RUNS" \
-    --argjson parse_avg_ms "$PARSE_AVG_MS" \
-    --argjson parse_p50_ms "$PARSE_P50_MS" \
-    --argjson parse_p95_ms "$PARSE_P95_MS" \
-    --argjson parse_min_ms "$PARSE_MIN_MS" \
-    --argjson parse_max_ms "$PARSE_MAX_MS" \
-    --argjson parse_internal_module_count "$PARSE_INTERNAL_MODULE_COUNT" \
-    --argjson parse_phase_avg_ms "$PARSE_PHASE_AVG_MS" \
-    --argjson parse_phase_p50_ms "$PARSE_PHASE_P50_MS" \
-    --argjson parse_phase_p95_ms "$PARSE_PHASE_P95_MS" \
-    --argjson parse_phase_min_ms "$PARSE_PHASE_MIN_MS" \
-    --argjson parse_phase_max_ms "$PARSE_PHASE_MAX_MS" \
-    --argjson index_phase_avg_ms "$INDEX_PHASE_AVG_MS" \
-    --argjson index_phase_p50_ms "$INDEX_PHASE_P50_MS" \
-    --argjson index_phase_p95_ms "$INDEX_PHASE_P95_MS" \
-    --argjson index_phase_min_ms "$INDEX_PHASE_MIN_MS" \
-    --argjson index_phase_max_ms "$INDEX_PHASE_MAX_MS" \
-    --argjson internal_total_avg_ms "$INTERNAL_TOTAL_AVG_MS" \
-    --argjson internal_total_p50_ms "$INTERNAL_TOTAL_P50_MS" \
-    --argjson internal_total_p95_ms "$INTERNAL_TOTAL_P95_MS" \
-    --argjson internal_total_min_ms "$INTERNAL_TOTAL_MIN_MS" \
-    --argjson internal_total_max_ms "$INTERNAL_TOTAL_MAX_MS" \
-    --argjson query_loading_ms "$QUERY_LOADING_MS" \
-    --argjson query_first_run_ms "$QUERY_FIRST_RUN_MS" \
-    --argjson query_avg_ms "$QUERY_AVG_MS" \
-    --argjson query_p50_ms "$QUERY_P50_MS" \
-    --argjson query_p95_ms "$QUERY_P95_MS" \
-    --argjson query_min_ms "$QUERY_MIN_MS" \
-    --argjson query_max_ms "$QUERY_MAX_MS" \
-    --argjson query_total_variables "$QUERY_TOTAL_VARS" \
-    --argjson query_address_count "$QUERY_ADDRESS_COUNT" \
-    --slurpfile manifest_json "$MANIFEST_PATH" \
-    '{
-        schema_version: 2,
-        generated_at: $generated_at,
-        repo_root: $repo_root,
-        corpus_dir: $corpus_dir,
-        manifest_path: $manifest,
-        result_path: $results_path,
-        parse_benchmark: {
-            description: "Fast parse benchmark: analyzer load plus initial DWARF fast-parse/index build.",
-            artifact_name: $parse_artifact_name,
-            binary: $parse_binary,
-            runs: $runs,
-            metrics_ms: {
-                average: $parse_avg_ms,
-                p50: $parse_p50_ms,
-                p95: $parse_p95_ms,
-                min: $parse_min_ms,
-                max: $parse_max_ms
-            },
-            internal_metrics_ms: {
-                module_count: $parse_internal_module_count,
-                parse_phase: {
-                    average: $parse_phase_avg_ms,
-                    p50: $parse_phase_p50_ms,
-                    p95: $parse_phase_p95_ms,
-                    min: $parse_phase_min_ms,
-                    max: $parse_phase_max_ms
-                },
-                index_phase: {
-                    average: $index_phase_avg_ms,
-                    p50: $index_phase_p50_ms,
-                    p95: $index_phase_p95_ms,
-                    min: $index_phase_min_ms,
-                    max: $index_phase_max_ms
-                },
-                internal_total: {
-                    average: $internal_total_avg_ms,
-                    p50: $internal_total_p50_ms,
-                    p95: $internal_total_p95_ms,
-                    min: $internal_total_min_ms,
-                    max: $internal_total_max_ms
-                }
-            }
-        },
-        query_benchmark: {
-            description: "End-to-end source-line query benchmark: source-line lookup, address resolution, and variable collection for all matched addresses.",
-            binary: $query_binary,
-            source: {
-                path: $query_source,
-                line: ($query_line | tonumber)
-            },
-            loading_time_ms: $query_loading_ms,
-            runs: $runs,
-            metrics_ms: {
-                first_run: $query_first_run_ms,
-                average: $query_avg_ms,
-                p50: $query_p50_ms,
-                p95: $query_p95_ms,
-                min: $query_min_ms,
-                max: $query_max_ms
-            }
-        },
-        query_result: {
-            description: "Snapshot of the matched query result for the benchmarked source line.",
-            source: {
-                path: $query_source,
-                line: ($query_line | tonumber)
-            },
-            first_address: $query_first_address,
-            address_count: $query_address_count,
-            total_variables: $query_total_variables
-        },
-        corpus_manifest: $manifest_json[0]
-    }' >"$RESULT_PATH"
+for target in "${ORDERED_PARSE_TARGETS[@]}"; do
+    target_idx=$((target_idx + 1))
+    parse_binary_rel=$(jq -r --arg parse_target "$target" '.artifacts[] | select(.name==$parse_target) | .relative_path' "$MANIFEST_PATH")
+    if [[ -z "$parse_binary_rel" || "$parse_binary_rel" == "null" ]]; then
+        echo "parse artifact not found in manifest: $target" >&2
+        exit 1
+    fi
 
-echo "Fast parse benchmark:"
-echo "  meaning: analyzer load + initial DWARF fast-parse/index build"
-echo "  artifact: $PARSE_TARGET_NAME"
-echo "  binary: $PARSE_BINARY"
-echo "  runs: $RUNS"
-echo "  average: ${PARSE_AVG_MS}ms"
-echo "  p50: ${PARSE_P50_MS}ms"
-echo "  p95: ${PARSE_P95_MS}ms"
-echo "  min: ${PARSE_MIN_MS}ms"
-echo "  max: ${PARSE_MAX_MS}ms"
-echo "  internal modules: ${PARSE_INTERNAL_MODULE_COUNT}"
-echo "  parse phase avg: $(display_metric_ms "$PARSE_PHASE_AVG_MS")"
-echo "  parse phase p50: $(display_metric_ms "$PARSE_PHASE_P50_MS")"
-echo "  parse phase p95: $(display_metric_ms "$PARSE_PHASE_P95_MS")"
-echo "  index phase avg: $(display_metric_ms "$INDEX_PHASE_AVG_MS")"
-echo "  index phase p50: $(display_metric_ms "$INDEX_PHASE_P50_MS")"
-echo "  index phase p95: $(display_metric_ms "$INDEX_PHASE_P95_MS")"
-echo "  internal total avg: $(display_metric_ms "$INTERNAL_TOTAL_AVG_MS")"
-echo "  internal total p50: $(display_metric_ms "$INTERNAL_TOTAL_P50_MS")"
-echo "  internal total p95: $(display_metric_ms "$INTERNAL_TOTAL_P95_MS")"
-echo
-echo "Source-line query benchmark:"
-echo "  meaning: source-line lookup + address resolution + variable collection for matched addresses"
-echo "  source: ${QUERY_SOURCE_ABS}:${QUERY_LINE}"
-echo "  binary: $QUERY_BINARY"
-echo "  loading time: ${QUERY_LOADING_MS}ms"
-echo "  runs: $RUNS"
-echo "  first run: ${QUERY_FIRST_RUN_MS}ms"
-echo "  average: ${QUERY_AVG_MS}ms"
-echo "  p50: ${QUERY_P50_MS}ms"
-echo "  p95: ${QUERY_P95_MS}ms"
-echo "  min: ${QUERY_MIN_MS}ms"
-echo "  max: ${QUERY_MAX_MS}ms"
-echo
-echo "Query result snapshot:"
-echo "  addresses: $QUERY_ADDRESS_COUNT"
-echo "  total variables: $QUERY_TOTAL_VARS"
-if [[ -n "$QUERY_FIRST_ADDRESS" ]]; then
-    echo "  first address: $QUERY_FIRST_ADDRESS"
-fi
-echo
+    parse_binary="$CORPUS_DIR/$parse_binary_rel"
+    if [[ ! -f "$parse_binary" ]]; then
+        echo "parse binary not found: $parse_binary" >&2
+        exit 1
+    fi
+
+    run_parse_benchmark "$parse_binary" "$target" "[$target_idx/$target_total]"
+    target_json="$temp_dir/${target}.json"
+    write_baseline_json "$target_json" "$target" "$parse_binary"
+    print_parse_summary "$target" "$parse_binary"
+
+    if [[ -z "$primary_result" ]]; then
+        primary_result=$target_json
+    else
+        additional_args+=(--additional "$target_json")
+    fi
+done
+
+log_stage "Combining per-target baselines into ${RESULT_PATH}"
+python3 "$SCRIPT_DIR/combine_baselines.py" \
+    --primary "$primary_result" \
+    "${additional_args[@]}" \
+    --output "$RESULT_PATH"
+log_stage "Completed combined baseline output"
+
+print_query_summary
+log_stage "Finished full baseline run"
+echo "Primary parse target: $PRIMARY_PARSE_TARGET"
+echo "Parse targets: ${ORDERED_PARSE_TARGETS[*]}"
 echo "Result JSON: $RESULT_PATH"


### PR DESCRIPTION
Add new C++ and Rust stress corpora, make baseline runs cover all parse targets by default, and keep --parse-target for focused runs.

Improve regression logging and refresh the history site so avg, p50, p95, and index-phase trends stay readable per corpus.