### PR TITLE
fix: stop remapping inline params from nested call sites

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,8 @@ scripts/dwarf-perf/*.sh linguist-vendored
 scripts/dwarf-perf/corpus/** linguist-vendored
 # Exclude benchmark comparison helpers from language statistics
 scripts/compare/** linguist-vendored
+# Exclude non-Rust e2e fixtures from language statistics
+e2e-tests/tests/fixtures/** linguist-vendored
 # Exclude docs and agent metadata from language statistics
 *.md linguist-documentation
 .github/** linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ e2e-tests/tests/fixtures/cpp_complex_program/cpp_complex_program
 e2e-tests/tests/fixtures/globals_program/globals_program
 e2e-tests/tests/fixtures/globals_program/libgvars.so
 e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
+e2e-tests/tests/fixtures/inline_call_value_program/inline_call_value_program
 e2e-tests/tests/fixtures/late_globals_program/late_globals_program
 e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program
 e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o*

--- a/e2e-tests/tests/common/mod.rs
+++ b/e2e-tests/tests/common/mod.rs
@@ -28,6 +28,8 @@ lazy_static! {
         Mutex::new(None);
     static ref COMPILE_LATE_GLOBALS_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_INLINE_CALLSITE_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
+    static ref COMPILE_INLINE_CALL_VALUE_RESULT: Mutex<Option<anyhow::Result<()>>> =
+        Mutex::new(None);
     static ref COMPILE_PARTITIONED_RANGES_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
     static ref COMPILE_STATIC_SCOPE_DEFAULT_RESULT: Mutex<Option<anyhow::Result<()>>> =
@@ -51,6 +53,7 @@ enum RegisteredFixtureKind {
     LateGlobals,
     RustGlobal,
     InlineCallsite,
+    InlineCallValue,
     PartitionedRanges,
     CppComplex,
     StaticScope,
@@ -109,6 +112,12 @@ const REGISTERED_FIXTURES: &[RegisteredFixture] = &[
         directory: "inline_callsite_program",
         cleanup: CleanupCommand::Make,
         kind: RegisteredFixtureKind::InlineCallsite,
+    },
+    RegisteredFixture {
+        name: "inline_call_value_program",
+        directory: "inline_call_value_program",
+        cleanup: CleanupCommand::Make,
+        kind: RegisteredFixtureKind::InlineCallValue,
     },
     RegisteredFixture {
         name: "partitioned_ranges_program",
@@ -337,6 +346,10 @@ impl RegisteredFixture {
             RegisteredFixtureKind::InlineCallsite => {
                 ensure_inline_callsite_program_compiled()?;
                 Ok(dir.join("inline_callsite_program"))
+            }
+            RegisteredFixtureKind::InlineCallValue => {
+                ensure_inline_call_value_program_compiled()?;
+                Ok(dir.join("inline_call_value_program"))
             }
             RegisteredFixtureKind::PartitionedRanges => {
                 ensure_partitioned_ranges_program_compiled()?;
@@ -835,6 +848,7 @@ static COMPILE_GLOBALS: Once = Once::new();
 static COMPILE_LATE_GLOBALS: Once = Once::new();
 static COMPILE_RUST_GLOBAL: Once = Once::new();
 static COMPILE_INLINE_CALLSITE: Once = Once::new();
+static COMPILE_INLINE_CALL_VALUE: Once = Once::new();
 static COMPILE_PARTITIONED_RANGES: Once = Once::new();
 static COMPILE_CPP_COMPLEX: Once = Once::new();
 static COMPILE_STATIC_SCOPE_DEFAULT: Once = Once::new();
@@ -966,6 +980,39 @@ fn ensure_inline_callsite_program_compiled() -> anyhow::Result<()> {
     });
 
     match COMPILE_INLINE_CALLSITE_RESULT.lock().unwrap().as_ref() {
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+        None => panic!("Compilation result should be set after call_once"),
+    }
+}
+
+fn ensure_inline_call_value_program_compiled() -> anyhow::Result<()> {
+    COMPILE_INLINE_CALL_VALUE.call_once(|| {
+        let compile_result = (|| -> anyhow::Result<()> {
+            let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/inline_call_value_program");
+            println!("Compiling inline_call_value_program (Optimized O3) in {base:?}");
+            let _ = Command::new("make")
+                .arg("clean")
+                .current_dir(base.clone())
+                .status()
+                .is_ok();
+            let out = Command::new("make").arg("all").current_dir(base).output()?;
+            if out.status.success() {
+                println!("✓ Successfully compiled inline_call_value_program");
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                Err(anyhow::anyhow!(
+                    "Failed to compile inline_call_value_program: {}",
+                    stderr
+                ))
+            }
+        })();
+        *COMPILE_INLINE_CALL_VALUE_RESULT.lock().unwrap() = Some(compile_result);
+    });
+
+    match COMPILE_INLINE_CALL_VALUE_RESULT.lock().unwrap().as_ref() {
         Some(Ok(())) => Ok(()),
         Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
         None => panic!("Compilation result should be set after call_once"),

--- a/e2e-tests/tests/fixtures/inline_call_value_program/Makefile
+++ b/e2e-tests/tests/fixtures/inline_call_value_program/Makefile
@@ -1,0 +1,16 @@
+CC = gcc
+BASE_CFLAGS = -Wall -Wextra -g
+CFLAGS = $(BASE_CFLAGS) -O3 -fno-ipa-cp
+
+all: inline_call_value_program
+
+inline_call_value_program: inline_call_value_program.o
+	$(CC) $(CFLAGS) -o $@ inline_call_value_program.o
+
+inline_call_value_program.o: inline_call_value_program.c
+	$(CC) $(CFLAGS) -c -o $@ inline_call_value_program.c
+
+clean:
+	rm -f *.o inline_call_value_program
+
+.PHONY: clean all

--- a/e2e-tests/tests/fixtures/inline_call_value_program/inline_call_value_program.c
+++ b/e2e-tests/tests/fixtures/inline_call_value_program/inline_call_value_program.c
@@ -1,0 +1,49 @@
+#include <unistd.h>
+
+/*
+ * This fixture targets a specific inline-parameter recovery bug:
+ * the traced line is after an internal call made from an inlined body, so the
+ * original inline parameters may be optimized out while the inline DIE still
+ * contains call_site_parameter children for that internal call.
+ */
+__attribute__((noinline)) static int consume_pair(int lhs, int rhs) {
+    asm volatile("" ::: "memory");
+    return lhs * rhs;
+}
+
+static inline __attribute__((always_inline)) int inline_after_call(
+    int original_x,
+    int original_y
+) {
+    int combined = consume_pair(original_x + original_y, original_x - original_y);
+    int after_call = combined + 7;
+    if (after_call & 1) {
+        after_call += 3;
+    } else {
+        after_call -= 2;
+    }
+    // Keep this on the first executable line after the post-call work.
+    asm volatile("" : "+r"(after_call) :: "memory");
+    return after_call;
+}
+
+__attribute__((noinline)) static int wrapper(int seed) {
+    int local_x = seed * 7;
+    int local_y = seed + 11;
+
+    asm volatile("" : "+r"(local_x), "+r"(local_y) :: "memory");
+    return inline_after_call(local_x, local_y);
+}
+
+int main(void) {
+    volatile int sink = 0;
+    int i = 1;
+
+    while (i < 20000) {
+        sink = wrapper(i);
+        i++;
+        usleep(10000);
+    }
+
+    return sink == 42 ? 0 : 0;
+}

