### PR TITLE
fix: recover non-inline entry values at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ e2e-tests/tests/fixtures/sample_program/sample_program_stripped.debug
 e2e-tests/tests/fixtures/static_scope_program/static_scope_program
 e2e-tests/tests/fixtures/static_scope_program/static_scope_program_clang_dwarf5
 e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program_clang_dwarf5
+e2e-tests/tests/fixtures/entry_value_breg_program/entry_value_breg_program_clang_debuglink
+e2e-tests/tests/fixtures/entry_value_breg_program/entry_value_breg_program_clang_debuglink.debug
 e2e-tests/tests/fixtures/**/.ghostscope-inline-entry-pc-regression-*/
 e2e-tests/tests/fixtures/**/.ghostscope-fast-parser-patched-*/
 e2e-tests/tests/fixtures/**/.ghostscope-entry-value-runtime-*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "ghostscope-compiler",
  "ghostscope-dwarf",
  "ghostscope-process",
+ "gimli 0.33.0",
  "lazy_static",
  "libc",
  "object",

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -21,6 +21,7 @@ tempfile = { workspace = true }
 lazy_static = { workspace = true }
 scopeguard = { workspace = true }
 serial_test = { workspace = true }
+gimli = { workspace = true }
 object = { workspace = true }
 ghostscope-compiler = { version = "0.1.3", path = "../ghostscope-compiler" }
 ghostscope-dwarf = { version = "0.1.3", path = "../ghostscope-dwarf" }

--- a/e2e-tests/tests/entry_value_recovery_execution.rs
+++ b/e2e-tests/tests/entry_value_recovery_execution.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use anyhow::Context;
 use common::{
     fixture_compiler_available, init,
     runner::GhostscopeRunner,
@@ -7,6 +8,13 @@ use common::{
     FixtureCompiler,
 };
 use ghostscope_dwarf::{ComputeStep, MemoryAccessSize};
+use gimli::constants;
+use gimli::write::{
+    Address, AttributeValue as WriteAttributeValue, Dwarf as WriteDwarf, EndianVec,
+    Expression as WriteExpression, LineProgram, Sections, Unit,
+};
+use gimli::{Format, Register, SectionId};
+use object::{Object, ObjectSymbol};
 use regex::Regex;
 use std::collections::HashMap;
 use std::fs;
@@ -20,8 +28,13 @@ const FIXTURE_NAME: &str = "entry_value_recovery_program";
 const FIXTURE_SOURCE: &str = "entry_value_recovery_program.c";
 const TOUCH_TRACE_LINE: u32 = 16;
 const POST_CALL_TRACE_LINE: u32 = 21;
+const BREG_FIXTURE_NAME: &str = "entry_value_breg_program";
+const BREG_FIXTURE_SOURCE: &str = "entry_value_breg_program.c";
+const BREG_FUNCTION_NAME: &str = "stack_entry_target";
+const BREG_ANCHOR_NAME: &str = "entry_value_breg_anchor";
 
 static CLANG_FIXTURE: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+static BREG_CLANG_FIXTURE: OnceLock<Result<PathBuf, String>> = OnceLock::new();
 
 struct LoggedTarget {
     target: TargetHandle,
@@ -81,6 +94,279 @@ fn compile_entry_value_recovery_program_clang() -> anyhow::Result<PathBuf> {
     });
 
     result.clone().map_err(|e| anyhow::anyhow!(e))
+}
+
+fn command_available(name: &str) -> bool {
+    StdCommand::new(name)
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn compile_entry_value_breg_program_clang() -> anyhow::Result<PathBuf> {
+    let result = BREG_CLANG_FIXTURE.get_or_init(|| {
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures")
+            .join(BREG_FIXTURE_NAME);
+        let source = base.join(BREG_FIXTURE_SOURCE);
+        let binary = base.join("entry_value_breg_program_clang_debuglink");
+        let debug_file = base.join("entry_value_breg_program_clang_debuglink.debug");
+
+        if !command_available("objcopy") {
+            return Err("objcopy is unavailable".to_string());
+        }
+
+        let _ = fs::remove_file(&binary);
+        let _ = fs::remove_file(&debug_file);
+
+        let output = StdCommand::new("clang")
+            .arg("-Wall")
+            .arg("-Wextra")
+            .arg("-gdwarf-4")
+            .arg("-O2")
+            .arg("-fomit-frame-pointer")
+            .arg("-no-pie")
+            .arg("-o")
+            .arg(&binary)
+            .arg(&source)
+            .current_dir(&base)
+            .output();
+
+        match output {
+            Ok(output) if output.status.success() => {}
+            Ok(output) => {
+                return Err(format!(
+                    "failed to compile {BREG_FIXTURE_NAME} clang fixture: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to invoke clang for {BREG_FIXTURE_NAME}: {error}"
+                ));
+            }
+        }
+
+        if let Err(error) = build_entry_value_breg_debuglink_fixture(&binary, &debug_file) {
+            return Err(format!(
+                "failed to synthesize debuglink fixture for {BREG_FIXTURE_NAME}: {error}"
+            ));
+        }
+
+        Ok(binary)
+    });
+
+    result.clone().map_err(|e| anyhow::anyhow!(e))
+}
+
+fn build_entry_value_breg_debuglink_fixture(
+    binary: &Path,
+    debug_file: &Path,
+) -> anyhow::Result<()> {
+    run_command(
+        StdCommand::new("objcopy")
+            .arg("--only-keep-debug")
+            .arg(binary)
+            .arg(debug_file),
+        "objcopy --only-keep-debug",
+    )?;
+    run_command(
+        StdCommand::new("objcopy").arg("--strip-debug").arg(binary),
+        "objcopy --strip-debug",
+    )?;
+
+    let (function_addr, function_size) = lookup_symbol(binary, BREG_FUNCTION_NAME)?;
+    let (anchor_addr, _) = lookup_symbol(binary, BREG_ANCHOR_NAME)?;
+    let function_size = function_size.max(anchor_addr.saturating_sub(function_addr) + 16);
+
+    let debug_sections_dir = create_runtime_log_dir(
+        debug_file
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("debug file path has no parent"))?,
+    )?;
+    write_synthetic_entry_value_breg_sections(&debug_sections_dir, function_addr, function_size)?;
+
+    update_debug_section(debug_file, ".debug_abbrev", &debug_sections_dir)?;
+    update_debug_section(debug_file, ".debug_info", &debug_sections_dir)?;
+    update_debug_section(debug_file, ".debug_str", &debug_sections_dir)?;
+    let _ = StdCommand::new("objcopy")
+        .arg("--remove-section")
+        .arg(".debug_aranges")
+        .arg(debug_file)
+        .output();
+
+    run_command(
+        StdCommand::new("objcopy")
+            .arg("--add-gnu-debuglink")
+            .arg(debug_file)
+            .arg(binary),
+        "objcopy --add-gnu-debuglink",
+    )?;
+
+    if command_available("dwarfdump") {
+        ensure_debug_dump_contains_breg_entry_value(debug_file)?;
+    }
+    let _ = fs::remove_dir_all(debug_sections_dir);
+    Ok(())
+}
+
+fn run_command(command: &mut StdCommand, label: &str) -> anyhow::Result<()> {
+    let output = command
+        .output()
+        .with_context(|| format!("failed to run {label}"))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "{label} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+fn lookup_symbol(binary: &Path, name: &str) -> anyhow::Result<(u64, u64)> {
+    let data = fs::read(binary)?;
+    let file = object::File::parse(&*data)?;
+    for symbol in file.symbols() {
+        if let Ok(symbol_name) = symbol.name() {
+            if symbol_name == name {
+                return Ok((symbol.address(), symbol.size()));
+            }
+        }
+    }
+    anyhow::bail!("missing symbol {name} in {}", binary.display())
+}
+
+fn write_synthetic_entry_value_breg_sections(
+    out_dir: &Path,
+    function_addr: u64,
+    function_size: u64,
+) -> anyhow::Result<()> {
+    let encoding = gimli::Encoding {
+        format: Format::Dwarf32,
+        version: 4,
+        address_size: 8,
+    };
+
+    let mut dwarf = WriteDwarf::new();
+    let unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+    let unit = dwarf.units.get_mut(unit_id);
+    let root = unit.root();
+    unit.get_mut(root).set(
+        constants::DW_AT_name,
+        WriteAttributeValue::String(BREG_FIXTURE_SOURCE.as_bytes().to_vec()),
+    );
+
+    let int_id = unit.add(root, constants::DW_TAG_base_type);
+    let int_entry = unit.get_mut(int_id);
+    int_entry.set(
+        constants::DW_AT_name,
+        WriteAttributeValue::String(b"int".to_vec()),
+    );
+    int_entry.set(constants::DW_AT_byte_size, WriteAttributeValue::Data1(4));
+    int_entry.set(
+        constants::DW_AT_encoding,
+        WriteAttributeValue::Encoding(constants::DW_ATE_signed),
+    );
+
+    let function_id = unit.add(root, constants::DW_TAG_subprogram);
+    let function = unit.get_mut(function_id);
+    function.set(
+        constants::DW_AT_name,
+        WriteAttributeValue::String(BREG_FUNCTION_NAME.as_bytes().to_vec()),
+    );
+    function.set(
+        constants::DW_AT_low_pc,
+        WriteAttributeValue::Address(Address::Constant(function_addr)),
+    );
+    function.set(
+        constants::DW_AT_high_pc,
+        WriteAttributeValue::Udata(function_size),
+    );
+    let payload_id = unit.add(function_id, constants::DW_TAG_formal_parameter);
+    let payload = unit.get_mut(payload_id);
+    payload.set(
+        constants::DW_AT_name,
+        WriteAttributeValue::String(b"payload".to_vec()),
+    );
+    payload.set(constants::DW_AT_type, WriteAttributeValue::UnitRef(int_id));
+    let mut inner = WriteExpression::new();
+    inner.op_breg(Register(7), 8);
+    let mut location = WriteExpression::new();
+    location.op_entry_value(inner);
+    payload.set(
+        constants::DW_AT_location,
+        WriteAttributeValue::Exprloc(location),
+    );
+
+    let mut sections = Sections::new(EndianVec::new(gimli::LittleEndian));
+    dwarf.write(&mut sections)?;
+    write_section_file(&sections, SectionId::DebugAbbrev, out_dir)?;
+    write_section_file(&sections, SectionId::DebugInfo, out_dir)?;
+    write_section_file(&sections, SectionId::DebugStr, out_dir)?;
+    Ok(())
+}
+
+fn write_section_file(
+    sections: &Sections<EndianVec<gimli::LittleEndian>>,
+    id: SectionId,
+    out_dir: &Path,
+) -> anyhow::Result<()> {
+    let data = sections
+        .get(id)
+        .map(|section| section.slice().to_vec())
+        .unwrap_or_default();
+    fs::write(out_dir.join(section_output_name(id)), data)?;
+    Ok(())
+}
+
+fn section_output_name(id: SectionId) -> &'static str {
+    match id {
+        SectionId::DebugAbbrev => "debug_abbrev.bin",
+        SectionId::DebugInfo => "debug_info.bin",
+        SectionId::DebugStr => "debug_str.bin",
+        _ => unreachable!("unexpected section id for synthetic DWARF"),
+    }
+}
+
+fn update_debug_section(debug_file: &Path, section: &str, dir: &Path) -> anyhow::Result<()> {
+    let section_file = dir.join(match section {
+        ".debug_abbrev" => "debug_abbrev.bin",
+        ".debug_info" => "debug_info.bin",
+        ".debug_str" => "debug_str.bin",
+        _ => unreachable!("unexpected section name"),
+    });
+    run_command(
+        StdCommand::new("objcopy")
+            .arg("--update-section")
+            .arg(format!("{section}={}", section_file.display()))
+            .arg(debug_file),
+        &format!("objcopy --update-section {section}"),
+    )
+}
+
+fn ensure_debug_dump_contains_breg_entry_value(debug_file: &Path) -> anyhow::Result<()> {
+    let output = StdCommand::new("dwarfdump")
+        .arg("-i")
+        .arg(debug_file)
+        .output()
+        .with_context(|| format!("failed to run dwarfdump on {}", debug_file.display()))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "dwarfdump failed for {}: {}",
+        debug_file.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    anyhow::ensure!(
+        (stdout.contains("DW_OP_entry_value") || stdout.contains("DW_OP_GNU_entry_value"))
+            && stdout.contains("payload")
+            && (stdout.contains("contents 0x7708")
+                || stdout.contains("DW_OP_breg7")
+                || stdout.contains("DW_OP_breg7 8")),
+        "synthetic debug file did not contain the expected entry_value(breg7) expression:\n{}",
+        stdout
+    );
+    Ok(())
 }
 
 async fn spawn_logged_target(binary_path: &Path) -> anyhow::Result<LoggedTarget> {
@@ -359,6 +645,88 @@ STDERR: {ghostscope_stderr}"
         seen >= 2,
         "Expected multiple post-call trace events. GhostScope STDOUT: {ghostscope_stdout}
 Target STDOUT: {target_stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_entry_value_breg_stack_parameter_recovers_at_runtime() -> anyhow::Result<()> {
+    init();
+    if !fixture_compiler_available(FixtureCompiler::ClangDwarf5) {
+        eprintln!("Skipping entry_value(breg) runtime test because clang is unavailable");
+        return Ok(());
+    }
+    if !command_available("objcopy") {
+        eprintln!("Skipping entry_value(breg) runtime test because objcopy is unavailable");
+        return Ok(());
+    }
+
+    let binary_path = compile_entry_value_breg_program_clang()?;
+    let (anchor_pc, _) = lookup_symbol(&binary_path, BREG_ANCHOR_NAME)?;
+
+    let target = spawn_logged_target(&binary_path).await?;
+    let script = format!(
+        "trace 0x{anchor_pc:x} {{
+    print \"STACKPAYLOAD:{{}}\", payload;
+}}
+"
+    );
+    let (exit_code, ghostscope_stdout, ghostscope_stderr) = GhostscopeRunner::new()
+        .with_script(&script)
+        .attach_to(&target.target)
+        .timeout_secs(4)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await?;
+    let (target_stdout, target_stderr) = target.terminate_and_collect().await?;
+
+    if should_skip_for_ebpf_env(exit_code, &ghostscope_stderr) {
+        return Ok(());
+    }
+
+    assert_eq!(
+        exit_code, 0,
+        "ghostscope stderr={ghostscope_stderr} ghostscope stdout={ghostscope_stdout} target stderr={target_stderr}"
+    );
+    assert!(
+        !ghostscope_stdout.contains("ExprError"),
+        "Expected entry_value(breg7 + 8) stack recovery. STDOUT: {ghostscope_stdout}\nSTDERR: {ghostscope_stderr}"
+    );
+    assert!(
+        !ghostscope_stdout.contains("<optimized out>"),
+        "entry_value(breg7 + 8) stack parameter should not be optimized out. STDOUT: {ghostscope_stdout}\nSTDERR: {ghostscope_stderr}"
+    );
+
+    let actual_re = Regex::new(r"ACTUAL:([0-9-]+):([0-9-]+)")?;
+    let actual_seeds: Vec<i64> = actual_re
+        .captures_iter(&target_stdout)
+        .map(|caps| caps[1].parse::<i64>())
+        .collect::<Result<_, _>>()?;
+    anyhow::ensure!(
+        !actual_seeds.is_empty(),
+        "fixture stdout did not contain ACTUAL lines: {target_stdout}"
+    );
+
+    let trace_re = Regex::new(r"STACKPAYLOAD:([0-9-]+)")?;
+    let mut next_actual_index = 0usize;
+    let mut seen = 0;
+    for caps in trace_re.captures_iter(&ghostscope_stdout) {
+        let payload = caps[1].parse::<i64>()?;
+        let relative_index = actual_seeds[next_actual_index..]
+            .iter()
+            .position(|seed| *seed == payload)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "missing ordered ACTUAL seed for payload={payload}; ghostscope stdout={ghostscope_stdout} target stdout={target_stdout}"
+                )
+            })?;
+        next_actual_index += relative_index + 1;
+        seen += 1;
+    }
+
+    assert!(
+        seen >= 2,
+        "Expected multiple stack-parameter trace events. GhostScope STDOUT: {ghostscope_stdout}\nTarget STDOUT: {target_stdout}"
     );
     Ok(())
 }

