### PR TITLE
fix: preserve signed scalar comparisons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
             e2e-tests/tests/fixtures/globals_program/globals_program
             e2e-tests/tests/fixtures/globals_program/libgvars.so
             e2e-tests/tests/fixtures/late_globals_program/late_globals_program
+            e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
             e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program
             e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
             e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5

--- a/.github/workflows/container-e2e.yml
+++ b/.github/workflows/container-e2e.yml
@@ -98,6 +98,7 @@ jobs:
             e2e-tests/tests/fixtures/globals_program/globals_program
             e2e-tests/tests/fixtures/globals_program/libgvars.so
             e2e-tests/tests/fixtures/late_globals_program/late_globals_program
+            e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
             e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program
             e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
             e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5
@@ -233,6 +234,7 @@ jobs:
             e2e-tests/tests/fixtures/globals_program/globals_program
             e2e-tests/tests/fixtures/globals_program/libgvars.so
             e2e-tests/tests/fixtures/late_globals_program/late_globals_program
+            e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
             e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program
             e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
             e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program
 e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o*
 e2e-tests/tests/fixtures/partitioned_ranges_program/partitioned_ranges_program
 e2e-tests/tests/fixtures/rust_global_program/target/
+e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
 e2e-tests/tests/fixtures/sample_program/sample_lib.o
 e2e-tests/tests/fixtures/sample_program/sample_program
 e2e-tests/tests/fixtures/sample_program/sample_program.o

--- a/e2e-tests/compile-fixtures.sh
+++ b/e2e-tests/compile-fixtures.sh
@@ -58,6 +58,9 @@ run_make_fixture globals_program all
 run_make_fixture late_globals_program clean
 run_make_fixture late_globals_program all
 
+run_make_fixture scalar_types_program clean
+run_make_fixture scalar_types_program all
+
 run_cargo_fixture "$RUST_FIXTURE_DIR" clean
 run_cargo_fixture "$RUST_FIXTURE_DIR" build --locked
 

