### PR TITLE
ci: add fixture compiler image

### DIFF
--- a/.github/workflows/fixture-compiler-image.yml
+++ b/.github/workflows/fixture-compiler-image.yml
@@ -1,0 +1,48 @@
+name: Build Fixture Compiler Image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/swananan/ghostscope-fixture-compiler
+          tags: |
+            type=raw,value=ubuntu24.04-clang18-rust1.88
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/fixture-compiler/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=fixture-compiler
+          cache-to: type=gha,mode=max,scope=fixture-compiler

--- a/docker/fixture-compiler/Dockerfile
+++ b/docker/fixture-compiler/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+ARG LLVM_MAJOR=18
+ARG RUST_TOOLCHAIN=1.88.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    binutils \
+    ca-certificates \
+    curl \
+    g++ \
+    gcc \
+    gnupg \
+    make \
+    tar \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc; \
+    echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_MAJOR} main" > /etc/apt/sources.list.d/llvm.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      clang-${LLVM_MAJOR}; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -sf /usr/bin/clang-${LLVM_MAJOR} /usr/local/bin/clang && \
+    ln -sf /usr/bin/clang++-${LLVM_MAJOR} /usr/local/bin/clang++
+
+RUN set -eux; \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none; \
+    export PATH="/root/.cargo/bin:$PATH"; \
+    rustup set profile minimal; \
+    rustup toolchain install "${RUST_TOOLCHAIN}"; \
+    rustup default "${RUST_TOOLCHAIN}"; \
+    cargo --version; \
+    rustc --version
+
+ENV PATH=/root/.cargo/bin:$PATH
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Add a dedicated image for compiling e2e fixtures with the toolchains used in CI.

Include gcc/g++, clang-18, Rust 1.88.0, make, and
binutils.