--- a/e2e-tests/tests/entry_value_recovery_execution.rs
+++ b/e2e-tests/tests/entry_value_recovery_execution.rs
@@ -10,6 +10,7 @@ use ghostscope_dwarf::{ComputeStep, MemoryAccessSize};
 use regex::Regex;
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use std::sync::OnceLock;
@@ -101,7 +102,7 @@ exec {binary} >>{stdout} 2>>{stderr}
         stdout = shell_quote(&stdout_log),
         stderr = shell_quote(&stderr_log),
     );
-    fs::write(&wrapper_path, wrapper)?;
+    write_wrapper_script(&wrapper_path, &wrapper)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -109,10 +110,7 @@ exec {binary} >>{stdout} 2>>{stderr}
         perms.set_mode(0o755);
         fs::set_permissions(&wrapper_path, perms)?;
     }
-    let target = TargetLauncher::binary(&wrapper_path)
-        .current_dir(base)
-        .spawn()
-        .await?;
+    let target = spawn_wrapper_target(&wrapper_path, base).await?;
     tokio::time::sleep(Duration::from_millis(500)).await;
     Ok(LoggedTarget {
         target,
@@ -127,6 +125,41 @@ fn create_runtime_log_dir(base: &Path) -> anyhow::Result<PathBuf> {
     let path = base.join(format!(".ghostscope-entry-value-runtime-{unique}"));
     fs::create_dir(&path)?;
     Ok(path)
+}
+
+fn write_wrapper_script(path: &Path, contents: &str) -> anyhow::Result<()> {
+    let mut file = fs::File::create(path)?;
+    file.write_all(contents.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+async fn spawn_wrapper_target(wrapper_path: &Path, base: &Path) -> anyhow::Result<TargetHandle> {
+    let mut delay = Duration::from_millis(50);
+    for attempt in 0..3 {
+        match TargetLauncher::binary(wrapper_path)
+            .current_dir(base)
+            .spawn()
+            .await
+        {
+            Ok(target) => return Ok(target),
+            Err(err) if attempt < 2 && is_text_file_busy(&err) => {
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    unreachable!("spawn retry loop should return on success or the final error")
+}
+
+fn is_text_file_busy(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .and_then(std::io::Error::raw_os_error)
+            == Some(libc::ETXTBSY)
+    })
 }
 
 fn read_log_file(path: &Path) -> anyhow::Result<String> {

--- a/e2e-tests/tests/entry_value_recovery_execution.rs
+++ b/e2e-tests/tests/entry_value_recovery_execution.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const FIXTURE_NAME: &str = "entry_value_recovery_program";
 const FIXTURE_SOURCE: &str = "entry_value_recovery_program.c";
+const TOUCH_TRACE_LINE: u32 = 16;
 const POST_CALL_TRACE_LINE: u32 = 21;
 
 static CLANG_FIXTURE: OnceLock<Result<PathBuf, String>> = OnceLock::new();
@@ -139,6 +140,104 @@ fn read_log_file(path: &Path) -> anyhow::Result<String> {
 fn shell_quote(path: &Path) -> String {
     let raw = path.display().to_string();
     format!("'{}'", raw.replace('\'', "'\"'\"'"))
+}
+
+#[tokio::test]
+async fn test_non_inline_entry_value_recovers_touch_parameters_at_runtime() -> anyhow::Result<()> {
+    init();
+    if !fixture_compiler_available(FixtureCompiler::ClangDwarf5) {
+        eprintln!("Skipping non-inline entry_value runtime test because clang is unavailable");
+        return Ok(());
+    }
+
+    let binary_path = compile_entry_value_recovery_program_clang()?;
+    let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path).await?;
+    let addrs = analyzer.lookup_addresses_by_source_line(FIXTURE_SOURCE, TOUCH_TRACE_LINE);
+    anyhow::ensure!(
+        !addrs.is_empty(),
+        "No DWARF addresses found for {FIXTURE_SOURCE}:{TOUCH_TRACE_LINE}"
+    );
+
+    let target = spawn_logged_target(&binary_path).await?;
+    let script = format!(
+        "trace {FIXTURE_SOURCE}:{TOUCH_TRACE_LINE} {{
+    print \"TOUCH:{{}}:{{}}:{{}}\", x, state.total_bytes, state.stream_id;
+}}
+"
+    );
+    let (exit_code, ghostscope_stdout, ghostscope_stderr) = GhostscopeRunner::new()
+        .with_script(&script)
+        .attach_to(&target.target)
+        .timeout_secs(4)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await?;
+    let (target_stdout, target_stderr) = target.terminate_and_collect().await?;
+
+    if should_skip_for_ebpf_env(exit_code, &ghostscope_stderr) {
+        return Ok(());
+    }
+
+    assert_eq!(
+        exit_code, 0,
+        "ghostscope stderr={ghostscope_stderr} ghostscope stdout={ghostscope_stdout} target stderr={target_stderr}"
+    );
+    assert!(
+        !ghostscope_stdout.contains("ExprError"),
+        "Expected exact non-inline entry_value recovery inside touch(). STDOUT: {ghostscope_stdout}\nSTDERR: {ghostscope_stderr}"
+    );
+    assert!(
+        !ghostscope_stdout.contains("<optimized out>"),
+        "touch() parameters should not be optimized out. STDOUT: {ghostscope_stdout}\nSTDERR: {ghostscope_stderr}"
+    );
+
+    let actual_re = Regex::new(r"ACTUAL:([0-9-]+):([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let mut actual_by_seed = HashMap::new();
+    for caps in actual_re.captures_iter(&target_stdout) {
+        actual_by_seed.insert(
+            caps[1].parse::<i64>()?,
+            (
+                caps[2].parse::<i64>()?,
+                caps[3].parse::<i64>()?,
+                caps[4].parse::<i64>()?,
+            ),
+        );
+    }
+    anyhow::ensure!(
+        !actual_by_seed.is_empty(),
+        "fixture stdout did not contain ACTUAL lines: {target_stdout}"
+    );
+
+    let trace_re = Regex::new(r"TOUCH:([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let mut seen = 0;
+    for caps in trace_re.captures_iter(&ghostscope_stdout) {
+        let seed = caps[1].parse::<i64>()?;
+        let total_bytes = caps[2].parse::<i64>()?;
+        let stream_id = caps[3].parse::<i64>()?;
+        let actual = actual_by_seed.get(&seed).ok_or_else(|| {
+            anyhow::anyhow!("missing ACTUAL record for seed={seed}; target stdout={target_stdout}")
+        })?;
+        let mut expected_result = total_bytes + (seed * 3);
+        if (expected_result & 1) != 0 {
+            expected_result += stream_id;
+        }
+        assert_eq!(
+            (total_bytes, stream_id),
+            (actual.0, actual.1),
+            "touch() recovered the wrong state for seed={seed}; ghostscope stdout={ghostscope_stdout}"
+        );
+        assert_eq!(
+            actual.2, expected_result,
+            "touch() recovered an inconsistent seed/result for seed={seed}; ghostscope stdout={ghostscope_stdout}"
+        );
+        seen += 1;
+    }
+
+    assert!(
+        seen >= 2,
+        "Expected multiple touch() trace events. GhostScope STDOUT: {ghostscope_stdout}\nTarget STDOUT: {target_stdout}"
+    );
+    Ok(())
 }
 
 #[tokio::test]

--- a/e2e-tests/tests/fixtures/entry_value_breg_program/entry_value_breg_program.c
+++ b/e2e-tests/tests/fixtures/entry_value_breg_program/entry_value_breg_program.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <unistd.h>
+
+__attribute__((noinline)) void clobber_regs(int value) {
+    asm volatile("" : : "r"(value)
+                 : "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10",
+                   "r11", "memory");
+}
+
+__attribute__((noinline)) int stack_entry_target(
+    int a1,
+    int a2,
+    int a3,
+    int a4,
+    int a5,
+    int a6,
+    int payload
+) {
+    volatile int scratch[8];
+    int sum = a1 + a2 + a3 + a4 + a5 + a6;
+    scratch[0] = sum;
+    scratch[7] = payload;
+    clobber_regs(scratch[0]);
+    asm volatile(
+        ".globl entry_value_breg_anchor\n"
+        "entry_value_breg_anchor:\n"
+        :
+        :
+        : "memory");
+    return scratch[7] * 5 + a4;
+}
+
+int main(void) {
+    volatile int sink = 0;
+    int i = 1;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    while (i < 20000) {
+        int result = stack_entry_target(11, 12, 13, 14, 15, 16, i);
+        printf("ACTUAL:%d:%d\n", i, result);
+        sink = result;
+        i++;
+        usleep(10000);
+    }
+
+    return sink == 42 ? 0 : 0;
+}

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -994,6 +994,20 @@ impl<'ctx> EbpfContext<'ctx> {
                     }
                 }
 
+                ComputeStep::EntryValueLookup {
+                    caller_pc_steps,
+                    cases,
+                } => {
+                    let value = self.generate_entry_value_lookup(
+                        caller_pc_steps,
+                        cases,
+                        pt_regs_ptr,
+                        _result_size,
+                        status_ptr,
+                    )?;
+                    stack.push(value);
+                }
+
                 // Add catch-all for unimplemented operations
                 _ => {
                     warn!("Unimplemented ComputeStep: {:?}", step);
@@ -1012,6 +1026,154 @@ impl<'ctx> EbpfContext<'ctx> {
                 stack.len()
             )))
         }
+    }
+
+    fn generate_entry_value_lookup(
+        &mut self,
+        caller_pc_steps: &[ComputeStep],
+        cases: &[ghostscope_dwarf::core::EntryValueCase],
+        pt_regs_ptr: PointerValue<'ctx>,
+        result_size: Option<MemoryAccessSize>,
+        status_ptr: Option<PointerValue<'ctx>>,
+    ) -> Result<IntValue<'ctx>> {
+        if cases.is_empty() {
+            return Err(CodeGenError::LLVMError(
+                "EntryValueLookup requires at least one case".to_string(),
+            ));
+        }
+
+        let caller_pc = self
+            .generate_compute_steps(
+                caller_pc_steps,
+                pt_regs_ptr,
+                Some(MemoryAccessSize::U64),
+                status_ptr,
+                None,
+            )?
+            .into_int_value();
+
+        let current_block = self.builder.get_insert_block().ok_or_else(|| {
+            CodeGenError::LLVMError("No insertion block for EntryValueLookup".to_string())
+        })?;
+        let current_fn = current_block.get_parent().ok_or_else(|| {
+            CodeGenError::LLVMError("No parent function for EntryValueLookup".to_string())
+        })?;
+        let merge_bb = self
+            .context
+            .append_basic_block(current_fn, "entry_value_merge");
+        let default_bb = self
+            .context
+            .append_basic_block(current_fn, "entry_value_default");
+
+        let module_for_offsets = {
+            let ctx = self.get_compile_time_context()?;
+            self.current_resolved_var_module_path
+                .clone()
+                .unwrap_or_else(|| ctx.module_path.clone())
+        };
+        let module_cookie = self.cookie_for_module_or_fallback(&module_for_offsets);
+        let mut incoming_values = Vec::with_capacity(cases.len() + 1);
+        let mut any_missing_offsets = None;
+
+        for (index, case) in cases.iter().enumerate() {
+            let st_code = self.section_code_for_address(&module_for_offsets, case.caller_return_pc);
+            let link_pc = self
+                .context
+                .i64_type()
+                .const_int(case.caller_return_pc, false);
+            let (runtime_return_pc, found_flag) =
+                self.generate_runtime_address_from_offsets(link_pc, st_code, module_cookie)?;
+            let missing_offsets = self
+                .builder
+                .build_not(found_flag, &format!("entry_value_missing_{index}"))
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+            any_missing_offsets = Some(match any_missing_offsets {
+                Some(prev) => self
+                    .builder
+                    .build_or(
+                        prev,
+                        missing_offsets,
+                        &format!("entry_value_missing_or_{index}"),
+                    )
+                    .map_err(|e| CodeGenError::LLVMError(e.to_string()))?,
+                None => missing_offsets,
+            });
+
+            let is_match = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    caller_pc,
+                    runtime_return_pc,
+                    &format!("entry_value_match_{index}"),
+                )
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+            let case_bb = self
+                .context
+                .append_basic_block(current_fn, &format!("entry_value_case_{index}"));
+            let next_bb = if index + 1 == cases.len() {
+                default_bb
+            } else {
+                self.context
+                    .append_basic_block(current_fn, &format!("entry_value_check_{}", index + 1))
+            };
+            self.builder
+                .build_conditional_branch(is_match, case_bb, next_bb)
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+
+            self.builder.position_at_end(case_bb);
+            let case_value = self
+                .generate_compute_steps(
+                    &case.value_steps,
+                    pt_regs_ptr,
+                    result_size,
+                    status_ptr,
+                    None,
+                )?
+                .into_int_value();
+            let case_value_block = self.builder.get_insert_block().ok_or_else(|| {
+                CodeGenError::LLVMError(
+                    "No insertion block after EntryValueLookup case".to_string(),
+                )
+            })?;
+            self.builder
+                .build_unconditional_branch(merge_bb)
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+            incoming_values.push((case_value, case_value_block));
+
+            self.builder.position_at_end(next_bb);
+        }
+
+        self.builder.position_at_end(default_bb);
+        if let Some(sp) = status_ptr {
+            self.store_variable_read_status(
+                sp,
+                self.context.bool_type().const_int(1, false),
+                any_missing_offsets.unwrap_or_else(|| self.context.bool_type().const_zero()),
+                "entry_value_default",
+            )?;
+        }
+        let default_value = self.context.i64_type().const_zero();
+        let default_value_block = self.builder.get_insert_block().ok_or_else(|| {
+            CodeGenError::LLVMError("No default block for EntryValueLookup".to_string())
+        })?;
+        self.builder
+            .build_unconditional_branch(merge_bb)
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        incoming_values.push((default_value, default_value_block));
+
+        self.builder.position_at_end(merge_bb);
+        let phi = self
+            .builder
+            .build_phi(self.context.i64_type(), "entry_value_phi")
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        let incoming_refs: Vec<(&dyn inkwell::values::BasicValue<'ctx>, _)> = incoming_values
+            .iter()
+            .map(|(value, block)| (value as &dyn inkwell::values::BasicValue<'ctx>, *block))
+            .collect();
+        phi.add_incoming(&incoming_refs);
+
+        Ok(phi.as_basic_value().into_int_value())
     }
 
     /// Query DWARF for complex expression (supports member access, array access, etc.)

--- a/ghostscope-compiler/src/ebpf/helper_functions.rs
+++ b/ghostscope-compiler/src/ebpf/helper_functions.rs
@@ -912,7 +912,7 @@ impl<'ctx> EbpfContext<'ctx> {
         Ok(())
     }
 
-    fn store_variable_read_status(
+    pub(crate) fn store_variable_read_status(
         &mut self,
         status_ptr: PointerValue<'ctx>,
         combined_fail: IntValue<'ctx>,

--- a/ghostscope-dwarf/src/binary/mapped_file.rs
+++ b/ghostscope-dwarf/src/binary/mapped_file.rs
@@ -2,6 +2,8 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use object::{Endianness, Object};
+
 /// Internal helper for mmap-backed file access and object parsing.
 #[derive(Debug)]
 pub(crate) struct MappedFile {
@@ -29,19 +31,24 @@ impl MappedFile {
     }
 
     /// Create a DWARF reader over the whole mapped file.
-    pub fn dwarf_reader(file: Arc<Self>) -> DwarfReader {
-        DwarfReader::new(DwarfBytes::Mapped(file), gimli::LittleEndian)
+    pub fn dwarf_reader(file: Arc<Self>, endian: DwarfEndian) -> DwarfReader {
+        DwarfReader::new(DwarfBytes::Mapped(file), endian)
     }
 
     /// Create a DWARF reader over a file range without copying the mapped data.
-    pub fn dwarf_reader_range(file: Arc<Self>, start: u64, size: u64) -> Option<DwarfReader> {
+    pub fn dwarf_reader_range(
+        file: Arc<Self>,
+        start: u64,
+        size: u64,
+        endian: DwarfEndian,
+    ) -> Option<DwarfReader> {
         let start = usize::try_from(start).ok()?;
         let size = usize::try_from(size).ok()?;
         let end = start.checked_add(size)?;
         if end > file.as_bytes().len() {
             return None;
         }
-        Some(Self::dwarf_reader(file).range(start..end))
+        Some(Self::dwarf_reader(file, endian).range(start..end))
     }
 }
 
@@ -66,13 +73,30 @@ impl Deref for DwarfBytes {
 unsafe impl gimli::StableDeref for DwarfBytes {}
 unsafe impl gimli::CloneStableDeref for DwarfBytes {}
 
-pub(crate) type DwarfReader = gimli::EndianReader<gimli::LittleEndian, DwarfBytes>;
+pub(crate) type DwarfEndian = gimli::RunTimeEndian;
+pub(crate) type DwarfReader = gimli::EndianReader<DwarfEndian, DwarfBytes>;
 pub(crate) type DwarfData = gimli::Dwarf<DwarfReader>;
 
+#[cfg(test)]
 pub(crate) fn dwarf_reader_from_arc(bytes: Arc<[u8]>) -> DwarfReader {
-    DwarfReader::new(DwarfBytes::Owned(bytes), gimli::LittleEndian)
+    dwarf_reader_from_arc_with_endian(bytes, gimli::RunTimeEndian::Little)
 }
 
-pub(crate) fn empty_dwarf_reader() -> DwarfReader {
-    dwarf_reader_from_arc(Arc::<[u8]>::from(&[][..]))
+#[cfg(test)]
+pub(crate) fn dwarf_reader_from_arc_with_endian(
+    bytes: Arc<[u8]>,
+    endian: DwarfEndian,
+) -> DwarfReader {
+    DwarfReader::new(DwarfBytes::Owned(bytes), endian)
+}
+
+pub(crate) fn empty_dwarf_reader_with_endian(endian: DwarfEndian) -> DwarfReader {
+    DwarfReader::new(DwarfBytes::Owned(Arc::<[u8]>::from(&[][..])), endian)
+}
+
+pub(crate) fn dwarf_endian_from_object(object: &object::File<'_>) -> DwarfEndian {
+    match object.endianness() {
+        Endianness::Little => gimli::RunTimeEndian::Little,
+        Endianness::Big => gimli::RunTimeEndian::Big,
+    }
 }

--- a/ghostscope-dwarf/src/binary/mod.rs
+++ b/ghostscope-dwarf/src/binary/mod.rs
@@ -2,6 +2,9 @@ pub(crate) mod debuglink;
 pub(crate) mod mapped_file;
 
 pub(crate) use debuglink::try_load_debug_file;
+pub(crate) use mapped_file::{
+    dwarf_endian_from_object, empty_dwarf_reader_with_endian, DwarfData, DwarfEndian, DwarfReader,
+    MappedFile,
+};
 #[cfg(test)]
-pub(crate) use mapped_file::dwarf_reader_from_arc;
-pub(crate) use mapped_file::{empty_dwarf_reader, DwarfData, DwarfReader, MappedFile};
+pub(crate) use mapped_file::{dwarf_reader_from_arc, dwarf_reader_from_arc_with_endian};

--- a/ghostscope-dwarf/src/core/evaluation.rs
+++ b/ghostscope-dwarf/src/core/evaluation.rs
@@ -235,7 +235,7 @@ impl EvaluationResult {
                 // CFA gives us the frame base, add the frame_offset to get final location
                 EvaluationResult::MemoryLocation(LocationResult::RegisterAddress {
                     register,
-                    offset: Some(offset + frame_offset),
+                    offset: Some(offset.saturating_add(frame_offset)),
                     size: None,
                 })
             }
@@ -676,5 +676,30 @@ impl fmt::Display for ComputeStep {
                 write!(f, "entry_value_lookup[cases:{}]", cases.len())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CfaResult, EvaluationResult, LocationResult};
+
+    #[test]
+    fn merge_with_cfa_saturates_register_plus_offset() {
+        let merged = EvaluationResult::Optimized.merge_with_cfa(
+            CfaResult::RegisterPlusOffset {
+                register: 7,
+                offset: i64::MAX - 2,
+            },
+            10,
+        );
+
+        assert_eq!(
+            merged,
+            EvaluationResult::MemoryLocation(LocationResult::RegisterAddress {
+                register: 7,
+                offset: Some(i64::MAX),
+                size: None,
+            })
+        );
     }
 }

--- a/ghostscope-dwarf/src/core/evaluation.rs
+++ b/ghostscope-dwarf/src/core/evaluation.rs
@@ -112,6 +112,15 @@ pub struct PieceResult {
     pub bit_offset: Option<u64>,
 }
 
+/// One caller-side case for recovering a callee's DW_OP_entry_value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntryValueCase {
+    /// Link-time caller return PC from DW_AT_call_return_pc.
+    pub caller_return_pc: u64,
+    /// Materialized ComputeStep[] that recover the original caller value.
+    pub value_steps: Vec<ComputeStep>,
+}
+
 /// Computation step for LLVM IR generation
 /// These map directly to LLVM IR operations that can be generated in eBPF
 #[derive(Debug, Clone, PartialEq)]
@@ -166,6 +175,13 @@ pub enum ComputeStep {
     If {
         then_branch: Vec<ComputeStep>,
         else_branch: Vec<ComputeStep>,
+    },
+
+    /// Recover a DW_OP_entry_value at runtime by matching the recovered caller
+    /// return PC against caller-side DW_AT_call_return_pc cases.
+    EntryValueLookup {
+        caller_pc_steps: Vec<ComputeStep>,
+        cases: Vec<EntryValueCase>,
     },
 }
 
@@ -461,6 +477,9 @@ impl DirectValueResult {
                     _ = then_branch;
                     _ = else_branch;
                 }
+                ComputeStep::EntryValueLookup { cases, .. } => {
+                    stack.push(format!("entry_value[{} cases]", cases.len()));
+                }
             }
         }
 
@@ -652,6 +671,9 @@ impl fmt::Display for ComputeStep {
                     then_branch.len(),
                     else_branch.len()
                 )
+            }
+            ComputeStep::EntryValueLookup { cases, .. } => {
+                write!(f, "entry_value_lookup[cases:{}]", cases.len())
             }
         }
     }

--- a/ghostscope-dwarf/src/index/block_index.rs
+++ b/ghostscope-dwarf/src/index/block_index.rs
@@ -554,14 +554,11 @@ impl<'a> BlockIndexBuilder<'a> {
         entry: &gimli::DebuggingInformationEntry<DwarfReader>,
     ) -> Option<u64> {
         let attr = entry.attr(gimli::constants::DW_AT_call_target)?;
-        let gimli::AttributeValue::Exprloc(expr) = attr.value() else {
+        let gimli::AttributeValue::Exprloc(mut expr) = attr.value() else {
             return None;
         };
-        let expr_bytes = expr.0.to_slice().ok()?;
-        let mut expression =
-            gimli::Expression(gimli::EndianSlice::new(&expr_bytes, gimli::LittleEndian));
-        let first = gimli::Operation::parse(&mut expression.0, unit.encoding()).ok()?;
-        if !expression.0.is_empty() {
+        let first = gimli::Operation::parse(&mut expr.0, unit.encoding()).ok()?;
+        if !expr.0.is_empty() {
             return None;
         }
         match first {
@@ -589,14 +586,11 @@ impl<'a> BlockIndexBuilder<'a> {
         entry: &gimli::DebuggingInformationEntry<DwarfReader>,
     ) -> Option<u16> {
         let attr = entry.attr(gimli::constants::DW_AT_location)?;
-        let gimli::AttributeValue::Exprloc(expr) = attr.value() else {
+        let gimli::AttributeValue::Exprloc(mut expr) = attr.value() else {
             return None;
         };
-        let expr_bytes = expr.0.to_slice().ok()?;
-        let mut expression =
-            gimli::Expression(gimli::EndianSlice::new(&expr_bytes, gimli::LittleEndian));
-        let first = gimli::Operation::parse(&mut expression.0, unit.encoding()).ok()?;
-        if !expression.0.is_empty() {
+        let first = gimli::Operation::parse(&mut expr.0, unit.encoding()).ok()?;
+        if !expr.0.is_empty() {
             return None;
         }
         match first {
@@ -623,9 +617,9 @@ impl<'a> BlockIndexBuilder<'a> {
                 _ => None,
             }
         })?;
-        let expr_bytes = expr.0.to_slice().ok()?;
         ExpressionEvaluator::parse_expression_to_steps_in_unit(
-            &expr_bytes,
+            expr.0.to_slice().ok().as_deref().unwrap_or(&[]),
+            expr.0.endian(),
             unit,
             self.dwarf,
             return_pc,
@@ -634,17 +628,15 @@ impl<'a> BlockIndexBuilder<'a> {
             None,
         )
         .ok()
-        .or_else(|| Self::lower_entry_value_call_site_register(unit, &expr_bytes))
+        .or_else(|| Self::lower_entry_value_call_site_register(unit, expr))
     }
 
     fn lower_entry_value_call_site_register(
         unit: &gimli::Unit<DwarfReader>,
-        expr_bytes: &[u8],
+        mut expr: gimli::Expression<DwarfReader>,
     ) -> Option<Vec<ComputeStep>> {
-        let mut expression =
-            gimli::Expression(gimli::EndianSlice::new(expr_bytes, gimli::LittleEndian));
-        let first = gimli::Operation::parse(&mut expression.0, unit.encoding()).ok()?;
-        if !expression.0.is_empty() {
+        let first = gimli::Operation::parse(&mut expr.0, unit.encoding()).ok()?;
+        if !expr.0.is_empty() {
             return None;
         }
         let gimli::Operation::EntryValue { expression: inner } = first else {
@@ -681,13 +673,13 @@ impl<'a> BlockIndexBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::binary::dwarf_reader_from_arc;
+    use crate::binary::{dwarf_reader_from_arc, dwarf_reader_from_arc_with_endian};
     use gimli::constants;
     use gimli::write::{
         Address, AttributeValue as WriteAttributeValue, Dwarf as WriteDwarf, EndianVec,
         Expression as WriteExpression, LineProgram, Sections, Unit,
     };
-    use gimli::{Format, LittleEndian, Register};
+    use gimli::{BigEndian, Format, LittleEndian, Register};
     use std::sync::Arc;
 
     fn build_call_site_fixture(
@@ -900,6 +892,95 @@ mod tests {
 
         let read_dwarf = dwarf_sections
             .borrow(|section| dwarf_reader_from_arc(Arc::<[u8]>::from(section.as_slice())));
+        let mut units = read_dwarf.units();
+        let header = units.next().unwrap().unwrap();
+        let cu_offset = header.debug_info_offset().unwrap();
+        (read_dwarf, cu_offset)
+    }
+
+    fn build_big_endian_call_target_expr_fixture(
+    ) -> (gimli::Dwarf<DwarfReader>, gimli::DebugInfoOffset) {
+        let encoding = gimli::Encoding {
+            format: Format::Dwarf32,
+            version: 5,
+            address_size: 8,
+        };
+
+        let mut dwarf = WriteDwarf::new();
+        let unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+        let unit = dwarf.units.get_mut(unit_id);
+        let root = unit.root();
+
+        let caller_id = unit.add(root, constants::DW_TAG_subprogram);
+        let caller = unit.get_mut(caller_id);
+        caller.set(
+            constants::DW_AT_name,
+            WriteAttributeValue::String(b"caller".to_vec()),
+        );
+        caller.set(
+            constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1000)),
+        );
+        caller.set(constants::DW_AT_high_pc, WriteAttributeValue::Udata(0x40));
+
+        let callee_id = unit.add(root, constants::DW_TAG_subprogram);
+        let callee = unit.get_mut(callee_id);
+        callee.set(
+            constants::DW_AT_name,
+            WriteAttributeValue::String(b"callee".to_vec()),
+        );
+        callee.set(
+            constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1200)),
+        );
+        callee.set(constants::DW_AT_high_pc, WriteAttributeValue::Udata(0x10));
+
+        let call_site_id = unit.add(caller_id, constants::DW_TAG_call_site);
+        let mut target_expr = WriteExpression::new();
+        target_expr.op_addr(Address::Constant(0x1200));
+        unit.get_mut(call_site_id).set(
+            constants::DW_AT_call_target,
+            WriteAttributeValue::Exprloc(target_expr),
+        );
+        unit.get_mut(call_site_id).set(
+            constants::DW_AT_call_return_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1018)),
+        );
+
+        let param_id = unit.add(call_site_id, constants::DW_TAG_call_site_parameter);
+        let param = unit.get_mut(param_id);
+        let mut location = WriteExpression::new();
+        location.op_reg(Register(5));
+        param.set(
+            constants::DW_AT_location,
+            WriteAttributeValue::Exprloc(location),
+        );
+        let mut value = WriteExpression::new();
+        value.op_constu(42);
+        param.set(
+            constants::DW_AT_call_value,
+            WriteAttributeValue::Exprloc(value),
+        );
+
+        let mut sections = Sections::new(EndianVec::new(BigEndian));
+        dwarf.write(&mut sections).unwrap();
+
+        let dwarf_sections: gimli::DwarfSections<Vec<u8>> = gimli::DwarfSections::load(|id| {
+            Ok::<_, gimli::Error>(
+                sections
+                    .get(id)
+                    .map(|section| section.slice().to_vec())
+                    .unwrap_or_default(),
+            )
+        })
+        .unwrap();
+
+        let read_dwarf = dwarf_sections.borrow(|section| {
+            dwarf_reader_from_arc_with_endian(
+                Arc::<[u8]>::from(section.as_slice()),
+                gimli::RunTimeEndian::Big,
+            )
+        });
         let mut units = read_dwarf.units();
         let header = units.next().unwrap().unwrap();
         let cu_offset = header.debug_info_offset().unwrap();
@@ -1176,6 +1257,30 @@ mod tests {
             callee.incoming_call_sites.is_empty(),
             "call-site DW_AT_low_pc should not resolve a callee link"
         );
+    }
+
+    #[test]
+    fn add_functions_links_big_endian_incoming_call_sites_by_call_target_expr() {
+        let (dwarf, cu_offset) = build_big_endian_call_target_expr_fixture();
+        let builder = BlockIndexBuilder::new(&dwarf);
+        let functions = builder
+            .build_for_unit(cu_offset)
+            .expect("fixture CU should build");
+
+        let mut block_index = BlockIndex::new();
+        block_index.add_functions(functions);
+
+        let callee = block_index
+            .find_function_by_pc(0x1200)
+            .expect("callee function should be indexed");
+        let incoming = callee
+            .incoming_call_sites
+            .get(&0x1018)
+            .map(Vec::as_slice)
+            .expect("callee should have one incoming call site");
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].call_origin, None);
+        assert_eq!(incoming[0].call_target, Some(0x1200));
     }
 
     #[test]

--- a/ghostscope-dwarf/src/index/block_index.rs
+++ b/ghostscope-dwarf/src/index/block_index.rs
@@ -208,6 +208,17 @@ impl FunctionBlocks {
         }
         out
     }
+
+    /// True when `pc` is inside an inlined-subroutine scope in this function.
+    pub fn is_inline_context_at(&self, pc: u64) -> bool {
+        if !self.function_contains_pc(pc) {
+            return false;
+        }
+        self.block_path_for_pc(pc)
+            .into_iter()
+            .skip(1)
+            .any(|idx| self.nodes[idx].entry_pc.is_some())
+    }
 }
 
 /// Global per-module block index
@@ -358,6 +369,71 @@ impl<'a> BlockIndexBuilder<'a> {
             }
         }
         Some(fb)
+    }
+
+    /// Scan DWARF directly for caller-side call-site parameters that target `callee`.
+    /// This is used as an on-demand fallback when the block index has not yet linked
+    /// all callers for a non-inline DW_OP_entry_value lookup.
+    pub fn collect_incoming_entry_value_parameters(
+        &self,
+        callee: &FunctionBlocks,
+        register: u16,
+    ) -> Vec<(u64, CallSiteParameter)> {
+        let mut out = Vec::new();
+        let mut units = self.dwarf.units();
+        while let Ok(Some(header)) = units.next() {
+            let Ok(unit) = self.dwarf.unit(header) else {
+                continue;
+            };
+            let mut entries = unit.entries();
+            while let Ok(Some(entry)) = entries.next_dfs() {
+                if !matches!(
+                    entry.tag(),
+                    gimli::constants::DW_TAG_call_site | gimli::constants::DW_TAG_GNU_call_site
+                ) {
+                    continue;
+                }
+
+                let Some(return_pc) =
+                    self.resolve_address_attr(&unit, entry, gimli::constants::DW_AT_call_return_pc)
+                else {
+                    continue;
+                };
+
+                let call_origin = Self::resolve_call_site_origin(self.dwarf, &unit, entry);
+                let call_target = self.resolve_call_site_target(&unit, entry);
+                if !Self::call_site_targets_function(callee, call_origin, call_target) {
+                    continue;
+                }
+
+                let Ok(mut tree) = unit.entries_tree(Some(entry.offset())) else {
+                    continue;
+                };
+                let Ok(root) = tree.root() else {
+                    continue;
+                };
+                let mut children = root.children();
+                while let Ok(Some(child)) = children.next() {
+                    let child_entry = child.entry();
+                    if !matches!(
+                        child_entry.tag(),
+                        gimli::constants::DW_TAG_call_site_parameter
+                            | gimli::constants::DW_TAG_GNU_call_site_parameter
+                    ) {
+                        continue;
+                    }
+                    let Some(parameter) =
+                        self.parse_call_site_parameter(&unit, child_entry, return_pc)
+                    else {
+                        continue;
+                    };
+                    if parameter.callee_register == register {
+                        out.push((return_pc, parameter));
+                    }
+                }
+            }
+        }
+        out
     }
 
     fn build_blocks_for_function(
@@ -667,6 +743,19 @@ impl<'a> BlockIndexBuilder<'a> {
             gimli::AttributeValue::DebugAddrIndex(index) => self.dwarf.address(unit, index).ok(),
             _ => None,
         }
+    }
+
+    fn call_site_targets_function(
+        callee: &FunctionBlocks,
+        call_origin: Option<gimli::DebugInfoOffset>,
+        call_target: Option<u64>,
+    ) -> bool {
+        if callee.abs_die_offset.is_some() && call_origin == callee.abs_die_offset {
+            return true;
+        }
+        call_target
+            .map(|target| callee.function_contains_pc(target))
+            .unwrap_or(false)
     }
 }
 