--- a/e2e-tests/tests/common/mod.rs
+++ b/e2e-tests/tests/common/mod.rs
@@ -28,6 +28,7 @@ lazy_static! {
         Mutex::new(None);
     static ref COMPILE_GLOBALS_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_LATE_GLOBALS_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
+    static ref COMPILE_SCALAR_TYPES_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_RUST_GLOBAL_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_INLINE_CALLSITE_DEFAULT_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
@@ -65,6 +66,7 @@ enum RegisteredFixtureKind {
     MemberPointer,
     Globals,
     LateGlobals,
+    ScalarTypes,
     RustGlobal,
     InlineCallsite,
     InlineCallValue,
@@ -115,6 +117,12 @@ const REGISTERED_FIXTURES: &[RegisteredFixture] = &[
         directory: "late_globals_program",
         cleanup: CleanupCommand::Make,
         kind: RegisteredFixtureKind::LateGlobals,
+    },
+    RegisteredFixture {
+        name: "scalar_types_program",
+        directory: "scalar_types_program",
+        cleanup: CleanupCommand::Make,
+        kind: RegisteredFixtureKind::ScalarTypes,
     },
     RegisteredFixture {
         name: "rust_global_program",
@@ -383,6 +391,16 @@ impl RegisteredFixture {
             RegisteredFixtureKind::LateGlobals => {
                 ensure_late_globals_program_compiled()?;
                 Ok(dir.join("late_globals_program"))
+            }
+            RegisteredFixtureKind::ScalarTypes => {
+                if !matches!(opt_level, OptimizationLevel::Debug) {
+                    anyhow::bail!(
+                        "Optimization level {} not supported for scalar_types_program",
+                        opt_level.description()
+                    );
+                }
+                ensure_scalar_types_program_compiled()?;
+                Ok(dir.join("scalar_types_program"))
             }
             RegisteredFixtureKind::RustGlobal => {
                 ensure_rust_global_program_compiled()?;
@@ -1037,6 +1055,7 @@ pub mod termination;
 
 static COMPILE_GLOBALS: Once = Once::new();
 static COMPILE_LATE_GLOBALS: Once = Once::new();
+static COMPILE_SCALAR_TYPES: Once = Once::new();
 static COMPILE_RUST_GLOBAL: Once = Once::new();
 static COMPILE_INLINE_CALLSITE_DEFAULT: Once = Once::new();
 static COMPILE_INLINE_CALLSITE_CLANG_DWARF5: Once = Once::new();
@@ -1122,6 +1141,23 @@ fn ensure_late_globals_program_compiled() -> anyhow::Result<()> {
     });
 
     match COMPILE_LATE_GLOBALS_RESULT.lock().unwrap().as_ref() {
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+        None => panic!("Compilation result should be set after call_once"),
+    }
+}
+
+fn ensure_scalar_types_program_compiled() -> anyhow::Result<()> {
+    COMPILE_SCALAR_TYPES.call_once(|| {
+        let compile_result = compile_c_make_fixture(
+            "scalar_types_program",
+            FixtureCompiler::Default,
+            "-Wall -Wextra -g -O0",
+        );
+        *COMPILE_SCALAR_TYPES_RESULT.lock().unwrap() = Some(compile_result);
+    });
+
+    match COMPILE_SCALAR_TYPES_RESULT.lock().unwrap().as_ref() {
         Some(Ok(())) => Ok(()),
         Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
         None => panic!("Compilation result should be set after call_once"),

--- a/e2e-tests/tests/fixtures/scalar_types_program/Makefile
+++ b/e2e-tests/tests/fixtures/scalar_types_program/Makefile
@@ -1,0 +1,18 @@
+CC ?= gcc
+BASE_CFLAGS ?= -Wall -Wextra -g
+CFLAGS ?= $(BASE_CFLAGS) -O0
+BINARY ?= scalar_types_program
+OBJ ?= $(BINARY).o
+
+all: $(BINARY)
+
+$(BINARY): $(OBJ)
+	$(CC) $(CFLAGS) -o $@ $^
+
+$(OBJ): scalar_types_program.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f *.o scalar_types_program
+
+.PHONY: all clean

--- a/e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program.c
+++ b/e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program.c
@@ -1,0 +1,88 @@
+#include <stdint.h>
+#include <unistd.h>
+
+static volatile uintptr_t scalar_sink;
+
+__attribute__((noinline)) static void scalar_anchor(
+    volatile int8_t *i8p,
+    volatile uint8_t *u8p,
+    volatile short *i16p,
+    volatile unsigned short *u16p,
+    volatile int *i32p,
+    volatile unsigned int *u32p,
+    volatile long *ilongp,
+    volatile unsigned long *ulongp,
+    volatile long long *i64p,
+    volatile uint64_t *u64p,
+    volatile _Bool *truep,
+    volatile _Bool *falsep,
+    volatile float *f32p,
+    volatile double *f64p,
+    volatile long double *ldp)
+{
+    uintptr_t mix = (uintptr_t)i8p;
+    mix ^= (uintptr_t)u8p;
+    mix ^= (uintptr_t)i16p;
+    mix ^= (uintptr_t)u16p;
+    mix ^= (uintptr_t)i32p;
+    mix ^= (uintptr_t)u32p;
+    mix ^= (uintptr_t)ilongp;
+    mix ^= (uintptr_t)ulongp;
+    mix ^= (uintptr_t)i64p;
+    mix ^= (uintptr_t)u64p;
+    mix ^= (uintptr_t)truep;
+    mix ^= (uintptr_t)falsep;
+    mix ^= (uintptr_t)f32p;
+    mix ^= (uintptr_t)f64p;
+    mix ^= (uintptr_t)ldp;
+    scalar_sink ^= mix;
+    asm volatile("" ::: "memory");
+}
+
+__attribute__((noinline)) static void scalar_probe(int iter)
+{
+    volatile int8_t i8_neg = (int8_t)-5;
+    volatile uint8_t u8_big = (uint8_t)250u;
+    volatile short i16_neg = (short)-1234;
+    volatile unsigned short u16_big = (unsigned short)60000u;
+    volatile int i32_neg = -12345678;
+    volatile unsigned int u32_big = 4000000000U;
+    volatile long ilong_neg = -4444444444L;
+    volatile unsigned long ulong_big = 9000000000UL;
+    volatile long long i64_neg = -9000000000000000000LL;
+    volatile uint64_t u64_big = UINT64_C(18446744073709551610);
+    volatile _Bool bool_true = iter >= 0;
+    volatile _Bool bool_false = 0;
+    volatile float f32_val = -12.5f;
+    volatile double f64_val = 123456.25;
+    volatile long double ldouble_val = -3.5L;
+
+    scalar_anchor(
+        &i8_neg,
+        &u8_big,
+        &i16_neg,
+        &u16_big,
+        &i32_neg,
+        &u32_big,
+        &ilong_neg,
+        &ulong_big,
+        &i64_neg,
+        &u64_big,
+        &bool_true,
+        &bool_false,
+        &f32_val,
+        &f64_val,
+        &ldouble_val);
+}
+
+int main(void)
+{
+    int iter = 0;
+
+    while (iter < 20000) {
+        scalar_probe(iter++);
+        usleep(10000);
+    }
+
+    return 0;
+}

--- a/e2e-tests/tests/scalar_types_execution.rs
+++ b/e2e-tests/tests/scalar_types_execution.rs
@@ -1,0 +1,144 @@
+//! C scalar type execution tests
+//! - Covers signed/unsigned integer widths, booleans, and floating-point formatting
+
+mod common;
+
+use common::{init, FIXTURES};
+use std::path::Path;
+use std::time::Duration;
+
+async fn run_ghostscope_with_script_for_target(
+    script_content: &str,
+    timeout_secs: u64,
+    target: &common::targets::TargetHandle,
+) -> anyhow::Result<(i32, String, String)> {
+    common::runner::GhostscopeRunner::new()
+        .with_script(script_content)
+        .attach_to(target)
+        .timeout_secs(timeout_secs)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await
+}
+
+async fn spawn_scalar_types_binary(
+    binary_path: &Path,
+) -> anyhow::Result<common::targets::TargetHandle> {
+    let target = common::targets::TargetLauncher::binary(binary_path)
+        .spawn()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(target)
+}
+
+#[tokio::test]
+async fn test_c_scalar_integer_prints_preserve_signedness() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("scalar_types_program")?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_anchor {
+    print "SIGNED:{}:{}:{}:{}:{}", *i8p, *i16p, *i32p, *ilongp, *i64p;
+    print "UNSIGNED:{}:{}:{}:{}:{}", *u8p, *u16p, *u32p, *ulongp, *u64p;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("SIGNED:-5:-1234:-12345678:-4444444444:-9000000000000000000"),
+        "Expected signed scalar values to preserve negative formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("UNSIGNED:250:60000:4000000000:9000000000:18446744073709551610"),
+        "Expected unsigned scalar values to preserve full-width formatting. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_integer_comparisons_respect_widths() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("scalar_types_program")?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_anchor {
+    if *i8p < 0 { print "I8_NEG"; }
+    if *i16p < -1000 { print "I16_NEG"; }
+    if *i32p < -10000000 { print "I32_NEG"; }
+    if *ilongp < -4000000000 { print "LONG_NEG"; }
+    if *i64p < -8000000000000000000 { print "I64_NEG"; }
+    if *u8p > 200 { print "U8_BIG"; }
+    if *u16p > 50000 { print "U16_BIG"; }
+    if *u32p > 3000000000 { print "U32_BIG"; }
+    if *ulongp > 8000000000 { print "ULONG_BIG"; }
+    if *u64p != 0 { print "U64_NONZERO"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    for marker in [
+        "I8_NEG",
+        "I16_NEG",
+        "I32_NEG",
+        "LONG_NEG",
+        "I64_NEG",
+        "U8_BIG",
+        "U16_BIG",
+        "U32_BIG",
+        "ULONG_BIG",
+        "U64_NONZERO",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected comparison marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_bool_and_float_prints() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("scalar_types_program")?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_anchor {
+    print "BOOL:{}:{}", *truep, *falsep;
+    print "FLOAT:{}:{}", *f32p, *f64p;
+    print "LDOUBLE:{}", *ldp;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("BOOL:true:false"),
+        "Expected _Bool formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("FLOAT:-12.5:123456.25"),
+        "Expected float/double formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("LDOUBLE:<UNSUPPORTED_FLOAT_SIZE_16>"),
+        "Expected long double to report the current unsupported 16-byte boundary. STDOUT: {stdout}"
+    );
+    Ok(())
+}

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -398,6 +398,55 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
     }
 
+    fn is_signed_integer_type(dwarf_type: &TypeInfo) -> bool {
+        match dwarf_type {
+            TypeInfo::BaseType { encoding, .. } => {
+                *encoding == ghostscope_dwarf::constants::DW_ATE_signed.0 as u16
+                    || *encoding == ghostscope_dwarf::constants::DW_ATE_signed_char.0 as u16
+            }
+            TypeInfo::EnumType { base_type, .. } => Self::is_signed_integer_type(base_type),
+            TypeInfo::BitfieldType {
+                underlying_type, ..
+            } => Self::is_signed_integer_type(underlying_type),
+            TypeInfo::TypedefType {
+                underlying_type, ..
+            }
+            | TypeInfo::QualifiedType {
+                underlying_type, ..
+            } => Self::is_signed_integer_type(underlying_type),
+            _ => false,
+        }
+    }
+
+    fn sign_extend_memory_read_if_needed(
+        &self,
+        value: BasicValueEnum<'ctx>,
+        dwarf_type: &TypeInfo,
+        access_size: MemoryAccessSize,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        if !Self::is_signed_integer_type(dwarf_type) || matches!(access_size, MemoryAccessSize::U64)
+        {
+            return Ok(value);
+        }
+
+        let int_value = value.into_int_value();
+        let narrow_type = match access_size {
+            MemoryAccessSize::U8 => self.context.i8_type(),
+            MemoryAccessSize::U16 => self.context.i16_type(),
+            MemoryAccessSize::U32 => self.context.i32_type(),
+            MemoryAccessSize::U64 => unreachable!("U64 values do not need sign extension"),
+        };
+        let narrowed = self
+            .builder
+            .build_int_truncate(int_value, narrow_type, "signed_mem_trunc")
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        let extended = self
+            .builder
+            .build_int_s_extend(narrowed, self.context.i64_type(), "signed_mem_sext")
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        Ok(extended.into())
+    }
+
     pub(super) fn variable_read_plan_to_runtime_read_parts(
         &self,
         plan: VariableReadPlan,
@@ -456,11 +505,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
 
         let access_size = self.dwarf_type_to_memory_access_size(dwarf_type);
-        if self.condition_context_active {
+        let read_value = if self.condition_context_active {
             self.generate_memory_read_with_status(addr, access_size)
         } else {
             self.generate_memory_read(addr, access_size, status_ptr)
-        }
+        }?;
+
+        self.sign_extend_memory_read_if_needed(read_value, dwarf_type, access_size)
     }
 
     /// Execute a sequence of compute steps


### PR DESCRIPTION
Add a C scalar fixture and e2e coverage for signed and unsigned integer widths, booleans, float/double formatting, and the current long double unsupported boundary.

Sign-extend memory-backed signed DWARF integers after probe reads so negative narrow values compare correctly.