### PR TITLE
refactor: centralize dwarf query assembly

### DIFF
--- a/bins/dwarf-tool/src/main.rs
+++ b/bins/dwarf-tool/src/main.rs
@@ -5,7 +5,9 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use ghostscope_dwarf::core::SectionType;
-use ghostscope_dwarf::{DwarfAnalyzer, ModuleAddress, ModuleLoadingEvent, ModuleLoadingStats};
+use ghostscope_dwarf::{
+    AddressQueryResult, DwarfAnalyzer, FunctionQueryResult, ModuleLoadingEvent, ModuleLoadingStats,
+};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -577,7 +579,7 @@ async fn analyze_source_location(
     loading_time: std::time::Duration,
 ) -> Result<()> {
     let (file_path, line_number) = parse_source_line(source)?;
-    let addresses = analyzer.lookup_addresses_by_source_line(file_path, line_number);
+    let addresses = analyzer.query_source_line(file_path, line_number)?;
 
     if addresses.is_empty() {
         if options.json() {
@@ -594,61 +596,29 @@ async fn analyze_source_location(
         return Ok(());
     }
 
-    let mut address_infos = Vec::new();
-    let mut total_variables = 0;
-
     if options.json() {
-        for module_address in &addresses {
-            let variables = analyzer.get_all_variables_at_address(module_address)?;
-            let source_location = analyzer.lookup_source_location(module_address);
-
-            let var_infos: Vec<VariableInfo> = variables
-                .iter()
-                .map(|var| VariableInfo {
-                    name: var.name.clone(),
-                    type_name: var.type_name.clone(),
-                    location: format!("{}", var.evaluation_result),
-                    is_parameter: var.is_parameter,
-                    scope_depth: var.scope_depth as u32,
-                })
-                .collect();
-
-            total_variables += var_infos.len();
-
-            address_infos.push(AddressInfo {
-                module: module_address.module_display().to_string(),
-                address: format!("0x{:x}", module_address.address),
-                source_file: source_location.as_ref().map(|sl| sl.file_path.clone()),
-                source_line: source_location.as_ref().map(|sl| sl.line_number),
-                source_column: source_location.as_ref().and_then(|sl| sl.column),
-                variables: var_infos,
-            });
-        }
-
         let result = AnalysisResult {
             source_location: source.to_string(),
-            addresses: address_infos,
-            total_variables,
+            addresses: addresses.iter().map(address_info_from_query).collect(),
+            total_variables: total_variables_in_query_results(&addresses),
             loading_time_ms: loading_time.as_millis() as u64,
         };
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         // Print results for each address
-        for module_address in addresses {
-            let variables = analyzer.get_all_variables_at_address(&module_address)?;
-
+        for address in &addresses {
             if !options.quiet() {
                 println!(
                     "\n=== {} @ {}:{} → 0x{:x} ===",
-                    module_address.module_display(),
+                    address.module_path.display(),
                     file_path,
                     line_number,
-                    module_address.address
+                    address.address
                 );
-                if variables.is_empty() {
+                if query_address_variable_count(address) == 0 {
                     println!("No variables found");
                 } else {
-                    print_variables_with_style(&variables, options);
+                    print_variables_with_style(iter_address_query_variables(address), options);
                 }
             }
         }
@@ -657,14 +627,89 @@ async fn analyze_source_location(
     Ok(())
 }
 
+fn iter_address_query_variables<'a>(
+    address: &'a AddressQueryResult,
+) -> impl Iterator<Item = &'a ghostscope_dwarf::VariableWithEvaluation> + 'a {
+    address.parameters.iter().chain(address.variables.iter())
+}
+
+fn query_address_variable_count(address: &AddressQueryResult) -> usize {
+    address.parameters.len() + address.variables.len()
+}
+
+fn total_variables_in_query_results(addresses: &[AddressQueryResult]) -> usize {
+    addresses.iter().map(query_address_variable_count).sum()
+}
+
+fn variable_info_from_query(variable: &ghostscope_dwarf::VariableWithEvaluation) -> VariableInfo {
+    VariableInfo {
+        name: variable.name.clone(),
+        type_name: variable.type_name.clone(),
+        location: format!("{}", variable.evaluation_result),
+        is_parameter: variable.is_parameter,
+        scope_depth: variable.scope_depth as u32,
+    }
+}
+
+fn address_info_from_query(address: &AddressQueryResult) -> AddressInfo {
+    AddressInfo {
+        module: address.module_path.display().to_string(),
+        address: format!("0x{:x}", address.address),
+        source_file: address.source_file.clone(),
+        source_line: address.source_line,
+        source_column: address.source_column,
+        variables: iter_address_query_variables(address)
+            .map(variable_info_from_query)
+            .collect(),
+    }
+}
+
+fn function_result_from_query(query_result: FunctionQueryResult) -> FunctionResult {
+    let mut modules = Vec::new();
+    let mut current_module: Option<String> = None;
+    let mut current_addresses = Vec::new();
+    let mut total_variables = 0;
+
+    for address in query_result.addresses {
+        let module = address.module_path.display().to_string();
+        total_variables += query_address_variable_count(&address);
+
+        if current_module.as_deref() != Some(module.as_str()) {
+            if let Some(module_name) = current_module.take() {
+                modules.push(FunctionModuleInfo {
+                    module: module_name,
+                    addresses: current_addresses,
+                });
+                current_addresses = Vec::new();
+            }
+            current_module = Some(module.clone());
+        }
+
+        current_addresses.push(address_info_from_query(&address));
+    }
+
+    if let Some(module_name) = current_module {
+        modules.push(FunctionModuleInfo {
+            module: module_name,
+            addresses: current_addresses,
+        });
+    }
+
+    FunctionResult {
+        function_name: query_result.function_name,
+        modules,
+        total_variables,
+    }
+}
+
 async fn analyze_function(
     analyzer: &mut DwarfAnalyzer,
     func_name: &str,
     options: &Commands,
 ) -> Result<()> {
-    let addresses = analyzer.lookup_function_addresses(func_name);
+    let function = analyzer.query_function(func_name)?;
 
-    if addresses.is_empty() {
+    if function.addresses.is_empty() {
         if !options.quiet() {
             if options.json() {
                 let result = FunctionResult {
@@ -681,81 +726,23 @@ async fn analyze_function(
     }
 
     if options.json() {
-        let mut modules = Vec::new();
-        let mut total_variables = 0;
-
-        // Group module addresses by module path
-        use std::collections::HashMap;
-        let mut grouped_by_module: HashMap<std::path::PathBuf, Vec<u64>> = HashMap::new();
-        for module_address in &addresses {
-            grouped_by_module
-                .entry(module_address.module_path.clone())
-                .or_default()
-                .push(module_address.address);
-        }
-
-        for (module_path, addrs) in grouped_by_module {
-            let mut address_infos = Vec::new();
-
-            for addr in &addrs {
-                let module_address = ModuleAddress::new(module_path.clone(), *addr);
-                let variables = analyzer.get_all_variables_at_address(&module_address)?;
-                let source_location = analyzer.lookup_source_location(&module_address);
-
-                let var_infos: Vec<VariableInfo> = variables
-                    .iter()
-                    .map(|var| VariableInfo {
-                        name: var.name.clone(),
-                        type_name: var.type_name.clone(),
-                        location: format!("{}", var.evaluation_result),
-                        is_parameter: var.is_parameter,
-                        scope_depth: var.scope_depth as u32,
-                    })
-                    .collect();
-
-                total_variables += var_infos.len();
-
-                address_infos.push(AddressInfo {
-                    module: module_path.display().to_string(),
-                    address: format!("0x{addr:x}"),
-                    source_file: source_location.as_ref().map(|sl| sl.file_path.clone()),
-                    source_line: source_location.as_ref().map(|sl| sl.line_number),
-                    source_column: source_location.as_ref().and_then(|sl| sl.column),
-                    variables: var_infos,
-                });
-            }
-
-            modules.push(FunctionModuleInfo {
-                module: module_path.display().to_string(),
-                addresses: address_infos,
-            });
-        }
-
-        let result = FunctionResult {
-            function_name: func_name.to_string(),
-            modules,
-            total_variables,
-        };
-
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&function_result_from_query(function))?
+        );
     } else {
         // Text output
         if !options.quiet() {
             println!("\n=== Function: {func_name} ===");
         }
 
-        for module_address in &addresses {
+        for address in &function.addresses {
             if !options.quiet() {
-                println!("\nModule: {}", module_address.module_display());
+                println!("\nModule: {}", address.module_path.display());
             }
 
-            let variables = analyzer.get_all_variables_at_address(module_address)?;
-
-            // Query source location for this address
-            let source_location = analyzer.lookup_source_location(module_address);
-
             if options.quiet() {
-                for var in &variables {
+                for var in iter_address_query_variables(address) {
                     // Use DWARF type if available, otherwise fall back to type name
                     let type_str = if let Some(dwarf_type) = &var.dwarf_type {
                         dwarf_type.to_string()
@@ -766,22 +753,24 @@ async fn analyze_function(
                     println!("{}: {} = {}", var.name, type_str, var.evaluation_result);
                 }
             } else {
-                println!("  Address: 0x{:x}", module_address.address);
+                println!("  Address: 0x{:x}", address.address);
 
                 // Display source location if available
-                if let Some(src_loc) = source_location {
-                    println!("  Source:  {}:{}", src_loc.file_path, src_loc.line_number);
-                    if let Some(column) = src_loc.column {
+                if let (Some(source_file), Some(source_line)) =
+                    (&address.source_file, address.source_line)
+                {
+                    println!("  Source:  {source_file}:{source_line}");
+                    if let Some(column) = address.source_column {
                         println!("  Column:  {column}");
                     }
                 } else {
                     println!("  Source:  (no source information available)");
                 }
 
-                if variables.is_empty() {
+                if query_address_variable_count(address) == 0 {
                     println!("    No variables found");
                 } else {
-                    print_variables_with_indent(&variables, "    ");
+                    print_variables_with_indent(iter_address_query_variables(address), "    ");
                 }
             }
         }
@@ -797,36 +786,16 @@ async fn analyze_module_address(
     options: &Commands,
 ) -> Result<()> {
     let address = parse_address(address_str)?;
-    let module_pathbuf = std::path::PathBuf::from(module_path);
-    let module_address = ModuleAddress::new(module_pathbuf, address);
 
-    match analyzer.get_all_variables_at_address(&module_address) {
-        Ok(variables) => {
+    match analyzer.query_address(module_path, address) {
+        Ok(address_info) => {
             if options.json() {
-                let var_infos: Vec<VariableInfo> = variables
-                    .iter()
-                    .map(|var| VariableInfo {
-                        name: var.name.clone(),
-                        type_name: var.type_name.clone(),
-                        location: format!("{}", var.evaluation_result),
-                        is_parameter: var.is_parameter,
-                        scope_depth: var.scope_depth as u32,
-                    })
-                    .collect();
-
-                let source_location = analyzer.lookup_source_location(&module_address);
-
-                let result = AddressInfo {
-                    module: module_path.to_string(),
-                    address: format!("0x{address:x}"),
-                    source_file: source_location.as_ref().map(|sl| sl.file_path.clone()),
-                    source_line: source_location.as_ref().map(|sl| sl.line_number),
-                    source_column: source_location.as_ref().and_then(|sl| sl.column),
-                    variables: var_infos,
-                };
-                println!("{}", serde_json::to_string_pretty(&result)?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&address_info_from_query(&address_info))?
+                );
             } else if options.quiet() {
-                for var in &variables {
+                for var in iter_address_query_variables(&address_info) {
                     println!(
                         "{}: {} = {}",
                         var.name, var.type_name, var.evaluation_result
@@ -834,10 +803,13 @@ async fn analyze_module_address(
                 }
             } else {
                 println!("\n=== {module_path} @ 0x{address:x} ===");
-                if variables.is_empty() {
+                if query_address_variable_count(&address_info) == 0 {
                     println!("No variables found");
                 } else {
-                    print_variables_with_style(&variables, options);
+                    print_variables_with_style(
+                        iter_address_query_variables(&address_info),
+                        options,
+                    );
                 }
             }
         }
@@ -1202,11 +1174,11 @@ fn percentile_nearest_rank(sorted_samples_ms: &[f64], percentile: f64) -> f64 {
     sorted_samples_ms[index]
 }
 
-fn print_variables_with_style(
-    variables: &[ghostscope_dwarf::VariableWithEvaluation],
+fn print_variables_with_style<'a>(
+    variables: impl IntoIterator<Item = &'a ghostscope_dwarf::VariableWithEvaluation>,
     options: &Commands,
 ) {
-    for (i, var) in variables.iter().enumerate() {
+    for (i, var) in variables.into_iter().enumerate() {
         if options.verbose() {
             println!("═══════════════════════════════════════");
             println!("Variable #{}", i + 1);
@@ -1247,8 +1219,8 @@ fn print_variables_with_style(
     }
 }
 
-fn print_variables_with_indent(
-    variables: &[ghostscope_dwarf::VariableWithEvaluation],
+fn print_variables_with_indent<'a>(
+    variables: impl IntoIterator<Item = &'a ghostscope_dwarf::VariableWithEvaluation>,
     indent: &str,
 ) {
     for var in variables {

--- a/ghostscope-dwarf/src/analyzer.rs
+++ b/ghostscope-dwarf/src/analyzer.rs
@@ -51,6 +51,27 @@ pub struct ModuleLoadingStats {
     pub module_total_time_ms: u64,
 }
 
+/// Rich query result for a single address within a module.
+#[derive(Debug, Clone)]
+pub struct AddressQueryResult {
+    pub module_path: PathBuf,
+    pub address: u64,
+    pub source_file: Option<String>,
+    pub source_line: Option<u32>,
+    pub source_column: Option<u32>,
+    pub function_name: Option<String>,
+    pub is_inline: Option<bool>,
+    pub variables: Vec<crate::VariableWithEvaluation>,
+    pub parameters: Vec<crate::VariableWithEvaluation>,
+}
+
+/// Rich query result for a function lookup across modules.
+#[derive(Debug, Clone)]
+pub struct FunctionQueryResult {
+    pub function_name: String,
+    pub addresses: Vec<AddressQueryResult>,
+}
+
 /// DWARF analyzer - unified entry point for all DWARF analysis
 #[derive(Debug)]
 pub struct DwarfAnalyzer {
@@ -61,6 +82,102 @@ pub struct DwarfAnalyzer {
 }
 
 impl DwarfAnalyzer {
+    fn build_address_query_result(
+        &mut self,
+        module_address: &ModuleAddress,
+    ) -> Result<AddressQueryResult> {
+        let mut variables = Vec::new();
+        let mut parameters = Vec::new();
+
+        for variable in self.get_all_variables_at_address(module_address)? {
+            if variable.is_parameter {
+                parameters.push(variable);
+            } else {
+                variables.push(variable);
+            }
+        }
+
+        let source_location = self.lookup_source_location(module_address);
+        let function_name = self.find_function_name_by_module_address(module_address);
+        let is_inline = self.is_inline_at(module_address);
+
+        Ok(AddressQueryResult {
+            module_path: module_address.module_path.clone(),
+            address: module_address.address,
+            source_file: source_location.as_ref().map(|sl| sl.file_path.clone()),
+            source_line: source_location.as_ref().map(|sl| sl.line_number),
+            source_column: source_location.as_ref().and_then(|sl| sl.column),
+            function_name,
+            is_inline,
+            variables,
+            parameters,
+        })
+    }
+
+    fn query_module_addresses(
+        &mut self,
+        module_addresses: Vec<ModuleAddress>,
+    ) -> Result<Vec<AddressQueryResult>> {
+        module_addresses
+            .iter()
+            .map(|module_address| self.build_address_query_result(module_address))
+            .collect()
+    }
+
+    fn query_module_addresses_best_effort(
+        &mut self,
+        module_addresses: Vec<ModuleAddress>,
+        query_label: &str,
+    ) -> Result<Vec<AddressQueryResult>> {
+        let mut results = Vec::new();
+        let mut first_error: Option<(ModuleAddress, String)> = None;
+
+        for module_address in &module_addresses {
+            match self.build_address_query_result(module_address) {
+                Ok(result) => results.push(result),
+                Err(error) => {
+                    let error_string = error.to_string();
+                    tracing::warn!(
+                        "Skipping failed address query for {} at {}:0x{:x}: {}",
+                        query_label,
+                        module_address.module_display(),
+                        module_address.address,
+                        error_string
+                    );
+
+                    if first_error.is_none() {
+                        first_error = Some((module_address.clone(), error_string));
+                    }
+                }
+            }
+        }
+
+        if results.is_empty() {
+            if let Some((module_address, error)) = first_error {
+                return Err(anyhow::anyhow!(
+                    "Failed to analyze any address for {} (first failure at {}:0x{:x}: {})",
+                    query_label,
+                    module_address.module_display(),
+                    module_address.address,
+                    error
+                ));
+            }
+        }
+
+        Ok(results)
+    }
+
+    fn find_function_name_by_module_address(
+        &self,
+        module_address: &ModuleAddress,
+    ) -> Option<String> {
+        self.modules
+            .get(&module_address.module_path)
+            .and_then(|module_data| {
+                module_data.find_function_name_by_address(module_address.address)
+            })
+    }
+
     /// Create DWARF analyzer from PID (now uses parallel loading)
     pub async fn from_pid(pid: u32) -> Result<Self> {
         Self::from_pid_parallel(pid).await
@@ -389,6 +506,28 @@ impl DwarfAnalyzer {
             }
         });
         results
+    }
+
+    /// Query function debug information across all modules.
+    pub fn query_function(&mut self, name: &str) -> Result<FunctionQueryResult> {
+        let module_addresses = self.lookup_function_addresses(name);
+        let addresses = self.query_module_addresses(module_addresses)?;
+        Ok(FunctionQueryResult {
+            function_name: name.to_string(),
+            addresses,
+        })
+    }
+
+    /// Query function debug information across all modules, skipping addresses
+    /// that fail to resolve so callers can still display partial results.
+    pub fn query_function_best_effort(&mut self, name: &str) -> Result<FunctionQueryResult> {
+        let module_addresses = self.lookup_function_addresses(name);
+        let addresses = self
+            .query_module_addresses_best_effort(module_addresses, &format!("function '{name}'"))?;
+        Ok(FunctionQueryResult {
+            function_name: name.to_string(),
+            addresses,
+        })
     }
 
     /// Convert a module-relative virtual address (DWARF PC) to an ELF file offset
@@ -725,6 +864,41 @@ impl DwarfAnalyzer {
         results
     }
 
+    /// Query source-line debug information across all modules.
+    pub fn query_source_line(
+        &mut self,
+        file_path: &str,
+        line_number: u32,
+    ) -> Result<Vec<AddressQueryResult>> {
+        let module_addresses = self.lookup_addresses_by_source_line(file_path, line_number);
+        self.query_module_addresses(module_addresses)
+    }
+
+    /// Query source-line debug information across all modules, skipping
+    /// addresses that fail to resolve so callers can still display partial
+    /// results.
+    pub fn query_source_line_best_effort(
+        &mut self,
+        file_path: &str,
+        line_number: u32,
+    ) -> Result<Vec<AddressQueryResult>> {
+        let module_addresses = self.lookup_addresses_by_source_line(file_path, line_number);
+        self.query_module_addresses_best_effort(
+            module_addresses,
+            &format!("source line '{file_path}:{line_number}'"),
+        )
+    }
+
+    /// Query a specific address within a module.
+    pub fn query_address<P: AsRef<Path>>(
+        &mut self,
+        module_path: P,
+        address: u64,
+    ) -> Result<AddressQueryResult> {
+        let module_address = ModuleAddress::new(module_path.as_ref().to_path_buf(), address);
+        self.build_address_query_result(&module_address)
+    }
+
     /// Get all function names (cross-module)
     pub fn get_all_function_names(&self) -> Vec<String> {
         let mut all_names = std::collections::HashSet::new();
@@ -989,15 +1163,6 @@ impl DwarfAnalyzer {
         filename.contains(".so")
             || module_path.to_string_lossy().starts_with("/lib")
             || module_path.to_string_lossy().starts_with("/usr/lib")
-    }
-
-    /// Find symbol by module address
-    pub fn find_symbol_by_module_address(&self, module_address: &ModuleAddress) -> Option<String> {
-        if let Some(module_data) = self.modules.get(&module_address.module_path) {
-            module_data.find_symbol_by_address(module_address.address)
-        } else {
-            None
-        }
     }
 
     /// Get grouped file info by module (compatibility method)

--- a/ghostscope-dwarf/src/index/lightweight_index.rs
+++ b/ghostscope-dwarf/src/index/lightweight_index.rs
@@ -260,17 +260,6 @@ impl LightweightIndex {
         entry.representative_addr == Some(address)
     }
 
-    fn entry_contains_address<F>(entry: &IndexEntry, address: u64, resolve_ranges: &mut F) -> bool
-    where
-        F: FnMut(&IndexEntry) -> Option<Vec<(u64, u64)>>,
-    {
-        if Self::is_function_tag(entry.tag) {
-            return Self::entry_contains_function_address(entry, address, resolve_ranges);
-        }
-
-        entry.representative_addr == Some(address)
-    }
-
     fn find_matching_function_in_indices<'a, I, F>(
         &'a self,
         indices: I,
@@ -289,27 +278,6 @@ impl LightweightIndex {
                 continue;
             }
             if Self::entry_contains_function_address(entry, address, resolve_ranges) {
-                return Some(entry);
-            }
-        }
-        None
-    }
-
-    fn find_matching_die_in_indices<'a, I, F>(
-        &'a self,
-        indices: I,
-        address: u64,
-        resolve_ranges: &mut F,
-    ) -> Option<&'a IndexEntry>
-    where
-        I: IntoIterator<Item = usize>,
-        F: FnMut(&IndexEntry) -> Option<Vec<(u64, u64)>>,
-    {
-        for idx in indices {
-            let Some(entry) = self.entries.get(idx) else {
-                continue;
-            };
-            if Self::entry_contains_address(entry, address, resolve_ranges) {
                 return Some(entry);
             }
         }
@@ -646,44 +614,6 @@ impl LightweightIndex {
             &mut resolve_ranges,
         )
     }
-
-    /// Find DIE entry by address - returns the DIE containing this address
-    /// This is the primary interface for address-based lookups
-    pub fn find_die_at_address<F>(&self, address: u64, mut resolve_ranges: F) -> Option<&IndexEntry>
-    where
-        F: FnMut(&IndexEntry) -> Option<Vec<(u64, u64)>>,
-    {
-        tracing::debug!("find_die_at_address: looking for address 0x{:x}", address);
-        tracing::trace!("  Address map has {} entries", self.address_map.len());
-
-        if let Some(entry) = self.find_matching_die_in_indices(
-            self.address_map
-                .range(..=address)
-                .rev()
-                .map(|(_, &idx)| idx),
-            address,
-            &mut resolve_ranges,
-        ) {
-            tracing::debug!("  ✓ Found DIE '{}' (tag={:?})", entry.name, entry.tag);
-            return Some(entry);
-        }
-
-        if let Some(entry) =
-            self.find_matching_die_in_indices(0..self.entries.len(), address, &mut resolve_ranges)
-        {
-            tracing::debug!(
-                "  ✓ Found DIE '{}' (tag={:?}) via fallback scan",
-                entry.name,
-                entry.tag
-            );
-            return Some(entry);
-        }
-
-        tracing::debug!("No DIE found containing address 0x{:x}", address);
-        None
-    }
-
-    // (old global fallback variant removed in favor of unified method above)
 
     /// Find DIE entries by function name - returns all matching DIEs
     /// Supports multiple implementations (including inline functions)

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -21,8 +21,8 @@ pub mod analyzer;
 
 // Re-export main public API only
 pub use analyzer::{
-    DwarfAnalyzer, MainExecutableInfo, ModuleLoadingEvent, ModuleLoadingStats, ModuleStats,
-    SharedLibraryInfo, SimpleFileInfo,
+    AddressQueryResult, DwarfAnalyzer, FunctionQueryResult, MainExecutableInfo, ModuleLoadingEvent,
+    ModuleLoadingStats, ModuleStats, SharedLibraryInfo, SimpleFileInfo,
 };
 
 // Re-export essential core types

--- a/ghostscope-dwarf/src/module/data.rs
+++ b/ghostscope-dwarf/src/module/data.rs
@@ -1859,11 +1859,6 @@ impl ModuleData {
             .find_function_by_address(address, |entry| self.resolve_function_ranges(entry).ok())
     }
 
-    fn find_die_index_entry_by_address(&self, address: u64) -> Option<&crate::core::IndexEntry> {
-        self.lightweight_index
-            .find_die_at_address(address, |entry| self.resolve_function_ranges(entry).ok())
-    }
-
     /// Compute addresses for a function entry (deterministic ordering)
     ///
     /// Semantics
@@ -2496,13 +2491,9 @@ impl ModuleData {
         addresses
     }
 
-    /// Find symbol name by address (compatibility method)
-    pub(crate) fn find_symbol_by_address(&self, address: u64) -> Option<String> {
-        // Prefer optimized function lookup for readability; fallback to any DIE
-        if let Some(entry) = self.find_function_index_entry_by_address(address) {
-            return Some(entry.name.to_string());
-        }
-        self.find_die_index_entry_by_address(address)
+    /// Find containing function name by address.
+    pub(crate) fn find_function_name_by_address(&self, address: u64) -> Option<String> {
+        self.find_function_index_entry_by_address(address)
             .map(|entry| entry.name.to_string())
     }
 

--- a/ghostscope/src/tui/info_handlers.rs
+++ b/ghostscope/src/tui/info_handlers.rs
@@ -1,7 +1,7 @@
 use crate::core::GhostSession;
-use ghostscope_dwarf::ModuleAddress;
+use ghostscope_dwarf::{AddressQueryResult, FunctionQueryResult};
 use ghostscope_ui::{events::*, RuntimeChannels, RuntimeStatus};
-use tracing::{info, warn};
+use tracing::info;
 
 /// Handle InfoTrace command
 pub async fn handle_info_trace(
@@ -408,20 +408,14 @@ pub async fn handle_info_address(
         let vaddr = parse_addr(addr_str)?;
         let module_path = resolve_module_path(analyzer, sess, module_spec)?;
 
-        // Aggregate per-module info via existing helper
-        let ma = ModuleAddress::new(std::path::PathBuf::from(&module_path), vaddr);
-        let (modules, _first) = process_module_addresses_for_variables(
-            sess.process_analyzer.as_mut().unwrap(),
-            &[ma.clone()],
-            &format!("address 0x{vaddr:x}"),
-        );
-
-        // Derive source location if available
-        let source_location = sess
+        let address_info = sess
             .process_analyzer
             .as_mut()
             .unwrap()
-            .lookup_source_location(&ma);
+            .query_address(&module_path, vaddr)
+            .map_err(|e| {
+                format!("Failed to analyze address 0x{vaddr:x} in module '{module_path}': {e}")
+            })?;
 
         Ok(TargetDebugInfo {
             target: if let Some(ms) = module_spec {
@@ -430,10 +424,10 @@ pub async fn handle_info_address(
                 addr_str.trim().to_string()
             },
             target_type: TargetType::Address,
-            file_path: source_location.as_ref().map(|sl| sl.file_path.clone()),
-            line_number: source_location.as_ref().map(|sl| sl.line_number),
-            function_name: None,
-            modules,
+            file_path: address_info.source_file.clone(),
+            line_number: address_info.source_line,
+            function_name: address_info.function_name.clone(),
+            modules: group_module_debug_info(vec![address_info]),
         })
     })();
 
@@ -538,10 +532,17 @@ fn try_get_line_debug_info(
 
     // Probe candidates until we find addresses
     for cand in &candidates {
-        let addrs = process_analyzer.lookup_addresses_by_source_line(cand, line_number);
-        if !addrs.is_empty() {
+        let query_results = process_analyzer
+            .query_source_line_best_effort(cand, line_number)
+            .map_err(|e| format!("Failed to analyze {cand}:{line_number}: {e}"))?;
+        if !query_results.is_empty() {
             let cand_target = format!("{cand}:{line_number}");
-            return handle_source_location_target(process_analyzer, &cand_target);
+            return Ok(build_source_location_target_debug_info(
+                cand_target,
+                cand.to_string(),
+                line_number,
+                query_results,
+            ));
         }
     }
 
@@ -555,140 +556,164 @@ fn try_get_line_debug_info(
     handle_source_location_target(process_analyzer, &final_target)
 }
 
-/// Process module addresses and extract variable information
-fn process_module_addresses_for_variables(
-    process_analyzer: &mut ghostscope_dwarf::DwarfAnalyzer,
-    module_addresses: &[ModuleAddress],
-    target_description: &str, // e.g., "function 'main'" or "source line 'file.c:42'"
-) -> (Vec<ModuleDebugInfo>, Option<ModuleAddress>) {
-    use std::collections::HashMap;
+fn unique_module_count(addresses: &[AddressQueryResult]) -> usize {
+    use std::collections::HashSet;
 
-    let mut modules = Vec::new();
-    let mut first_module_address: Option<ModuleAddress> = None;
+    addresses
+        .iter()
+        .map(|address| address.module_path.as_path())
+        .collect::<HashSet<_>>()
+        .len()
+}
 
-    // Build ordered modules and per-module address lists preserving input order
-    let mut module_order: Vec<std::path::PathBuf> = Vec::new();
-    let mut grouped_by_module: HashMap<std::path::PathBuf, Vec<&ModuleAddress>> = HashMap::new();
-    for ma in module_addresses {
-        if !grouped_by_module.contains_key(&ma.module_path) {
-            module_order.push(ma.module_path.clone());
-        }
-        grouped_by_module
-            .entry(ma.module_path.clone())
-            .or_default()
-            .push(ma);
+fn variable_debug_info_from_query(
+    variable: ghostscope_dwarf::VariableWithEvaluation,
+) -> VariableDebugInfo {
+    let type_pretty = variable.dwarf_type.as_ref().map(|t| t.to_string());
+    let size = variable.dwarf_type.as_ref().map(|t| t.size());
 
-        if first_module_address.is_none() {
-            first_module_address = Some(ma.clone());
-        }
+    VariableDebugInfo {
+        name: variable.name,
+        type_name: variable.type_name,
+        type_pretty,
+        location_description: format!("{}", variable.evaluation_result),
+        size,
+        scope_start: None,
+        scope_end: None,
     }
+}
 
-    let mut global_index: usize = 1;
-    for module_path in module_order {
-        let module_addresses_in_module = grouped_by_module.get(&module_path).unwrap();
-        info!(
-            "Processing {} in module '{}' at {} addresses",
-            target_description,
-            module_path.display(),
-            module_addresses_in_module.len()
-        );
+fn group_module_debug_info(addresses: Vec<AddressQueryResult>) -> Vec<ModuleDebugInfo> {
+    let mut modules = Vec::new();
+    let mut current_binary_path: Option<String> = None;
+    let mut current_mappings = Vec::new();
 
-        let mut address_mappings = Vec::new();
-
-        for module_address in module_addresses_in_module {
-            info!(
-                "Analyzing variables at address 0x{:x} for {} in module '{}'",
-                module_address.address,
-                target_description,
-                module_address.module_display()
-            );
-
-            // Get enhanced variables at this address using the DWARF analyzer helper
-            info!(
-                "Using module '{}' for analysis at binary offset 0x{:x}",
-                module_address.module_display(),
-                module_address.address
-            );
-
-            // DWARF analyzer doesn't need EvaluationContext - just pass the module address directly
-            let enhanced_vars = match process_analyzer.get_all_variables_at_address(module_address)
-            {
-                Ok(vars) => vars,
-                Err(e) => {
-                    warn!(
-                        "Failed to get variables at address 0x{:x}: {}",
-                        module_address.address, e
-                    );
-                    Vec::new()
-                }
-            };
-
-            // Separate parameters and variables for this address
-            let mut parameters = Vec::new();
-            let mut variables = Vec::new();
-
-            for enhanced_var in enhanced_vars {
-                let location_description = format!("{}", enhanced_var.evaluation_result);
-
-                let var_info = VariableDebugInfo {
-                    name: enhanced_var.name.clone(),
-                    type_name: enhanced_var.type_name.clone(),
-                    type_pretty: enhanced_var.dwarf_type.as_ref().map(|t| t.to_string()),
-                    location_description,
-                    size: enhanced_var.dwarf_type.as_ref().map(|t| t.size()),
-                    scope_start: None, // VariableWithEvaluation doesn't have scope_ranges
-                    scope_end: None,   // VariableWithEvaluation doesn't have scope_ranges
-                };
-
-                // Use the is_parameter field from DWARF parsing (which is based on DW_TAG_formal_parameter)
-                let is_parameter = enhanced_var.is_parameter;
-
-                // Log using enhanced evaluation result
-                let log_location = format!("{:?}", enhanced_var.evaluation_result);
-
-                info!(
-                    "Address 0x{:x}: Variable '{}' location: {}, is_parameter: {} (from DWARF)",
-                    module_address.address, enhanced_var.name, log_location, is_parameter
-                );
-
-                if is_parameter {
-                    parameters.push(var_info);
-                } else {
-                    variables.push(var_info);
-                }
+    for (index, address) in addresses.into_iter().enumerate() {
+        let binary_path = address.module_path.to_string_lossy().to_string();
+        if current_binary_path.as_deref() != Some(binary_path.as_str()) {
+            if let Some(path) = current_binary_path.take() {
+                modules.push(ModuleDebugInfo {
+                    binary_path: path,
+                    address_mappings: current_mappings,
+                });
+                current_mappings = Vec::new();
             }
-
-            // Get function name by finding symbol at this address in the specific module
-            let function_name: Option<String> =
-                process_analyzer.find_symbol_by_module_address(module_address);
-
-            // Source location for this address (per mapping)
-            let src_loc = process_analyzer.lookup_source_location(module_address);
-            // Inline classification
-            let is_inline = process_analyzer.is_inline_at(module_address);
-
-            address_mappings.push(AddressMapping {
-                address: module_address.address,
-                binary_path: module_address.module_path.to_string_lossy().to_string(),
-                function_name,
-                variables,
-                parameters,
-                source_file: src_loc.as_ref().map(|sl| sl.file_path.clone()),
-                source_line: src_loc.as_ref().map(|sl| sl.line_number),
-                is_inline,
-                index: Some(global_index),
-            });
-            global_index += 1;
+            current_binary_path = Some(binary_path.clone());
         }
 
-        // Create ModuleDebugInfo for this module
-        modules.push(ModuleDebugInfo {
-            binary_path: module_path.to_string_lossy().to_string(),
-            address_mappings,
+        current_mappings.push(AddressMapping {
+            address: address.address,
+            binary_path,
+            function_name: address.function_name,
+            variables: address
+                .variables
+                .into_iter()
+                .map(variable_debug_info_from_query)
+                .collect(),
+            parameters: address
+                .parameters
+                .into_iter()
+                .map(variable_debug_info_from_query)
+                .collect(),
+            source_file: address.source_file,
+            source_line: address.source_line,
+            is_inline: address.is_inline,
+            index: Some(index + 1),
         });
     }
 
-    (modules, first_module_address)
+    if let Some(path) = current_binary_path {
+        modules.push(ModuleDebugInfo {
+            binary_path: path,
+            address_mappings: current_mappings,
+        });
+    }
+
+    modules
+}
+
+fn build_target_debug_info_from_query_results(
+    target: String,
+    target_type: TargetType,
+    addresses: Vec<AddressQueryResult>,
+    fallback_file_path: Option<String>,
+    fallback_line_number: Option<u32>,
+    function_name: Option<String>,
+) -> TargetDebugInfo {
+    let file_path = addresses
+        .first()
+        .and_then(|address| address.source_file.clone())
+        .or(fallback_file_path);
+    let line_number = addresses
+        .first()
+        .and_then(|address| address.source_line)
+        .or(fallback_line_number);
+    let resolved_function_name = function_name.or_else(|| {
+        addresses
+            .first()
+            .and_then(|address| address.function_name.clone())
+    });
+
+    TargetDebugInfo {
+        target,
+        target_type,
+        file_path,
+        line_number,
+        function_name: resolved_function_name,
+        modules: group_module_debug_info(addresses),
+    }
+}
+
+fn handle_function_query_result(
+    query_result: FunctionQueryResult,
+) -> Result<TargetDebugInfo, String> {
+    if query_result.addresses.is_empty() {
+        return Err(format!(
+            "Function '{}' not found in any loaded module",
+            query_result.function_name
+        ));
+    }
+
+    info!(
+        "Found function '{}' at {} address(es) across {} modules",
+        query_result.function_name,
+        query_result.addresses.len(),
+        unique_module_count(&query_result.addresses)
+    );
+
+    let function_name = query_result.function_name.clone();
+    Ok(build_target_debug_info_from_query_results(
+        function_name.clone(),
+        TargetType::Function,
+        query_result.addresses,
+        None,
+        None,
+        Some(function_name),
+    ))
+}
+
+fn build_source_location_target_debug_info(
+    target: String,
+    fallback_file_path: String,
+    line_number: u32,
+    query_results: Vec<AddressQueryResult>,
+) -> TargetDebugInfo {
+    info!(
+        "Found source line '{}:{}' at {} address(es) across {} modules",
+        fallback_file_path,
+        line_number,
+        query_results.len(),
+        unique_module_count(&query_results)
+    );
+
+    build_target_debug_info_from_query_results(
+        target,
+        TargetType::SourceLocation,
+        query_results,
+        Some(fallback_file_path),
+        Some(line_number),
+        None,
+    )
 }
 
 /// Handle function name target
@@ -696,57 +721,10 @@ fn handle_function_target(
     process_analyzer: &mut ghostscope_dwarf::DwarfAnalyzer,
     function_name: &str,
 ) -> Result<TargetDebugInfo, String> {
-    // Use DWARF information across all modules
-    let module_addresses = process_analyzer.lookup_function_addresses(function_name);
-
-    if module_addresses.is_empty() {
-        return Err(format!(
-            "Function '{function_name}' not found in any loaded module"
-        ));
-    }
-
-    let total_addresses: usize = module_addresses.len();
-    let unique_modules: std::collections::HashSet<_> =
-        module_addresses.iter().map(|ma| &ma.module_path).collect();
-    info!(
-        "Found function '{}' at {} address(es) across {} modules",
-        function_name,
-        total_addresses,
-        unique_modules.len()
-    );
-
-    // Process modules and extract variable information
-    let target_description = format!("function '{function_name}'");
-    let (mut modules, first_module_address) = process_module_addresses_for_variables(
-        process_analyzer,
-        &module_addresses,
-        &target_description,
-    );
-
-    // Update function_name in all address mappings since we know it's a function target
-    for module in &mut modules {
-        for mapping in &mut module.address_mappings {
-            if mapping.function_name.is_none() {
-                mapping.function_name = Some(function_name.to_string());
-            }
-        }
-    }
-
-    // Try to get source location for the first function address
-    let source_location = if let Some(module_address) = &first_module_address {
-        process_analyzer.lookup_source_location(module_address)
-    } else {
-        None
-    };
-
-    Ok(TargetDebugInfo {
-        target: function_name.to_string(),
-        target_type: TargetType::Function,
-        file_path: source_location.as_ref().map(|sl| sl.file_path.clone()),
-        line_number: source_location.as_ref().map(|sl| sl.line_number),
-        function_name: Some(function_name.to_string()),
-        modules,
-    })
+    let query_result = process_analyzer
+        .query_function_best_effort(function_name)
+        .map_err(|e| format!("Failed to analyze function '{function_name}': {e}"))?;
+    handle_function_query_result(query_result)
 }
 
 /// Handle source location target (file:line)
@@ -754,70 +732,27 @@ fn handle_source_location_target(
     process_analyzer: &mut ghostscope_dwarf::DwarfAnalyzer,
     target: &str,
 ) -> Result<TargetDebugInfo, String> {
-    // Parse file:line format
-    let parts: Vec<&str> = target.split(':').collect();
-    if parts.len() != 2 {
-        return Err(format!(
-            "Invalid target format '{target}'. Expected format: file:line"
-        ));
-    }
-
-    let file_path = parts[0];
-    let line_number = parts[1]
+    let (file_path, line_part) = target
+        .rsplit_once(':')
+        .ok_or_else(|| format!("Invalid target format '{target}'. Expected format: file:line"))?;
+    let line_number = line_part
         .parse::<u32>()
-        .map_err(|_| format!("Invalid line number '{}' in target '{target}'", parts[1]))?;
+        .map_err(|_| format!("Invalid line number '{line_part}' in target '{target}'"))?;
 
-    // Resolve source line to all addresses across all modules
-    let module_addresses = process_analyzer.lookup_addresses_by_source_line(file_path, line_number);
+    let query_results = process_analyzer
+        .query_source_line_best_effort(file_path, line_number)
+        .map_err(|e| format!("Failed to analyze {file_path}:{line_number}: {e}"))?;
 
-    if module_addresses.is_empty() {
+    if query_results.is_empty() {
         return Err(format!(
             "Cannot resolve any address for {file_path}:{line_number}"
         ));
     }
 
-    let total_addresses: usize = module_addresses.len();
-    let unique_modules: std::collections::HashSet<_> =
-        module_addresses.iter().map(|ma| &ma.module_path).collect();
-    info!(
-        "Found source line '{}:{}' at {} address(es) across {} modules",
-        file_path,
+    Ok(build_source_location_target_debug_info(
+        target.to_string(),
+        file_path.to_string(),
         line_number,
-        total_addresses,
-        unique_modules.len()
-    );
-
-    // Process modules and extract variable information
-    let target_description = format!("source line '{file_path}:{line_number}'");
-    let (modules, first_module_address) = process_module_addresses_for_variables(
-        process_analyzer,
-        &module_addresses,
-        &target_description,
-    );
-
-    // Get actual source location from first module that has addresses
-    let actual_source_location = if let Some(ref first_module_address) = first_module_address {
-        process_analyzer.lookup_source_location(first_module_address)
-    } else {
-        None
-    };
-    let complete_file_path = actual_source_location
-        .as_ref()
-        .map(|sl| sl.file_path.clone())
-        .unwrap_or_else(|| file_path.to_string()); // fallback to user input if no location found
-
-    // Try to get overall function name (from first module's first mapping or fallback)
-    let overall_function_name = modules
-        .first()
-        .and_then(|module| module.address_mappings.first())
-        .and_then(|mapping| mapping.function_name.clone());
-
-    Ok(TargetDebugInfo {
-        target: target.to_string(),
-        target_type: TargetType::SourceLocation,
-        file_path: Some(complete_file_path),
-        line_number: Some(line_number),
-        function_name: overall_function_name,
-        modules,
-    })
+        query_results,
+    ))
 }


### PR DESCRIPTION
Share one DWARF query assembly path between ghostscope-dwarf, dwarf-tool, and the TUI.

This removes duplicated address/function/source-line aggregation, keeps CLI queries fail-fast, and preserves best-effort TUI behavior for partial multi-module results.