--- a/e2e-tests/tests/optimized_inline_call_value_execution.rs
+++ b/e2e-tests/tests/optimized_inline_call_value_execution.rs
@@ -6,7 +6,15 @@ use std::path::Path;
 use std::time::Duration;
 
 // Keep this on the first executable line after consume_pair() returns.
+// This is intentionally a negative regression point: at this PC the inline
+// parameters have already fallen out of their own location-list coverage, so
+// we only assert that GhostScope does not misreport them as consume_pair's
+// argument registers. We do not expect post-call value recovery to work until
+// full DW_OP_entry_value + caller-side call-site evaluation is implemented.
 const INLINE_AFTER_CALL_TRACE_LINE: u32 = 19;
+// TODO(positive_test): Add a companion positive test on a pre-call line where
+// original_x/original_y are still covered by their own location lists and can
+// be asserted with exact values without relying on entry_value support.
 
 async fn spawn_inline_call_value_program(
     binary_path: &Path,

--- a/e2e-tests/tests/optimized_inline_call_value_execution.rs
+++ b/e2e-tests/tests/optimized_inline_call_value_execution.rs
@@ -1,0 +1,106 @@
+mod common;
+
+use common::{init, FIXTURES};
+use ghostscope_dwarf::{DirectValueResult, EvaluationResult};
+use std::path::Path;
+use std::time::Duration;
+
+// Keep this on the first executable line after consume_pair() returns.
+const INLINE_AFTER_CALL_TRACE_LINE: u32 = 19;
+
+async fn spawn_inline_call_value_program(
+    binary_path: &Path,
+) -> anyhow::Result<common::targets::TargetHandle> {
+    let bin_dir = binary_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("inline_call_value_program has no parent directory"))?;
+    let target = common::targets::TargetLauncher::binary(binary_path)
+        .current_dir(bin_dir)
+        .spawn()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(target)
+}
+
+fn assert_not_internal_call_register_aliases(
+    parameters: &[ghostscope_dwarf::VariableWithEvaluation],
+    address: u64,
+) -> anyhow::Result<()> {
+    let original_x = parameters
+        .iter()
+        .find(|param| param.name == "original_x")
+        .ok_or_else(|| anyhow::anyhow!("missing original_x at 0x{:x}", address))?;
+    let original_y = parameters
+        .iter()
+        .find(|param| param.name == "original_y")
+        .ok_or_else(|| anyhow::anyhow!("missing original_y at 0x{:x}", address))?;
+
+    assert_ne!(
+        original_x.evaluation_result,
+        EvaluationResult::DirectValue(DirectValueResult::RegisterValue(5)),
+        "original_x aliased consume_pair's first argument register at 0x{:x}: {:?}",
+        address,
+        parameters
+    );
+    assert_ne!(
+        original_y.evaluation_result,
+        EvaluationResult::DirectValue(DirectValueResult::RegisterValue(4)),
+        "original_y aliased consume_pair's second argument register at 0x{:x}: {:?}",
+        address,
+        parameters
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimized_inline_parameters_survive_internal_call_sites() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("inline_call_value_program")?;
+    let mut analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path).await?;
+    let addrs = analyzer.lookup_addresses_by_source_line(
+        "inline_call_value_program.c",
+        INLINE_AFTER_CALL_TRACE_LINE,
+    );
+    anyhow::ensure!(
+        !addrs.is_empty(),
+        "No DWARF addresses found for inline_call_value_program.c:{INLINE_AFTER_CALL_TRACE_LINE}"
+    );
+    for module_address in &addrs {
+        anyhow::ensure!(
+            analyzer.is_inline_at(module_address) == Some(true),
+            "Expected inline address at 0x{:x}",
+            module_address.address
+        );
+    }
+    let query_results = analyzer.query_source_line_best_effort(
+        "inline_call_value_program.c",
+        INLINE_AFTER_CALL_TRACE_LINE,
+    )?;
+    anyhow::ensure!(
+        !query_results.is_empty(),
+        "No query results for inline_call_value_program.c:{INLINE_AFTER_CALL_TRACE_LINE}"
+    );
+    for result in &query_results {
+        assert_not_internal_call_register_aliases(&result.parameters, result.address)?;
+    }
+
+    let target = spawn_inline_call_value_program(&binary_path).await?;
+    let mut pid_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_pid(target.host_pid()).await?;
+    let pid_results = pid_analyzer.query_source_line_best_effort(
+        "inline_call_value_program.c",
+        INLINE_AFTER_CALL_TRACE_LINE,
+    )?;
+    target.terminate().await?;
+
+    anyhow::ensure!(
+        !pid_results.is_empty(),
+        "No PID-backed query results for inline_call_value_program.c:{INLINE_AFTER_CALL_TRACE_LINE}"
+    );
+    for result in &pid_results {
+        assert_not_internal_call_register_aliases(&result.parameters, result.address)?;
+    }
+
+    Ok(())
+}