@@ -1229,6 +1318,35 @@ mod tests {
         assert_eq!(incoming.len(), 1);
         assert_eq!(incoming[0].call_origin, None);
         assert_eq!(incoming[0].call_target, Some(0x1200));
+    }
+
+    #[test]
+    fn collect_incoming_entry_value_parameters_scans_dwarf_without_preindexed_callers() {
+        let (dwarf, _cu_offset) =
+            build_incoming_call_site_fixture_with_target(IncomingCallSiteTarget::CallTargetExpr);
+        let builder = BlockIndexBuilder::new(&dwarf);
+        let callee = FunctionBlocks {
+            cu_offset: gimli::DebugInfoOffset(1),
+            die_offset: gimli::UnitOffset(0),
+            abs_die_offset: None,
+            ranges: vec![(0x1200, 0x1210)],
+            nodes: vec![],
+            block_addr_map: BTreeMap::new(),
+            call_sites: BTreeMap::new(),
+            incoming_call_sites: BTreeMap::new(),
+        };
+
+        let incoming = builder.collect_incoming_entry_value_parameters(&callee, 5);
+        assert_eq!(
+            incoming,
+            vec![(
+                0x1018,
+                CallSiteParameter {
+                    callee_register: 5,
+                    caller_value_steps: vec![ComputeStep::PushConstant(42)],
+                }
+            )]
+        );
     }
 
     #[test]