--- a/ghostscope-dwarf/src/index/block_index.rs
+++ b/ghostscope-dwarf/src/index/block_index.rs
@@ -282,6 +282,7 @@ impl<'a> BlockIndexBuilder<'a> {
                         bn.ranges = ranges;
                     }
                     if let Some(a) = e.attr(gimli::constants::DW_AT_entry_pc) {
+                        // TODO(dwarf5): Also handle DebugAddrIndex-backed DW_AT_entry_pc.
                         if let gimli::AttributeValue::Addr(addr) = a.value() {
                             bn.entry_pc = Some(addr);
                         }

--- a/ghostscope-dwarf/src/objfile/variables.rs
+++ b/ghostscope-dwarf/src/objfile/variables.rs
@@ -1,7 +1,7 @@
 use super::{access_planner::AccessPlanner, LoadedObjfile};
 use crate::{
     core::Result,
-    index::{BlockIndexBuilder, FunctionBlocks, VarRef},
+    index::{BlockIndexBuilder, FunctionBlocks},
     parser::{DetailedParser, ExpressionEvaluator},
     semantics::{resolve_attr_with_unit_origins, resolve_name_with_origins},
 };
@@ -57,173 +57,6 @@ impl LoadedObjfile {
 
         Some(false)
     }
-
-    fn try_apply_call_site_mapping(
-        &self,
-        func: &FunctionBlocks,
-        inline_idx: usize,
-        address: u64,
-        vars: &mut [crate::VariableWithEvaluation],
-        _var_refs: &[VarRef],
-        get_cfa: &dyn Fn(u64) -> Result<Option<crate::core::CfaResult>>,
-    ) {
-        let dwarf = self.dwarf();
-        let header = match dwarf.unit_header(func.cu_offset) {
-            Ok(h) => h,
-            Err(_) => return,
-        };
-        let unit = match dwarf.unit(header) {
-            Ok(u) => u,
-            Err(_) => return,
-        };
-        let node = &func.nodes[inline_idx];
-        let inline_die = match node.die_offset.and_then(|off| unit.entry(off).ok()) {
-            Some(e) => e,
-            None => return,
-        };
-        if inline_die.tag() != gimli::constants::DW_TAG_inlined_subroutine {
-            return;
-        }
-
-        let origin_off = match inline_die.attr_value(gimli::constants::DW_AT_abstract_origin) {
-            Some(gimli::AttributeValue::UnitRef(o)) => o,
-            _ => return,
-        };
-
-        let mut origin_param_names: Vec<String> = Vec::new();
-        if let Ok(mut it) = unit.entries_at_offset(origin_off) {
-            let _ = it.next_entry();
-            while let Ok(Some(e)) = it.next_dfs() {
-                if e.depth() <= 0 {
-                    break;
-                }
-                if e.depth() > 1 {
-                    continue;
-                }
-                if e.tag() == gimli::constants::DW_TAG_formal_parameter {
-                    if let Some(a) = e.attr(gimli::constants::DW_AT_name) {
-                        if let Ok(s) = dwarf.attr_string(&unit, a.value()) {
-                            if let Ok(ss) = s.to_string_lossy() {
-                                origin_param_names.push(ss.into_owned());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if origin_param_names.is_empty() {
-            return;
-        }
-
-        let mut param_values: Vec<Option<crate::core::EvaluationResult>> =
-            vec![None; origin_param_names.len()];
-        if let Ok(mut it) = unit.entries_at_offset(node.die_offset.unwrap()) {
-            let _ = it.next_entry();
-            while let Ok(Some(e)) = it.next_dfs() {
-                if e.depth() <= 0 {
-                    break;
-                }
-                if e.depth() > 1 {
-                    continue;
-                }
-                if e.tag() == gimli::constants::DW_TAG_call_site
-                    || e.tag() == gimli::constants::DW_TAG_GNU_call_site
-                {
-                    if let Ok(mut pit) = unit.entries_at_offset(e.offset()) {
-                        let _ = pit.next_entry();
-                        while let Ok(Some(pe)) = pit.next_dfs() {
-                            if pe.depth() <= 0 {
-                                break;
-                            }
-                            if pe.depth() > 1 {
-                                continue;
-                            }
-                            if pe.tag() == gimli::constants::DW_TAG_call_site_parameter
-                                || pe.tag() == gimli::constants::DW_TAG_GNU_call_site_parameter
-                            {
-                                let loc_attr = pe.attr_value(gimli::constants::DW_AT_location);
-                                if let Some(gimli::AttributeValue::Exprloc(expr)) = loc_attr {
-                                    if let Ok(ev) = ExpressionEvaluator::parse_expression_in_unit(
-                                        expr.0.to_slice().ok().as_deref().unwrap_or(&[]),
-                                        &unit,
-                                        dwarf,
-                                        address,
-                                        Some(get_cfa),
-                                    ) {
-                                        if let Some(slot) =
-                                            param_values.iter_mut().find(|v| v.is_none())
-                                        {
-                                            *slot = Some(ev);
-                                        }
-                                    }
-                                } else if let Some(cv) =
-                                    pe.attr_value(gimli::constants::DW_AT_const_value)
-                                {
-                                    use crate::core::DirectValueResult as DV;
-                                    use crate::core::EvaluationResult as ER;
-                                    let ev = match cv {
-                                        gimli::AttributeValue::Udata(u) => {
-                                            ER::DirectValue(DV::Constant(u as i64))
-                                        }
-                                        gimli::AttributeValue::Sdata(s) => {
-                                            ER::DirectValue(DV::Constant(s))
-                                        }
-                                        gimli::AttributeValue::Data1(d) => {
-                                            ER::DirectValue(DV::Constant(d as i64))
-                                        }
-                                        gimli::AttributeValue::Data2(d) => {
-                                            ER::DirectValue(DV::Constant(d as i64))
-                                        }
-                                        gimli::AttributeValue::Data4(d) => {
-                                            ER::DirectValue(DV::Constant(d as i64))
-                                        }
-                                        gimli::AttributeValue::Data8(d) => {
-                                            ER::DirectValue(DV::Constant(d as i64))
-                                        }
-                                        gimli::AttributeValue::Block(b) => match b.to_slice() {
-                                            Ok(bytes) => {
-                                                ER::DirectValue(DV::ImplicitValue(bytes.to_vec()))
-                                            }
-                                            Err(_) => ER::Optimized,
-                                        },
-                                        _ => ER::Optimized,
-                                    };
-                                    if let Some(slot) =
-                                        param_values.iter_mut().find(|v| v.is_none())
-                                    {
-                                        *slot = Some(ev);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if param_values.iter().all(|v| v.is_none()) {
-            return;
-        }
-
-        for v in vars.iter_mut() {
-            if !v.is_parameter {
-                continue;
-            }
-            if !matches!(
-                v.evaluation_result,
-                crate::core::EvaluationResult::Optimized
-            ) {
-                continue;
-            }
-            let name = v.name.as_str();
-            if let Some(pos) = origin_param_names.iter().position(|n| n == name) {
-                if let Some(Some(ev)) = param_values.get(pos) {
-                    v.evaluation_result = ev.clone();
-                }
-            }
-        }
-    }
-
     pub(super) fn plan_chain_access_from_var(
         &mut self,
         address: u64,
@@ -509,17 +342,6 @@ impl LoadedObjfile {
                             }
                         }
                     }
-                }
-
-                if let Some(inline_idx) = Self::find_innermost_inline_node(&func, address) {
-                    self.try_apply_call_site_mapping(
-                        &func,
-                        inline_idx,
-                        address,
-                        &mut vars,
-                        &var_refs,
-                        &get_cfa_closure,
-                    );
                 }
 
                 let mut seen_param_names: std::collections::HashSet<String> =

--- a/ghostscope-dwarf/src/objfile/variables.rs
+++ b/ghostscope-dwarf/src/objfile/variables.rs
@@ -344,6 +344,15 @@ impl LoadedObjfile {
                     }
                 }
 
+                // Keep the parser's direct DWARF result for inline parameters as-is.
+                // We intentionally do not remap optimized inline params from nested
+                // call_site_parameter DIEs here: those describe the callee's argument
+                // locations/values, not the inline function's original parameters, and
+                // using them here caused false aliases like "original_x = RDI".
+                // TODO(inline_params): If we want to recover optimized inline params in
+                // these cases, it has to come from a complete DW_OP_entry_value path that
+                // evaluates caller-side call-site values, not from the inline body's own
+                // nested call-site subtree.
                 let mut seen_param_names: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
                 let mut filtered: Vec<crate::VariableWithEvaluation> =

--- a/ghostscope-dwarf/src/parser/expression_evaluator.rs
+++ b/ghostscope-dwarf/src/parser/expression_evaluator.rs
@@ -202,8 +202,12 @@ impl ExpressionEvaluator {
                 debug!("Found DW_OP_stack_value - this is a computed value");
             }
             match &op {
-                // Support DW_OP_entry_value minimally for inline parameters:
-                // If inner expression is a single DW_OP_reg*, treat it as a direct value.
+                // TODO(entry_value): This is only a minimal fallback.
+                // For inline parameters, a correct DW_OP_entry_value implementation must
+                // walk back to the caller and evaluate the matching call_site_parameter's
+                // DW_AT_call_value / DW_AT_GNU_call_site_value. Merely stripping
+                // entry_value(reg) to a bare register only preserves the simplest cases
+                // where the parameter is still equivalent to the entry register.
                 Operation::EntryValue { expression } => {
                     let mut inner = *expression;
                     let mut inner_ops: Vec<Operation<_>> = Vec::new();

--- a/ghostscope-dwarf/src/parser/fast_parser.rs
+++ b/ghostscope-dwarf/src/parser/fast_parser.rs
@@ -544,6 +544,7 @@ impl<'a> DwarfParser<'a> {
                     attrs.ranges_attr = Some(value);
                 }
                 gimli::constants::DW_AT_entry_pc => {
+                    // TODO(dwarf5): Also handle DebugAddrIndex-backed DW_AT_entry_pc.
                     if let gimli::AttributeValue::Addr(addr) = value {
                         attrs.entry_pc = Some(addr);
                     }


### PR DESCRIPTION
Drop the invalid call-site based inline parameter recovery path. Add a dedicated inline-call-value fixture and regression test. Ignore the new fixture binary and exclude fixtures from Linguist stats.