--- a/ghostscope-dwarf/src/index/block_index.rs
+++ b/ghostscope-dwarf/src/index/block_index.rs
@@ -34,10 +34,16 @@ pub struct CallSiteParameter {
 /// A call-site record keyed by DW_AT_call_return_pc.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CallSiteRecord {
+    /// Compilation unit offset for the caller-side call-site DIE.
+    pub cu_offset: gimli::DebugInfoOffset,
     /// DIE offset for the call-site itself.
     pub die_offset: gimli::UnitOffset,
     /// Return PC immediately after the call instruction.
     pub return_pc: u64,
+    /// Target callee resolved from DW_AT_call_origin when available.
+    pub call_origin: Option<gimli::DebugInfoOffset>,
+    /// Target callee address from DW_AT_call_target when available.
+    pub call_target: Option<u64>,
     /// Callee parameter bindings available at this call site.
     pub parameters: Vec<CallSiteParameter>,
 }
@@ -84,6 +90,8 @@ impl BlockNode {
 pub struct FunctionBlocks {
     pub cu_offset: gimli::DebugInfoOffset,
     pub die_offset: gimli::UnitOffset,
+    /// Absolute DIE offset for this function in .debug_info.
+    pub abs_die_offset: Option<gimli::DebugInfoOffset>,
     /// Function ranges
     pub ranges: Vec<(u64, u64)>,
     /// Root node is index 0
@@ -92,6 +100,9 @@ pub struct FunctionBlocks {
     pub block_addr_map: BTreeMap<u64, usize>,
     /// Caller-side call-site records keyed by DW_AT_call_return_pc.
     pub call_sites: BTreeMap<u64, Vec<CallSiteRecord>>,
+    /// Incoming caller-side call-site records for this callee, keyed by the
+    /// caller's DW_AT_call_return_pc.
+    pub incoming_call_sites: BTreeMap<u64, Vec<CallSiteRecord>>,
 }
 
 impl FunctionBlocks {
@@ -102,10 +113,12 @@ impl FunctionBlocks {
         Self {
             cu_offset,
             die_offset,
+            abs_die_offset: None,
             ranges: Vec::new(),
             nodes,
             block_addr_map: BTreeMap::new(),
             call_sites: BTreeMap::new(),
+            incoming_call_sites: BTreeMap::new(),
         }
     }
 
@@ -179,6 +192,22 @@ impl FunctionBlocks {
         }
         None
     }
+
+    /// Collect all incoming caller-side call-site bindings for a callee
+    /// register. These are used for non-inline DW_OP_entry_value recovery.
+    pub fn incoming_entry_value_parameters(&self, register: u16) -> Vec<(u64, &CallSiteParameter)> {
+        let mut out = Vec::new();
+        for (return_pc, records) in &self.incoming_call_sites {
+            for record in records {
+                for parameter in &record.parameters {
+                    if parameter.callee_register == register {
+                        out.push((*return_pc, parameter));
+                    }
+                }
+            }
+        }
+        out
+    }
 }
 
 /// Global per-module block index
@@ -196,15 +225,8 @@ impl BlockIndex {
 
     /// Find a function containing PC via start-addr map and range verification
     pub fn find_function_by_pc(&self, pc: u64) -> Option<&FunctionBlocks> {
-        let mut cand: Option<&FunctionBlocks> = None;
-        for (_, &fi) in self.func_addr_map.range(..=pc).rev() {
-            let f = &self.functions[fi];
-            if f.function_contains_pc(pc) {
-                cand = Some(f);
-                break;
-            }
-        }
-        cand
+        self.find_function_index_by_pc(pc)
+            .map(|index| &self.functions[index])
     }
 
     /// Add built functions and update address map
@@ -215,6 +237,56 @@ impl BlockIndex {
                 self.func_addr_map.insert(*lo, idx);
             }
             self.functions.push(fb);
+        }
+        self.rebuild_incoming_call_site_links();
+    }
+
+    fn find_function_index_by_pc(&self, pc: u64) -> Option<usize> {
+        for (_, &fi) in self.func_addr_map.range(..=pc).rev() {
+            let f = &self.functions[fi];
+            if f.function_contains_pc(pc) {
+                return Some(fi);
+            }
+        }
+        None
+    }
+
+    fn rebuild_incoming_call_site_links(&mut self) {
+        for function in &mut self.functions {
+            function.incoming_call_sites.clear();
+        }
+
+        let mut functions_by_die = BTreeMap::new();
+        for (index, function) in self.functions.iter().enumerate() {
+            if let Some(abs_die_offset) = function.abs_die_offset {
+                functions_by_die.insert(abs_die_offset, index);
+            }
+        }
+
+        let incoming_links: Vec<(usize, CallSiteRecord)> = self
+            .functions
+            .iter()
+            .flat_map(|function| function.call_sites.values())
+            .flat_map(|records| records.iter())
+            .filter_map(|record| {
+                let callee_index = record
+                    .call_origin
+                    .and_then(|origin| functions_by_die.get(&origin).copied())
+                    .or_else(|| {
+                        record
+                            .call_target
+                            .and_then(|target| self.find_function_index_by_pc(target))
+                    })?;
+                Some((callee_index, record.clone()))
+            })
+            .collect();
+
+        for (callee_index, record) in incoming_links {
+            self.functions[callee_index]
+                .incoming_call_sites
+                .entry(record.return_pc)
+                .or_default()
+                .push(record);
         }
     }
 }
@@ -240,6 +312,7 @@ impl<'a> BlockIndexBuilder<'a> {
         while let Ok(Some(entry)) = entries.next_dfs() {
             if entry.tag() == gimli::constants::DW_TAG_subprogram {
                 let mut fb = FunctionBlocks::new(cu_offset, entry.offset());
+                fb.abs_die_offset = entry.offset().to_debug_info_offset(&unit.header);
                 if let Ok(ranges) = RangeExtractor::extract_all_ranges(entry, &unit, self.dwarf) {
                     fb.ranges = ranges;
                 }
@@ -271,6 +344,7 @@ impl<'a> BlockIndexBuilder<'a> {
             return None;
         }
         let mut fb = FunctionBlocks::new(cu_offset, die_offset);
+        fb.abs_die_offset = entry.offset().to_debug_info_offset(&unit.header);
         if let Ok(ranges) = RangeExtractor::extract_all_ranges(&entry, &unit, self.dwarf) {
             fb.ranges = ranges;
         }
@@ -424,8 +498,11 @@ impl<'a> BlockIndexBuilder<'a> {
         };
 
         let mut record = CallSiteRecord {
+            cu_offset: fb.cu_offset,
             die_offset: entry.offset(),
             return_pc,
+            call_origin: Self::resolve_call_site_origin(self.dwarf, unit, entry),
+            call_target: self.resolve_call_site_target(unit, entry),
             parameters: Vec::new(),
         };
 
@@ -446,6 +523,51 @@ impl<'a> BlockIndexBuilder<'a> {
         }
 
         fb.call_sites.entry(return_pc).or_default().push(record);
+    }
+
+    fn resolve_call_site_origin(
+        dwarf: &gimli::Dwarf<DwarfReader>,
+        unit: &gimli::Unit<DwarfReader>,
+        entry: &gimli::DebuggingInformationEntry<DwarfReader>,
+    ) -> Option<gimli::DebugInfoOffset> {
+        entry
+            .attr_value(gimli::constants::DW_AT_call_origin)
+            .and_then(|value| {
+                resolve_origin_entry(dwarf, unit, value)
+                    .ok()
+                    .flatten()
+                    .map(|(debug_info_offset, _, _)| debug_info_offset)
+            })
+    }
+
+    fn resolve_call_site_target(
+        &self,
+        unit: &gimli::Unit<DwarfReader>,
+        entry: &gimli::DebuggingInformationEntry<DwarfReader>,
+    ) -> Option<u64> {
+        self.resolve_address_attr(unit, entry, gimli::constants::DW_AT_call_target)
+            .or_else(|| Self::parse_call_target_expr_address(unit, entry))
+    }
+
+    fn parse_call_target_expr_address(
+        unit: &gimli::Unit<DwarfReader>,
+        entry: &gimli::DebuggingInformationEntry<DwarfReader>,
+    ) -> Option<u64> {
+        let attr = entry.attr(gimli::constants::DW_AT_call_target)?;
+        let gimli::AttributeValue::Exprloc(expr) = attr.value() else {
+            return None;
+        };
+        let expr_bytes = expr.0.to_slice().ok()?;
+        let mut expression =
+            gimli::Expression(gimli::EndianSlice::new(&expr_bytes, gimli::LittleEndian));
+        let first = gimli::Operation::parse(&mut expression.0, unit.encoding()).ok()?;
+        if !expression.0.is_empty() {
+            return None;
+        }
+        match first {
+            gimli::Operation::Address { address } => Some(address),
+            _ => None,
+        }
     }
 
     fn parse_call_site_parameter(
@@ -664,6 +786,126 @@ mod tests {
         (read_dwarf, cu_offset)
     }
 
+    fn build_incoming_call_site_fixture() -> (gimli::Dwarf<DwarfReader>, gimli::DebugInfoOffset) {
+        build_incoming_call_site_fixture_with_target(IncomingCallSiteTarget::CallOrigin)
+    }
+
+    #[derive(Clone, Copy)]
+    enum IncomingCallSiteTarget {
+        CallOrigin,
+        CallTargetAttr,
+        CallTargetExpr,
+        LowPcOnly,
+    }
+
+    fn build_incoming_call_site_fixture_with_target(
+        target_kind: IncomingCallSiteTarget,
+    ) -> (gimli::Dwarf<DwarfReader>, gimli::DebugInfoOffset) {
+        let encoding = gimli::Encoding {
+            format: Format::Dwarf32,
+            version: 5,
+            address_size: 8,
+        };
+
+        let mut dwarf = WriteDwarf::new();
+        let unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+        let unit = dwarf.units.get_mut(unit_id);
+        let root = unit.root();
+
+        let caller_id = unit.add(root, constants::DW_TAG_subprogram);
+        let caller = unit.get_mut(caller_id);
+        caller.set(
+            constants::DW_AT_name,
+            WriteAttributeValue::String(b"caller".to_vec()),
+        );
+        caller.set(
+            constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1000)),
+        );
+        caller.set(constants::DW_AT_high_pc, WriteAttributeValue::Udata(0x40));
+
+        let callee_id = unit.add(root, constants::DW_TAG_subprogram);
+        let callee = unit.get_mut(callee_id);
+        callee.set(
+            constants::DW_AT_name,
+            WriteAttributeValue::String(b"callee".to_vec()),
+        );
+        callee.set(
+            constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1200)),
+        );
+        callee.set(constants::DW_AT_high_pc, WriteAttributeValue::Udata(0x10));
+
+        let call_site_id = unit.add(caller_id, constants::DW_TAG_call_site);
+        match target_kind {
+            IncomingCallSiteTarget::CallOrigin => {
+                unit.get_mut(call_site_id).set(
+                    constants::DW_AT_call_origin,
+                    WriteAttributeValue::UnitRef(callee_id),
+                );
+            }
+            IncomingCallSiteTarget::CallTargetAttr => {
+                unit.get_mut(call_site_id).set(
+                    constants::DW_AT_call_target,
+                    WriteAttributeValue::Address(Address::Constant(0x1200)),
+                );
+            }
+            IncomingCallSiteTarget::CallTargetExpr => {
+                let mut target_expr = WriteExpression::new();
+                target_expr.op_addr(Address::Constant(0x1200));
+                unit.get_mut(call_site_id).set(
+                    constants::DW_AT_call_target,
+                    WriteAttributeValue::Exprloc(target_expr),
+                );
+            }
+            IncomingCallSiteTarget::LowPcOnly => {
+                unit.get_mut(call_site_id).set(
+                    constants::DW_AT_low_pc,
+                    WriteAttributeValue::Address(Address::Constant(0x1014)),
+                );
+            }
+        }
+        unit.get_mut(call_site_id).set(
+            constants::DW_AT_call_return_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1018)),
+        );
+
+        let param_id = unit.add(call_site_id, constants::DW_TAG_call_site_parameter);
+        let param = unit.get_mut(param_id);
+        let mut location = WriteExpression::new();
+        location.op_reg(Register(5));
+        param.set(
+            constants::DW_AT_location,
+            WriteAttributeValue::Exprloc(location),
+        );
+        let mut value = WriteExpression::new();
+        value.op_constu(42);
+        param.set(
+            constants::DW_AT_call_value,
+            WriteAttributeValue::Exprloc(value),
+        );
+
+        let mut sections = Sections::new(EndianVec::new(LittleEndian));
+        dwarf.write(&mut sections).unwrap();
+
+        let dwarf_sections: gimli::DwarfSections<Vec<u8>> = gimli::DwarfSections::load(|id| {
+            Ok::<_, gimli::Error>(
+                sections
+                    .get(id)
+                    .map(|section| section.slice().to_vec())
+                    .unwrap_or_default(),
+            )
+        })
+        .unwrap();
+
+        let read_dwarf = dwarf_sections
+            .borrow(|section| dwarf_reader_from_arc(Arc::<[u8]>::from(section.as_slice())));
+        let mut units = read_dwarf.units();
+        let header = units.next().unwrap().unwrap();
+        let cu_offset = header.debug_info_offset().unwrap();
+        (read_dwarf, cu_offset)
+    }
+
     #[test]
     fn build_for_unit_indexes_standard_call_site_values() {
         let (dwarf, cu_offset) = build_call_site_fixture(
@@ -685,6 +927,7 @@ mod tests {
             .map(Vec::as_slice)
             .expect("call-site return_pc should be indexed");
         assert_eq!(records.len(), 1);
+        assert_eq!(records[0].cu_offset, cu_offset);
         assert_eq!(records[0].return_pc, 0x1018);
         assert_eq!(records[0].parameters.len(), 2);
         assert_eq!(records[0].parameters[0].callee_register, 5);
@@ -724,6 +967,7 @@ mod tests {
             .map(Vec::as_slice)
             .expect("GNU call-site return_pc should be indexed");
         assert_eq!(records.len(), 1);
+        assert_eq!(records[0].cu_offset, cu_offset);
         assert_eq!(records[0].parameters.len(), 2);
         assert_eq!(records[0].parameters[0].callee_register, 5);
         assert_eq!(
@@ -827,13 +1071,124 @@ mod tests {
     }
 
     #[test]
+    fn add_functions_links_incoming_call_sites_by_call_origin() {
+        let (dwarf, cu_offset) = build_incoming_call_site_fixture();
+        let builder = BlockIndexBuilder::new(&dwarf);
+        let functions = builder
+            .build_for_unit(cu_offset)
+            .expect("fixture CU should build");
+
+        let mut block_index = BlockIndex::new();
+        block_index.add_functions(functions);
+
+        let callee = block_index
+            .find_function_by_pc(0x1200)
+            .expect("callee function should be indexed");
+        let incoming = callee
+            .incoming_call_sites
+            .get(&0x1018)
+            .map(Vec::as_slice)
+            .expect("callee should have one incoming call site");
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].return_pc, 0x1018);
+        assert_eq!(incoming[0].parameters.len(), 1);
+        assert_eq!(incoming[0].parameters[0].callee_register, 5);
+        assert_eq!(
+            incoming[0].parameters[0].caller_value_steps,
+            vec![ComputeStep::PushConstant(42)]
+        );
+        assert_eq!(incoming[0].call_origin, callee.abs_die_offset);
+    }
+
+    #[test]
+    fn add_functions_links_incoming_call_sites_by_call_target_attr() {
+        let (dwarf, cu_offset) =
+            build_incoming_call_site_fixture_with_target(IncomingCallSiteTarget::CallTargetAttr);
+        let builder = BlockIndexBuilder::new(&dwarf);
+        let functions = builder
+            .build_for_unit(cu_offset)
+            .expect("fixture CU should build");
+
+        let mut block_index = BlockIndex::new();
+        block_index.add_functions(functions);
+
+        let callee = block_index
+            .find_function_by_pc(0x1200)
+            .expect("callee function should be indexed");
+        let incoming = callee
+            .incoming_call_sites
+            .get(&0x1018)
+            .map(Vec::as_slice)
+            .expect("callee should have one incoming call site");
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].call_origin, None);
+        assert_eq!(incoming[0].call_target, Some(0x1200));
+    }
+
+    #[test]
+    fn add_functions_links_incoming_call_sites_by_call_target_expr() {
+        let (dwarf, cu_offset) =
+            build_incoming_call_site_fixture_with_target(IncomingCallSiteTarget::CallTargetExpr);
+        let builder = BlockIndexBuilder::new(&dwarf);
+        let functions = builder
+            .build_for_unit(cu_offset)
+            .expect("fixture CU should build");
+
+        let mut block_index = BlockIndex::new();
+        block_index.add_functions(functions);
+
+        let callee = block_index
+            .find_function_by_pc(0x1200)
+            .expect("callee function should be indexed");
+        let incoming = callee
+            .incoming_call_sites
+            .get(&0x1018)
+            .map(Vec::as_slice)
+            .expect("callee should have one incoming call site");
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].call_origin, None);
+        assert_eq!(incoming[0].call_target, Some(0x1200));
+    }
+
+    #[test]
+    fn add_functions_does_not_treat_call_site_low_pc_as_callee_target() {
+        let (dwarf, cu_offset) =
+            build_incoming_call_site_fixture_with_target(IncomingCallSiteTarget::LowPcOnly);
+        let builder = BlockIndexBuilder::new(&dwarf);
+        let functions = builder
+            .build_for_unit(cu_offset)
+            .expect("fixture CU should build");
+
+        let mut block_index = BlockIndex::new();
+        block_index.add_functions(functions);
+
+        let caller = block_index
+            .find_function_by_pc(0x1000)
+            .expect("caller function should be indexed");
+        let callee = block_index
+            .find_function_by_pc(0x1200)
+            .expect("callee function should be indexed");
+        assert!(
+            caller.incoming_call_sites.is_empty(),
+            "call-site DW_AT_low_pc should not create a self-link"
+        );
+        assert!(
+            callee.incoming_call_sites.is_empty(),
+            "call-site DW_AT_low_pc should not resolve a callee link"
+        );
+    }
+
+    #[test]
     fn entry_value_parameter_lookup_uses_nearest_prior_return_pc() {
         let mut function = FunctionBlocks::new(gimli::DebugInfoOffset(0), gimli::UnitOffset(0));
         function.call_sites.insert(
             0x1018,
             vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(0),
                 die_offset: gimli::UnitOffset(1),
                 return_pc: 0x1018,
+                call_origin: None,
+                call_target: None,
                 parameters: vec![CallSiteParameter {
                     callee_register: 5,
                     caller_value_steps: vec![ComputeStep::PushConstant(11)],
@@ -843,8 +1198,11 @@ mod tests {
         function.call_sites.insert(
             0x1030,
             vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(0),
                 die_offset: gimli::UnitOffset(2),
                 return_pc: 0x1030,
+                call_origin: None,
+                call_target: None,
                 parameters: vec![CallSiteParameter {
                     callee_register: 5,
                     caller_value_steps: vec![ComputeStep::PushConstant(22)],

--- a/ghostscope-dwarf/src/index/cfi_index.rs
+++ b/ghostscope-dwarf/src/index/cfi_index.rs
@@ -4,7 +4,7 @@
 //! by utilizing eh_frame_hdr's binary search table when available.
 
 use crate::{
-    binary::{DwarfReader, MappedFile},
+    binary::{dwarf_endian_from_object, DwarfReader, MappedFile},
     core::{CallerFrameRecovery, CfaResult, ComputeStep, Result},
 };
 use anyhow::{anyhow, Context};
@@ -46,6 +46,7 @@ impl CfiIndex {
         let object = file_data
             .parse_object()
             .context("Failed to parse object file")?;
+        let endian = dwarf_endian_from_object(&object);
 
         // Load eh_frame section (required)
         let eh_frame_section = object
@@ -56,9 +57,13 @@ impl CfiIndex {
         let (eh_frame_start, eh_frame_size) = eh_frame_section
             .file_range()
             .ok_or_else(|| anyhow!(".eh_frame section has no file range"))?;
-        let eh_frame_reader =
-            MappedFile::dwarf_reader_range(Arc::clone(&file_data), eh_frame_start, eh_frame_size)
-                .ok_or_else(|| anyhow!("Invalid .eh_frame range in mapped file"))?;
+        let eh_frame_reader = MappedFile::dwarf_reader_range(
+            Arc::clone(&file_data),
+            eh_frame_start,
+            eh_frame_size,
+            endian,
+        )
+        .ok_or_else(|| anyhow!("Invalid .eh_frame range in mapped file"))?;
         let eh_frame = EhFrame::from(eh_frame_reader);
 
         // Try to load eh_frame_hdr for fast lookup (optional)
@@ -67,9 +72,13 @@ impl CfiIndex {
                 let (hdr_start, hdr_size) = hdr_section_obj
                     .file_range()
                     .ok_or_else(|| anyhow!(".eh_frame_hdr section has no file range"))?;
-                let hdr_reader =
-                    MappedFile::dwarf_reader_range(Arc::clone(&file_data), hdr_start, hdr_size)
-                        .ok_or_else(|| anyhow!("Invalid .eh_frame_hdr range in mapped file"))?;
+                let hdr_reader = MappedFile::dwarf_reader_range(
+                    Arc::clone(&file_data),
+                    hdr_start,
+                    hdr_size,
+                    endian,
+                )
+                .ok_or_else(|| anyhow!("Invalid .eh_frame_hdr range in mapped file"))?;
                 let hdr_section = EhFrameHdr::from(hdr_reader);
 
                 // Parse with proper address_size

--- a/ghostscope-dwarf/src/objfile/loading.rs
+++ b/ghostscope-dwarf/src/objfile/loading.rs
@@ -1,6 +1,9 @@
 use super::LoadedObjfile;
 use crate::{
-    binary::{empty_dwarf_reader, try_load_debug_file, DwarfData, MappedFile},
+    binary::{
+        dwarf_endian_from_object, empty_dwarf_reader_with_endian, try_load_debug_file, DwarfData,
+        MappedFile,
+    },
     core::{mapping::ModuleMapping, Result},
     index::{BlockIndex, CfiIndex, TypeNameIndex},
     parser::DetailedParser,
@@ -239,18 +242,20 @@ impl LoadedObjfile {
 
     fn load_dwarf_sections(file_data: &Arc<MappedFile>) -> Result<DwarfData> {
         let object = file_data.parse_object()?;
+        let endian = dwarf_endian_from_object(&object);
 
         let load_section = |id: gimli::SectionId| -> Result<_> {
             if let Some(section) = object.section_by_name(id.name()) {
                 if let Some((start, size)) = section.file_range() {
-                    MappedFile::dwarf_reader_range(Arc::clone(file_data), start, size).ok_or_else(
-                        || anyhow::anyhow!("Invalid DWARF section range for {}", id.name()),
-                    )
+                    MappedFile::dwarf_reader_range(Arc::clone(file_data), start, size, endian)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("Invalid DWARF section range for {}", id.name())
+                        })
                 } else {
-                    Ok(empty_dwarf_reader())
+                    Ok(empty_dwarf_reader_with_endian(endian))
                 }
             } else {
-                Ok(empty_dwarf_reader())
+                Ok(empty_dwarf_reader_with_endian(endian))
             }
         };
 

--- a/ghostscope-dwarf/src/objfile/variables.rs
+++ b/ghostscope-dwarf/src/objfile/variables.rs
@@ -628,6 +628,7 @@ impl LoadedObjfile {
                         gimli::AttributeValue::Exprloc(expr) => {
                             ExpressionEvaluator::parse_expression_in_unit(
                                 expr.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                expr.0.endian(),
                                 &unit,
                                 dwarf,
                                 pc,

--- a/ghostscope-dwarf/src/parser/expression_evaluator.rs
+++ b/ghostscope-dwarf/src/parser/expression_evaluator.rs
@@ -7,7 +7,7 @@ use crate::core::{
     ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
     MemoryAccessSize, Result,
 };
-use crate::index::{CfiIndex, FunctionBlocks};
+use crate::index::{BlockIndexBuilder, CfiIndex, FunctionBlocks};
 use crate::semantics::{range_contains_pc, resolve_attr_with_unit_origins};
 use gimli::{read::RawLocListEntry, EndianSlice, Expression, Operation, Reader};
 use tracing::{debug, trace, warn};
@@ -366,6 +366,7 @@ impl ExpressionEvaluator {
                                 match Self::resolve_entry_value_register(
                                     address,
                                     register.0,
+                                    dwarf,
                                     function_context,
                                     cfi_index,
                                 ) {
@@ -382,6 +383,20 @@ impl ExpressionEvaluator {
                                         return Ok(EvaluationResult::Optimized);
                                     }
                                 }
+                            }
+                            Operation::RegisterOffset {
+                                register, offset, ..
+                            } => {
+                                let steps = Self::resolve_entry_value_register_offset(
+                                    address,
+                                    register.0,
+                                    *offset,
+                                    encoding.address_size,
+                                    dwarf,
+                                    function_context,
+                                    cfi_index,
+                                )?;
+                                operations.push(ParsedOperation::PrecomputedSteps(steps));
                             }
                             _ => {
                                 debug!("Unsupported EntryValue inner op: {:?}", inner_ops[0]);
@@ -1275,27 +1290,51 @@ impl ExpressionEvaluator {
     fn resolve_entry_value_register(
         current_pc: u64,
         register: u16,
+        dwarf: Option<&gimli::Dwarf<DwarfReader>>,
         function_context: Option<&FunctionBlocks>,
         cfi_index: Option<&CfiIndex>,
     ) -> Result<Vec<ComputeStep>> {
         let function_context = function_context.ok_or_else(|| {
             anyhow::anyhow!("DW_OP_entry_value requires function call-site context")
         })?;
-        if let Some(parameter) = function_context.entry_value_parameter_for_pc(current_pc, register)
-        {
-            return Self::materialize_caller_value_steps(
-                &parameter.caller_value_steps,
-                current_pc,
-                cfi_index,
-            );
+        if function_context.is_inline_context_at(current_pc) {
+            if let Some(parameter) =
+                function_context.entry_value_parameter_for_pc(current_pc, register)
+            {
+                return Self::materialize_caller_value_steps(
+                    &parameter.caller_value_steps,
+                    current_pc,
+                    cfi_index,
+                );
+            }
         }
 
-        Self::build_incoming_entry_value_lookup(current_pc, register, function_context, cfi_index)
+        Self::build_incoming_entry_value_lookup(
+            current_pc,
+            register,
+            dwarf,
+            function_context,
+            cfi_index,
+        )
+        .or_else(|incoming_error| {
+            Self::recover_entry_register_from_cfi(current_pc, register, cfi_index).map_err(
+                |cfi_error| {
+                    anyhow::anyhow!(
+                        "failed to recover DW_OP_entry_value register {} at 0x{:x}: {}; fallback via CFI also failed: {}",
+                        register,
+                        current_pc,
+                        incoming_error,
+                        cfi_error
+                    )
+                },
+            )
+        })
     }
 
     fn build_incoming_entry_value_lookup(
         current_pc: u64,
         register: u16,
+        dwarf: Option<&gimli::Dwarf<DwarfReader>>,
         function_context: &FunctionBlocks,
         cfi_index: Option<&CfiIndex>,
     ) -> Result<Vec<ComputeStep>> {
@@ -1308,11 +1347,11 @@ impl ExpressionEvaluator {
         let recovery = cfi_index.recover_caller_frame(current_pc, &[])?;
 
         let mut cases_by_return_pc = std::collections::BTreeMap::<u64, Vec<ComputeStep>>::new();
-        for (caller_return_pc, parameter) in
-            function_context.incoming_entry_value_parameters(register)
-        {
+        let parameters =
+            Self::collect_incoming_entry_value_parameter_steps(register, dwarf, function_context);
+        for (caller_return_pc, caller_value_steps) in parameters {
             let value_steps = Self::materialize_caller_value_steps(
-                &parameter.caller_value_steps,
+                &caller_value_steps,
                 current_pc,
                 Some(cfi_index),
             )
@@ -1354,6 +1393,154 @@ impl ExpressionEvaluator {
             recovery.caller_pc_steps,
             cases_by_return_pc,
         ))
+    }
+
+    fn collect_incoming_entry_value_parameter_steps(
+        register: u16,
+        dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        function_context: &FunctionBlocks,
+    ) -> Vec<(u64, Vec<ComputeStep>)> {
+        let indexed_parameters: Vec<_> = function_context
+            .incoming_entry_value_parameters(register)
+            .into_iter()
+            .map(|(caller_return_pc, parameter)| {
+                (caller_return_pc, parameter.caller_value_steps.clone())
+            })
+            .collect();
+        if !indexed_parameters.is_empty() {
+            return indexed_parameters;
+        }
+
+        dwarf
+            .map(|dwarf| {
+                BlockIndexBuilder::new(dwarf)
+                    .collect_incoming_entry_value_parameters(function_context, register)
+                    .into_iter()
+                    .map(|(caller_return_pc, parameter)| {
+                        (caller_return_pc, parameter.caller_value_steps)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn resolve_entry_value_register_offset(
+        current_pc: u64,
+        register: u16,
+        offset: i64,
+        address_size: u8,
+        dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        function_context: Option<&FunctionBlocks>,
+        cfi_index: Option<&CfiIndex>,
+    ) -> Result<Vec<ComputeStep>> {
+        if Self::is_stack_pointer_register(register) {
+            return Self::recover_entry_stack_pointer_steps(
+                current_pc,
+                offset,
+                address_size,
+                cfi_index,
+            );
+        }
+
+        match Self::resolve_entry_value_register(
+            current_pc,
+            register,
+            dwarf,
+            function_context,
+            cfi_index,
+        ) {
+            Ok(mut steps) => {
+                Self::append_constant_offset(&mut steps, offset);
+                Ok(steps)
+            }
+            Err(entry_error) => {
+                let mut steps = Self::recover_entry_register_from_cfi(
+                    current_pc, register, cfi_index,
+                )
+                .map_err(|cfi_error| {
+                    anyhow::anyhow!(
+                        "failed to recover DW_OP_entry_value base register {} with offset {} at 0x{:x}: {}; fallback via CFI also failed: {}",
+                        register,
+                        offset,
+                        current_pc,
+                        entry_error,
+                        cfi_error
+                    )
+                })?;
+                Self::append_constant_offset(&mut steps, offset);
+                Ok(steps)
+            }
+        }
+    }
+
+    fn recover_entry_register_from_cfi(
+        current_pc: u64,
+        register: u16,
+        cfi_index: Option<&CfiIndex>,
+    ) -> Result<Vec<ComputeStep>> {
+        let cfi_index = cfi_index.ok_or_else(|| {
+            anyhow::anyhow!(
+                "DW_OP_entry_value register recovery needs CFI at 0x{:x}",
+                current_pc
+            )
+        })?;
+        cfi_index
+            .recover_caller_register_steps(current_pc, register)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no entry register recovery rule for DWARF register {} at 0x{:x}",
+                    register,
+                    current_pc
+                )
+            })
+    }
+
+    fn recover_entry_stack_pointer_steps(
+        current_pc: u64,
+        offset: i64,
+        address_size: u8,
+        cfi_index: Option<&CfiIndex>,
+    ) -> Result<Vec<ComputeStep>> {
+        let cfi_index = cfi_index.ok_or_else(|| {
+            anyhow::anyhow!(
+                "DW_OP_entry_value stack-pointer recovery needs CFI at 0x{:x}",
+                current_pc
+            )
+        })?;
+        let mut steps = Self::cfa_to_steps(cfi_index.get_cfa_result(current_pc)?);
+        // This assumes the common x86/x86_64 call-frame convention where the CFA
+        // observed after the call is `SP_entry + address_size` because the return
+        // address is stored on the stack. Targets such as AArch64 may define the
+        // CFA at call entry differently when LR is not pushed, so keep this
+        // adjustment centralized until entry-SP reconstruction becomes
+        // target-aware.
+        Self::append_constant_offset(&mut steps, offset - i64::from(address_size));
+        Ok(steps)
+    }
+
+    fn cfa_to_steps(cfa: crate::core::CfaResult) -> Vec<ComputeStep> {
+        match cfa {
+            crate::core::CfaResult::RegisterPlusOffset { register, offset } => {
+                let mut steps = vec![ComputeStep::LoadRegister(register)];
+                Self::append_constant_offset(&mut steps, offset);
+                steps
+            }
+            crate::core::CfaResult::Expression { steps } => steps,
+        }
+    }
+
+    fn append_constant_offset(steps: &mut Vec<ComputeStep>, offset: i64) {
+        if offset != 0 {
+            steps.push(ComputeStep::PushConstant(offset));
+            steps.push(ComputeStep::Add);
+        }
+    }
+
+    fn is_stack_pointer_register(register: u16) -> bool {
+        matches!(
+            ghostscope_platform::register_mapping::dwarf_reg_to_name(register),
+            Some("RSP" | "ESP" | "SP")
+        )
     }
 
     fn build_entry_value_lookup_steps(
@@ -1415,10 +1602,91 @@ impl ExpressionEvaluator {
 #[cfg(test)]
 mod tests {
     use super::ExpressionEvaluator;
+    use crate::binary::{dwarf_reader_from_arc, DwarfReader};
     use crate::core::{
         ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
     };
-    use crate::index::{CallSiteParameter, CallSiteRecord, FunctionBlocks};
+    use crate::index::{BlockNode, CallSiteParameter, CallSiteRecord, FunctionBlocks};
+    use gimli::constants;
+    use gimli::write::{
+        Address, AttributeValue as WriteAttributeValue, Dwarf as WriteDwarf, EndianVec,
+        Expression as WriteExpression, LineProgram, Sections, Unit,
+    };
+    use gimli::{Format, LittleEndian, Register};
+    use std::sync::Arc;
+
+    fn build_scanned_incoming_entry_value_fixture(
+        register: u16,
+        caller_value: u64,
+    ) -> gimli::Dwarf<DwarfReader> {
+        let encoding = gimli::Encoding {
+            format: Format::Dwarf32,
+            version: 5,
+            address_size: 8,
+        };
+
+        let mut dwarf = WriteDwarf::new();
+        let unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+        let unit = dwarf.units.get_mut(unit_id);
+        let root = unit.root();
+
+        let caller_id = unit.add(root, constants::DW_TAG_subprogram);
+        let caller = unit.get_mut(caller_id);
+        caller.set(
+            constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1000)),
+        );
+        caller.set(constants::DW_AT_high_pc, WriteAttributeValue::Udata(0x40));
+
+        let callee_id = unit.add(root, constants::DW_TAG_subprogram);
+        let callee = unit.get_mut(callee_id);
+        callee.set(
+            constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x1200)),
+        );
+        callee.set(constants::DW_AT_high_pc, WriteAttributeValue::Udata(0x10));
+
+        let call_site_id = unit.add(caller_id, constants::DW_TAG_call_site);
+        unit.get_mut(call_site_id).set(
+            constants::DW_AT_call_target,
+            WriteAttributeValue::Address(Address::Constant(0x1200)),
+        );
+        unit.get_mut(call_site_id).set(
+            constants::DW_AT_call_return_pc,
+            WriteAttributeValue::Address(Address::Constant(0x2018)),
+        );
+
+        let param_id = unit.add(call_site_id, constants::DW_TAG_call_site_parameter);
+        let param = unit.get_mut(param_id);
+        let mut location = WriteExpression::new();
+        location.op_reg(Register(register));
+        param.set(
+            constants::DW_AT_location,
+            WriteAttributeValue::Exprloc(location),
+        );
+        let mut value = WriteExpression::new();
+        value.op_constu(caller_value);
+        param.set(
+            constants::DW_AT_call_value,
+            WriteAttributeValue::Exprloc(value),
+        );
+
+        let mut sections = Sections::new(EndianVec::new(LittleEndian));
+        dwarf.write(&mut sections).unwrap();
+
+        let dwarf_sections: gimli::DwarfSections<Vec<u8>> = gimli::DwarfSections::load(|id| {
+            Ok::<_, gimli::Error>(
+                sections
+                    .get(id)
+                    .map(|section| section.slice().to_vec())
+                    .unwrap_or_default(),
+            )
+        })
+        .unwrap();
+
+        dwarf_sections
+            .borrow(|section| dwarf_reader_from_arc(Arc::<[u8]>::from(section.as_slice())))
+    }
 
     #[test]
     fn implicit_pointer_to_static_storage_preserves_absolute_address_semantics() {
@@ -1435,13 +1703,28 @@ mod tests {
     }
 
     #[test]
-    fn entry_value_uses_nearest_call_site_parameter_steps() {
+    fn entry_value_uses_nearest_call_site_parameter_steps_in_inline_context() {
         let mut function = FunctionBlocks {
             cu_offset: gimli::DebugInfoOffset(0),
             die_offset: gimli::UnitOffset(0),
             abs_die_offset: Some(gimli::DebugInfoOffset(0)),
-            ranges: vec![],
-            nodes: vec![],
+            ranges: vec![(0x1000, 0x1040)],
+            nodes: vec![
+                BlockNode {
+                    ranges: vec![],
+                    entry_pc: None,
+                    die_offset: Some(gimli::UnitOffset(0)),
+                    variables: vec![],
+                    children: vec![1],
+                },
+                BlockNode {
+                    ranges: vec![(0x1000, 0x1040)],
+                    entry_pc: Some(0x1000),
+                    die_offset: Some(gimli::UnitOffset(1)),
+                    variables: vec![],
+                    children: vec![],
+                },
+            ],
             block_addr_map: std::collections::BTreeMap::new(),
             call_sites: std::collections::BTreeMap::new(),
             incoming_call_sites: std::collections::BTreeMap::new(),
@@ -1475,10 +1758,64 @@ mod tests {
             }],
         );
 
-        let steps =
-            ExpressionEvaluator::resolve_entry_value_register(0x1034, 5, Some(&function), None)
-                .expect("entry_value should resolve to the nearest call site");
+        let steps = ExpressionEvaluator::resolve_entry_value_register(
+            0x1034,
+            5,
+            None,
+            Some(&function),
+            None,
+        )
+        .expect("entry_value should resolve to the nearest call site");
         assert_eq!(steps, vec![ComputeStep::PushConstant(22)]);
+    }
+
+    #[test]
+    fn entry_value_ignores_outgoing_call_sites_in_non_inline_context() {
+        let mut function = FunctionBlocks {
+            cu_offset: gimli::DebugInfoOffset(0),
+            die_offset: gimli::UnitOffset(0),
+            abs_die_offset: Some(gimli::DebugInfoOffset(0)),
+            ranges: vec![(0x1000, 0x1040)],
+            nodes: vec![BlockNode {
+                ranges: vec![],
+                entry_pc: None,
+                die_offset: Some(gimli::UnitOffset(0)),
+                variables: vec![],
+                children: vec![],
+            }],
+            block_addr_map: std::collections::BTreeMap::new(),
+            call_sites: std::collections::BTreeMap::new(),
+            incoming_call_sites: std::collections::BTreeMap::new(),
+        };
+        function.call_sites.insert(
+            0x1030,
+            vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(0),
+                die_offset: gimli::UnitOffset(2),
+                return_pc: 0x1030,
+                call_origin: None,
+                call_target: None,
+                parameters: vec![CallSiteParameter {
+                    callee_register: 5,
+                    caller_value_steps: vec![ComputeStep::PushConstant(22)],
+                }],
+            }],
+        );
+
+        let error = ExpressionEvaluator::resolve_entry_value_register(
+            0x1034,
+            5,
+            None,
+            Some(&function),
+            None,
+        )
+        .expect_err("non-inline entry_value must not reuse outgoing call-site bindings");
+        assert!(
+            error
+                .to_string()
+                .contains("DW_OP_entry_value register recovery needs CFI"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -1487,8 +1824,14 @@ mod tests {
             cu_offset: gimli::DebugInfoOffset(0),
             die_offset: gimli::UnitOffset(0),
             abs_die_offset: Some(gimli::DebugInfoOffset(0)),
-            ranges: vec![],
-            nodes: vec![],
+            ranges: vec![(0x1200, 0x1210)],
+            nodes: vec![BlockNode {
+                ranges: vec![],
+                entry_pc: None,
+                die_offset: Some(gimli::UnitOffset(0)),
+                variables: vec![],
+                children: vec![],
+            }],
             block_addr_map: std::collections::BTreeMap::new(),
             call_sites: std::collections::BTreeMap::new(),
             incoming_call_sites: std::collections::BTreeMap::new(),
@@ -1545,6 +1888,71 @@ mod tests {
                     },
                 ],
             }]
+        );
+    }
+
+    #[test]
+    fn entry_value_prefers_indexed_incoming_parameters_over_dwarf_scan() {
+        let mut function = FunctionBlocks {
+            cu_offset: gimli::DebugInfoOffset(0),
+            die_offset: gimli::UnitOffset(0),
+            abs_die_offset: Some(gimli::DebugInfoOffset(0)),
+            ranges: vec![(0x1200, 0x1210)],
+            nodes: vec![BlockNode {
+                ranges: vec![],
+                entry_pc: None,
+                die_offset: Some(gimli::UnitOffset(0)),
+                variables: vec![],
+                children: vec![],
+            }],
+            block_addr_map: std::collections::BTreeMap::new(),
+            call_sites: std::collections::BTreeMap::new(),
+            incoming_call_sites: std::collections::BTreeMap::new(),
+        };
+        function.incoming_call_sites.insert(
+            0x2018,
+            vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(1),
+                die_offset: gimli::UnitOffset(3),
+                return_pc: 0x2018,
+                call_origin: function.abs_die_offset,
+                call_target: Some(0x1200),
+                parameters: vec![CallSiteParameter {
+                    callee_register: 5,
+                    caller_value_steps: vec![ComputeStep::PushConstant(33)],
+                }],
+            }],
+        );
+        let dwarf = build_scanned_incoming_entry_value_fixture(5, 99);
+
+        let parameters = ExpressionEvaluator::collect_incoming_entry_value_parameter_steps(
+            5,
+            Some(&dwarf),
+            &function,
+        );
+
+        assert_eq!(
+            parameters,
+            vec![(0x2018, vec![ComputeStep::PushConstant(33)])]
+        );
+    }
+
+    #[test]
+    fn entry_value_stack_pointer_offsets_use_cfa_based_entry_sp() {
+        let mut entry_sp_steps =
+            ExpressionEvaluator::cfa_to_steps(crate::core::CfaResult::RegisterPlusOffset {
+                register: 7,
+                offset: 32,
+            });
+        ExpressionEvaluator::append_constant_offset(&mut entry_sp_steps, 8 - 8);
+
+        assert_eq!(
+            entry_sp_steps,
+            vec![
+                ComputeStep::LoadRegister(7),
+                ComputeStep::PushConstant(32),
+                ComputeStep::Add,
+            ]
         );
     }
 

--- a/ghostscope-dwarf/src/parser/expression_evaluator.rs
+++ b/ghostscope-dwarf/src/parser/expression_evaluator.rs
@@ -2,14 +2,14 @@
 //!
 //! Converts DWARF location expressions to EvaluationResult for eBPF code generation
 
-use crate::binary::DwarfReader;
+use crate::binary::{DwarfEndian, DwarfReader};
 use crate::core::{
     ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
     MemoryAccessSize, Result,
 };
 use crate::index::{CfiIndex, FunctionBlocks};
 use crate::semantics::{range_contains_pc, resolve_attr_with_unit_origins};
-use gimli::{read::RawLocListEntry, EndianSlice, Expression, LittleEndian, Operation, Reader};
+use gimli::{read::RawLocListEntry, EndianSlice, Expression, Operation, Reader};
 use tracing::{debug, trace, warn};
 
 /// DWARF expression evaluator
@@ -62,6 +62,7 @@ impl ExpressionEvaluator {
                 debug!("Found Exprloc, parsing DWARF expression");
                 Self::parse_expression_with_context(
                     expr.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                    expr.0.endian(),
                     unit.encoding(),
                     Some(dwarf),
                     address,
@@ -152,6 +153,7 @@ impl ExpressionEvaluator {
                             // Some compilers may encode an implicit value via expression
                             match Self::parse_expression_with_context(
                                 expr.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                expr.0.endian(),
                                 unit.encoding(),
                                 Some(dwarf),
                                 address,
@@ -191,8 +193,10 @@ impl ExpressionEvaluator {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn parse_expression_in_unit(
         expr_bytes: &[u8],
+        endian: DwarfEndian,
         unit: &gimli::Unit<DwarfReader>,
         dwarf: &gimli::Dwarf<DwarfReader>,
         address: u64,
@@ -202,6 +206,7 @@ impl ExpressionEvaluator {
     ) -> Result<EvaluationResult> {
         Self::parse_expression_with_context(
             expr_bytes,
+            endian,
             unit.encoding(),
             Some(dwarf),
             address,
@@ -212,8 +217,10 @@ impl ExpressionEvaluator {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn parse_expression_to_steps_in_unit(
         expr_bytes: &[u8],
+        endian: DwarfEndian,
         unit: &gimli::Unit<DwarfReader>,
         dwarf: &gimli::Dwarf<DwarfReader>,
         address: u64,
@@ -223,6 +230,7 @@ impl ExpressionEvaluator {
     ) -> Result<Vec<ComputeStep>> {
         let evaluation = Self::parse_expression_in_unit(
             expr_bytes,
+            endian,
             unit,
             dwarf,
             address,
@@ -236,6 +244,7 @@ impl ExpressionEvaluator {
     #[allow(clippy::too_many_arguments)]
     fn parse_expression_with_context(
         expr_bytes: &[u8],
+        endian: DwarfEndian,
         encoding: gimli::Encoding,
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
         address: u64,
@@ -251,6 +260,7 @@ impl ExpressionEvaluator {
         // Parse all expressions through unified handler
         Self::parse_full_expression(
             expr_bytes,
+            endian,
             encoding,
             dwarf,
             address,
@@ -311,6 +321,7 @@ impl ExpressionEvaluator {
     #[allow(clippy::too_many_arguments)]
     fn parse_full_expression(
         expr_bytes: &[u8],
+        endian: DwarfEndian,
         encoding: gimli::Encoding,
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
         address: u64,
@@ -325,7 +336,7 @@ impl ExpressionEvaluator {
             PrecomputedSteps(Vec<ComputeStep>),
         }
 
-        let mut expression = Expression(EndianSlice::new(expr_bytes, LittleEndian));
+        let mut expression = Expression(EndianSlice::new(expr_bytes, endian));
         let mut operations: Vec<ParsedOperation<_>> = Vec::new();
         let mut has_stack_value = false;
 
@@ -967,6 +978,7 @@ impl ExpressionEvaluator {
                             .ok()
                             .as_deref()
                             .unwrap_or(&[]),
+                        location_list_entry.data.0.endian(),
                         unit.encoding(),
                         Some(dwarf),
                         address,
@@ -1041,6 +1053,7 @@ impl ExpressionEvaluator {
                             if contains {
                                 let location_expr = Self::parse_expression_with_context(
                                     data.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                    data.0.endian(),
                                     unit.encoding(),
                                     Some(dwarf),
                                     address,
@@ -1076,6 +1089,7 @@ impl ExpressionEvaluator {
                             if contains {
                                 let location_expr = Self::parse_expression_with_context(
                                     data.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                    data.0.endian(),
                                     unit.encoding(),
                                     Some(dwarf),
                                     address,
@@ -1114,6 +1128,7 @@ impl ExpressionEvaluator {
                             if contains {
                                 let location_expr = Self::parse_expression_with_context(
                                     data.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                    data.0.endian(),
                                     unit.encoding(),
                                     Some(dwarf),
                                     address,
@@ -1155,6 +1170,7 @@ impl ExpressionEvaluator {
                                 if contains {
                                     let location_expr = Self::parse_expression_with_context(
                                         data.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                        data.0.endian(),
                                         unit.encoding(),
                                         Some(dwarf),
                                         address,
@@ -1197,6 +1213,7 @@ impl ExpressionEvaluator {
                                 if contains {
                                     let location_expr = Self::parse_expression_with_context(
                                         data.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                        data.0.endian(),
                                         unit.encoding(),
                                         Some(dwarf),
                                         address,
@@ -1225,6 +1242,7 @@ impl ExpressionEvaluator {
                             debug!("  Raw fallback default location entry");
                             let location_expr = Self::parse_expression_with_context(
                                 data.0.to_slice().ok().as_deref().unwrap_or(&[]),
+                                data.0.endian(),
                                 unit.encoding(),
                                 Some(dwarf),
                                 address,
@@ -1527,6 +1545,33 @@ mod tests {
                     },
                 ],
             }]
+        );
+    }
+
+    #[test]
+    fn big_endian_dw_op_addr_preserves_absolute_address() {
+        let encoding = gimli::Encoding {
+            format: gimli::Format::Dwarf32,
+            version: 5,
+            address_size: 8,
+        };
+        let expr_bytes = [0x03, 0, 0, 0, 0, 0, 0, 0x12, 0x34];
+        let result = ExpressionEvaluator::parse_expression_with_context(
+            &expr_bytes,
+            gimli::RunTimeEndian::Big,
+            encoding,
+            None,
+            0,
+            None,
+            None,
+            None,
+            0,
+        )
+        .expect("big-endian DW_OP_addr should parse");
+
+        assert_eq!(
+            result,
+            EvaluationResult::MemoryLocation(LocationResult::Address(0x1234))
         );
     }
 }

--- a/ghostscope-dwarf/src/parser/expression_evaluator.rs
+++ b/ghostscope-dwarf/src/parser/expression_evaluator.rs
@@ -4,7 +4,8 @@
 
 use crate::binary::DwarfReader;
 use crate::core::{
-    ComputeStep, DirectValueResult, EvaluationResult, LocationResult, MemoryAccessSize, Result,
+    ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
+    MemoryAccessSize, Result,
 };
 use crate::index::{CfiIndex, FunctionBlocks};
 use crate::semantics::{range_contains_pc, resolve_attr_with_unit_origins};
@@ -16,6 +17,7 @@ pub struct ExpressionEvaluator;
 
 impl ExpressionEvaluator {
     const MAX_IMPLICIT_POINTER_DEPTH: usize = 8;
+    const ENTRY_VALUE_LOOKUP_WARN_CASES: usize = 16;
 
     /// Evaluate a variable's location from its DIE attributes
     pub fn evaluate_location(
@@ -1261,17 +1263,102 @@ impl ExpressionEvaluator {
         let function_context = function_context.ok_or_else(|| {
             anyhow::anyhow!("DW_OP_entry_value requires function call-site context")
         })?;
-        let parameter = function_context
-            .entry_value_parameter_for_pc(current_pc, register)
-            .ok_or_else(|| {
+        if let Some(parameter) = function_context.entry_value_parameter_for_pc(current_pc, register)
+        {
+            return Self::materialize_caller_value_steps(
+                &parameter.caller_value_steps,
+                current_pc,
+                cfi_index,
+            );
+        }
+
+        Self::build_incoming_entry_value_lookup(current_pc, register, function_context, cfi_index)
+    }
+
+    fn build_incoming_entry_value_lookup(
+        current_pc: u64,
+        register: u16,
+        function_context: &FunctionBlocks,
+        cfi_index: Option<&CfiIndex>,
+    ) -> Result<Vec<ComputeStep>> {
+        let cfi_index = cfi_index.ok_or_else(|| {
+            anyhow::anyhow!(
+                "DW_OP_entry_value register recovery needs CFI at 0x{:x}",
+                current_pc
+            )
+        })?;
+        let recovery = cfi_index.recover_caller_frame(current_pc, &[])?;
+
+        let mut cases_by_return_pc = std::collections::BTreeMap::<u64, Vec<ComputeStep>>::new();
+        for (caller_return_pc, parameter) in
+            function_context.incoming_entry_value_parameters(register)
+        {
+            let value_steps = Self::materialize_caller_value_steps(
+                &parameter.caller_value_steps,
+                current_pc,
+                Some(cfi_index),
+            )
+            .map_err(|error| {
                 anyhow::anyhow!(
-                    "no call-site parameter found for DW_OP_entry_value register {} at 0x{:x}",
+                    "failed to materialize incoming call-site parameter for DW_OP_entry_value register {} at 0x{:x} (caller return pc 0x{:x}): {}",
                     register,
-                    current_pc
+                    current_pc,
+                    caller_return_pc,
+                    error
                 )
             })?;
+            match cases_by_return_pc.entry(caller_return_pc) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(value_steps);
+                }
+                std::collections::btree_map::Entry::Occupied(entry) => {
+                    if entry.get() != &value_steps {
+                        return Err(anyhow::anyhow!(
+                            "ambiguous incoming call-site parameter for DW_OP_entry_value register {} at 0x{:x} (caller return pc 0x{:x})",
+                            register,
+                            current_pc,
+                            caller_return_pc
+                        ));
+                    }
+                }
+            }
+        }
 
-        Self::materialize_caller_value_steps(&parameter.caller_value_steps, current_pc, cfi_index)
+        if cases_by_return_pc.is_empty() {
+            return Err(anyhow::anyhow!(
+                "no call-site parameter found for DW_OP_entry_value register {} at 0x{:x}",
+                register,
+                current_pc
+            ));
+        }
+
+        Ok(Self::build_entry_value_lookup_steps(
+            recovery.caller_pc_steps,
+            cases_by_return_pc,
+        ))
+    }
+
+    fn build_entry_value_lookup_steps(
+        caller_pc_steps: Vec<ComputeStep>,
+        cases_by_return_pc: std::collections::BTreeMap<u64, Vec<ComputeStep>>,
+    ) -> Vec<ComputeStep> {
+        let cases: Vec<_> = cases_by_return_pc
+            .into_iter()
+            .map(|(caller_return_pc, value_steps)| EntryValueCase {
+                caller_return_pc,
+                value_steps,
+            })
+            .collect();
+        if cases.len() > Self::ENTRY_VALUE_LOOKUP_WARN_CASES {
+            warn!(
+                "DW_OP_entry_value lookup generated {} caller return-pc cases; large fan-in may exceed eBPF verifier limits",
+                cases.len()
+            );
+        }
+        vec![ComputeStep::EntryValueLookup {
+            caller_pc_steps,
+            cases,
+        }]
     }
 
     fn materialize_caller_value_steps(
@@ -1293,7 +1380,7 @@ impl ExpressionEvaluator {
                         .recover_caller_register_steps(current_pc, *register)?
                         .ok_or_else(|| {
                             anyhow::anyhow!(
-                                "no caller register recovery rule for DWARF register {} at 0x{:x}",
+                                "no caller register recovery rule for DWARF register {} at 0x{:x}; DW_OP_entry_value can only materialize caller values for registers with unwind recovery, and caller-saved argument registers are often unavailable after the call",
                                 register,
                                 current_pc
                             )
@@ -1310,7 +1397,9 @@ impl ExpressionEvaluator {
 #[cfg(test)]
 mod tests {
     use super::ExpressionEvaluator;
-    use crate::core::{ComputeStep, DirectValueResult, EvaluationResult, LocationResult};
+    use crate::core::{
+        ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
+    };
     use crate::index::{CallSiteParameter, CallSiteRecord, FunctionBlocks};
 
     #[test]
@@ -1332,16 +1421,21 @@ mod tests {
         let mut function = FunctionBlocks {
             cu_offset: gimli::DebugInfoOffset(0),
             die_offset: gimli::UnitOffset(0),
+            abs_die_offset: Some(gimli::DebugInfoOffset(0)),
             ranges: vec![],
             nodes: vec![],
             block_addr_map: std::collections::BTreeMap::new(),
             call_sites: std::collections::BTreeMap::new(),
+            incoming_call_sites: std::collections::BTreeMap::new(),
         };
         function.call_sites.insert(
             0x1018,
             vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(0),
                 die_offset: gimli::UnitOffset(1),
                 return_pc: 0x1018,
+                call_origin: None,
+                call_target: None,
                 parameters: vec![CallSiteParameter {
                     callee_register: 5,
                     caller_value_steps: vec![ComputeStep::PushConstant(11)],
@@ -1351,8 +1445,11 @@ mod tests {
         function.call_sites.insert(
             0x1030,
             vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(0),
                 die_offset: gimli::UnitOffset(2),
                 return_pc: 0x1030,
+                call_origin: None,
+                call_target: None,
                 parameters: vec![CallSiteParameter {
                     callee_register: 5,
                     caller_value_steps: vec![ComputeStep::PushConstant(22)],
@@ -1364,5 +1461,72 @@ mod tests {
             ExpressionEvaluator::resolve_entry_value_register(0x1034, 5, Some(&function), None)
                 .expect("entry_value should resolve to the nearest call site");
         assert_eq!(steps, vec![ComputeStep::PushConstant(22)]);
+    }
+
+    #[test]
+    fn entry_value_uses_incoming_call_site_lookup_for_non_inline_functions() {
+        let mut function = FunctionBlocks {
+            cu_offset: gimli::DebugInfoOffset(0),
+            die_offset: gimli::UnitOffset(0),
+            abs_die_offset: Some(gimli::DebugInfoOffset(0)),
+            ranges: vec![],
+            nodes: vec![],
+            block_addr_map: std::collections::BTreeMap::new(),
+            call_sites: std::collections::BTreeMap::new(),
+            incoming_call_sites: std::collections::BTreeMap::new(),
+        };
+        function.incoming_call_sites.insert(
+            0x2018,
+            vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(1),
+                die_offset: gimli::UnitOffset(3),
+                return_pc: 0x2018,
+                call_origin: function.abs_die_offset,
+                call_target: Some(0x1200),
+                parameters: vec![CallSiteParameter {
+                    callee_register: 5,
+                    caller_value_steps: vec![ComputeStep::PushConstant(33)],
+                }],
+            }],
+        );
+        function.incoming_call_sites.insert(
+            0x2030,
+            vec![CallSiteRecord {
+                cu_offset: gimli::DebugInfoOffset(2),
+                die_offset: gimli::UnitOffset(4),
+                return_pc: 0x2030,
+                call_origin: function.abs_die_offset,
+                call_target: Some(0x1200),
+                parameters: vec![CallSiteParameter {
+                    callee_register: 5,
+                    caller_value_steps: vec![ComputeStep::PushConstant(44)],
+                }],
+            }],
+        );
+
+        let mut cases_by_return_pc = std::collections::BTreeMap::new();
+        for (caller_return_pc, parameter) in function.incoming_entry_value_parameters(5) {
+            cases_by_return_pc.insert(caller_return_pc, parameter.caller_value_steps.clone());
+        }
+        let steps = ExpressionEvaluator::build_entry_value_lookup_steps(
+            vec![ComputeStep::PushConstant(0xdeadbeef)],
+            cases_by_return_pc,
+        );
+        assert_eq!(
+            steps,
+            vec![ComputeStep::EntryValueLookup {
+                caller_pc_steps: vec![ComputeStep::PushConstant(0xdeadbeef)],
+                cases: vec![
+                    EntryValueCase {
+                        caller_return_pc: 0x2018,
+                        value_steps: vec![ComputeStep::PushConstant(33)],
+                    },
+                    EntryValueCase {
+                        caller_return_pc: 0x2030,
+                        value_steps: vec![ComputeStep::PushConstant(44)],
+                    },
+                ],
+            }]
+        );
     }
 }

--- a/ghostscope-dwarf/src/parser/expression_evaluator.rs
+++ b/ghostscope-dwarf/src/parser/expression_evaluator.rs
@@ -685,7 +685,7 @@ impl ExpressionEvaluator {
                             } => Ok(EvaluationResult::MemoryLocation(
                                 LocationResult::RegisterAddress {
                                     register,
-                                    offset: Some(cfa_offset + offset),
+                                    offset: Some(cfa_offset.saturating_add(*offset)),
                                     size: None,
                                 },
                             )),
@@ -1604,7 +1604,7 @@ mod tests {
     use super::ExpressionEvaluator;
     use crate::binary::{dwarf_reader_from_arc, DwarfReader};
     use crate::core::{
-        ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
+        CfaResult, ComputeStep, DirectValueResult, EntryValueCase, EvaluationResult, LocationResult,
     };
     use crate::index::{BlockNode, CallSiteParameter, CallSiteRecord, FunctionBlocks};
     use gimli::constants;
@@ -1612,7 +1612,7 @@ mod tests {
         Address, AttributeValue as WriteAttributeValue, Dwarf as WriteDwarf, EndianVec,
         Expression as WriteExpression, LineProgram, Sections, Unit,
     };
-    use gimli::{Format, LittleEndian, Register};
+    use gimli::{Format, LittleEndian, Register, RunTimeEndian};
     use std::sync::Arc;
 
     fn build_scanned_incoming_entry_value_fixture(
@@ -1953,6 +1953,43 @@ mod tests {
                 ComputeStep::PushConstant(32),
                 ComputeStep::Add,
             ]
+        );
+    }
+
+    #[test]
+    fn single_fbreg_fast_path_saturates_cfa_offset_addition() {
+        let encoding = gimli::Encoding {
+            format: gimli::Format::Dwarf32,
+            version: 5,
+            address_size: 8,
+        };
+        let get_cfa = |_address| {
+            Ok(Some(CfaResult::RegisterPlusOffset {
+                register: 7,
+                offset: i64::MAX - 3,
+            }))
+        };
+
+        let result = ExpressionEvaluator::parse_expression_with_context(
+            &[0x91, 0x0a],
+            RunTimeEndian::Little,
+            encoding,
+            None,
+            0,
+            Some(&get_cfa),
+            None,
+            None,
+            0,
+        )
+        .expect("single DW_OP_fbreg should parse");
+
+        assert_eq!(
+            result,
+            EvaluationResult::MemoryLocation(LocationResult::RegisterAddress {
+                register: 7,
+                offset: Some(i64::MAX),
+                size: None,
+            })
         );
     }
 

--- a/ghostscope-dwarf/src/semantics/expr.rs
+++ b/ghostscope-dwarf/src/semantics/expr.rs
@@ -1,14 +1,12 @@
 use crate::binary::DwarfReader;
-use gimli::{EndianSlice, LittleEndian, Reader};
+use gimli::Reader;
 
 pub(crate) fn eval_member_offset_expr(expr: &gimli::Expression<DwarfReader>) -> Option<u64> {
-    let bytes_cow = expr.0.to_slice().ok()?;
-    let bytes: &[u8] = &bytes_cow;
-    if bytes.is_empty() {
+    let mut reader = expr.0.clone();
+    if reader.is_empty() {
         return None;
     }
 
-    let mut reader = EndianSlice::new(bytes, LittleEndian);
     match reader.read_u8().ok()? {
         0x10 => reader.read_uleb128().ok(), // DW_OP_constu
         0x11 => reader.read_sleb128().ok().map(|value| value as u64), // DW_OP_consts


### PR DESCRIPTION
Map caller-side call-site metadata back to callees and lower non-inline DW_OP_entry_value(reg) recovery to a runtime caller-PC lookup.

This preserves the existing inline path while allowing tracing to materialize caller-provided DW_AT_call_value bindings for normal function calls.