### PR TITLE
refactor: narrow dwarf direct materialization

### DIFF
--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -77,46 +77,18 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         );
         debug!("Evaluation context PC address: 0x{:x}", pc_address);
 
-        let pt_regs_ptr = self.get_pt_regs_parameter()?;
-        let result_size = MemoryAccessSize::from_size(Self::get_dwarf_type_size(dwarf_type));
+        if let Some(value) = ghostscope_dwarf::PlannedValue::from_location(location.clone()) {
+            return self
+                .planned_value_to_llvm_value(&value, dwarf_type, var_name, pc_address, status_ptr);
+        }
 
         match location {
-            VariableLocation::RegisterValue { dwarf_reg } => {
-                debug!("Generating register value: {dwarf_reg}");
-                self.load_register_value(*dwarf_reg, pt_regs_ptr)
-            }
-            VariableLocation::ComputedValue(steps) => {
-                debug!("Generating computed value: {} steps", steps.len());
-                let runtime_status_ptr = if self.condition_context_active {
-                    Some(self.get_or_create_cond_error_global())
-                } else {
-                    status_ptr
-                };
-                self.generate_compute_steps(
-                    steps,
-                    pt_regs_ptr,
-                    Some(result_size),
-                    runtime_status_ptr,
-                    None,
-                )
-            }
-            VariableLocation::ImplicitValue(bytes) => {
-                debug!("Generating implicit value: {} bytes", bytes.len());
-                let mut value: u64 = 0;
-                for (i, &byte) in bytes.iter().enumerate().take(8) {
-                    value |= (byte as u64) << (i * 8);
-                }
-                Ok(self.context.i64_type().const_int(value, false).into())
-            }
-            VariableLocation::AbsoluteAddressValue(_) => {
-                let runtime_status_ptr = if self.condition_context_active {
-                    Some(self.get_or_create_cond_error_global())
-                } else {
-                    status_ptr
-                };
-                self.variable_location_to_address_with_hint(location, runtime_status_ptr, None)
-                    .map(Into::into)
-            }
+            VariableLocation::AbsoluteAddressValue(_)
+            | VariableLocation::RegisterValue { .. }
+            | VariableLocation::ComputedValue(_)
+            | VariableLocation::ImplicitValue(_) => Err(CodeGenError::DwarfError(format!(
+                "Direct DWARF value '{var_name}' could not be materialized as a planned value"
+            ))),
             VariableLocation::Address(_)
             | VariableLocation::RegisterAddress { .. }
             | VariableLocation::ComputedAddress(_) => {
@@ -146,6 +118,62 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             VariableLocation::Unknown => Err(CodeGenError::DwarfError(
                 "Variable read plan has unknown location".to_string(),
             )),
+        }
+    }
+
+    fn planned_value_to_llvm_value(
+        &mut self,
+        value: &ghostscope_dwarf::PlannedValue,
+        dwarf_type: &TypeInfo,
+        var_name: &str,
+        _pc_address: u64,
+        status_ptr: Option<PointerValue<'ctx>>,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        let pt_regs_ptr = self.get_pt_regs_parameter()?;
+        let result_size = MemoryAccessSize::from_size(Self::get_dwarf_type_size(dwarf_type));
+        match value {
+            ghostscope_dwarf::PlannedValue::Constant(value) => Ok(self
+                .context
+                .i64_type()
+                .const_int(*value as u64, true)
+                .into()),
+            ghostscope_dwarf::PlannedValue::RegisterValue { dwarf_reg } => {
+                debug!("Generating register value: {dwarf_reg}");
+                self.load_register_value(*dwarf_reg, pt_regs_ptr)
+            }
+            ghostscope_dwarf::PlannedValue::ComputedValue { steps } => {
+                debug!("Generating computed value: {} steps", steps.len());
+                let runtime_status_ptr = if self.condition_context_active {
+                    Some(self.get_or_create_cond_error_global())
+                } else {
+                    status_ptr
+                };
+                self.generate_compute_steps(
+                    steps,
+                    pt_regs_ptr,
+                    Some(result_size),
+                    runtime_status_ptr,
+                    None,
+                )
+            }
+            ghostscope_dwarf::PlannedValue::ImplicitBytes(bytes) => {
+                debug!("Generating implicit value: {} bytes", bytes.len());
+                let mut value: u64 = 0;
+                for (i, &byte) in bytes.iter().enumerate().take(8) {
+                    value |= (byte as u64) << (i * 8);
+                }
+                Ok(self.context.i64_type().const_int(value, false).into())
+            }
+            ghostscope_dwarf::PlannedValue::AddressValue { address } => {
+                debug!("Generating address direct value for variable: {var_name}");
+                let runtime_status_ptr = if self.condition_context_active {
+                    Some(self.get_or_create_cond_error_global())
+                } else {
+                    status_ptr
+                };
+                self.planned_address_to_llvm_address(address, runtime_status_ptr, None)
+                    .map(Into::into)
+            }
         }
     }
 
@@ -453,14 +481,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         status_ptr: Option<PointerValue<'ctx>>,
     ) -> Result<BasicValueEnum<'ctx>> {
         match &materialization.materialization {
-            ghostscope_dwarf::VariableMaterialization::DirectValue { location, .. } => {
+            ghostscope_dwarf::VariableMaterialization::DirectValue { value } => {
                 let dwarf_type = materialization.dwarf_type.as_ref().ok_or_else(|| {
                     CodeGenError::DwarfError(
                         "Expression has no DWARF type information".to_string(),
                     )
                 })?;
-                self.variable_location_to_llvm_value(
-                    location,
+                self.planned_value_to_llvm_value(
+                    value,
                     dwarf_type,
                     &materialization.name,
                     pc_address,

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -36,7 +36,7 @@ pub use core::{
 // Re-export semantic contract types.
 pub use semantics::{
     AddressOrigin, AddressSpaceInfo, CfaRulePlan, CompactUnwindRow, CompactUnwindStats,
-    CompactUnwindTable, InlineFrame, PcContext, PcLineInfo, PcRange, PlannedAddress,
+    CompactUnwindTable, InlineFrame, PcContext, PcLineInfo, PcRange, PlannedAddress, PlannedValue,
     RegisterRecoveryPlan, UnwindDiagnostic, UnwindDiagnosticKind, VariableAccessPath,
     VariableAccessSegment, VariableLoweringKind, VariableLoweringPlan, VariableMaterialization,
     VariableMaterializationPlan, VariablePlan, VariableQueryDiagnostic, VariableReadPlan,

--- a/ghostscope-dwarf/src/semantics/variable_plan.rs
+++ b/ghostscope-dwarf/src/semantics/variable_plan.rs
@@ -74,20 +74,20 @@ pub struct PlannedAddress {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum PlannedValue {
+    Constant(i64),
+    RegisterValue { dwarf_reg: u16 },
+    ComputedValue { steps: Vec<ComputeStep> },
+    ImplicitBytes(Vec<u8>),
+    AddressValue { address: PlannedAddress },
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum VariableMaterialization {
-    DirectValue {
-        location: VariableLocation,
-        address_origin: Option<AddressOrigin>,
-    },
-    UserMemoryRead {
-        address: PlannedAddress,
-    },
-    Composite {
-        pieces: Vec<PieceLocation>,
-    },
-    Unavailable {
-        availability: Availability,
-    },
+    DirectValue { value: PlannedValue },
+    UserMemoryRead { address: PlannedAddress },
+    Composite { pieces: Vec<PieceLocation> },
+    Unavailable { availability: Availability },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -288,10 +288,21 @@ impl VariableReadPlan {
             }
         } else {
             match lowering.kind {
-                VariableLoweringKind::DirectValue => VariableMaterialization::DirectValue {
-                    address_origin: direct_value_address_origin(&self.location),
-                    location: self.location.clone(),
-                },
+                VariableLoweringKind::DirectValue => {
+                    match PlannedValue::from_location(self.location.clone()) {
+                        Some(value) => VariableMaterialization::DirectValue { value },
+                        None => VariableMaterialization::Unavailable {
+                            availability: Availability::Unsupported(
+                                UnsupportedReason::ExpressionShape {
+                                    detail: format!(
+                                        "location {} cannot be materialized as a direct value",
+                                        self.location
+                                    ),
+                                },
+                            ),
+                        },
+                    }
+                }
                 VariableLoweringKind::UserMemoryRead => {
                     match PlannedAddress::from_location(self.location.clone()) {
                         Some(address) => VariableMaterialization::UserMemoryRead { address },
@@ -450,6 +461,35 @@ impl VariableReadPlan {
     }
 }
 
+impl PlannedValue {
+    pub fn from_location(location: VariableLocation) -> Option<Self> {
+        match location {
+            VariableLocation::RegisterValue { dwarf_reg } => {
+                Some(Self::RegisterValue { dwarf_reg })
+            }
+            VariableLocation::ComputedValue(steps) => {
+                if let [ComputeStep::PushConstant(value)] = steps.as_slice() {
+                    Some(Self::Constant(*value))
+                } else {
+                    Some(Self::ComputedValue { steps })
+                }
+            }
+            VariableLocation::ImplicitValue(bytes) => Some(Self::ImplicitBytes(bytes)),
+            VariableLocation::AbsoluteAddressValue(expr) => {
+                PlannedAddress::from_location(VariableLocation::AbsoluteAddressValue(expr))
+                    .map(|address| Self::AddressValue { address })
+            }
+            VariableLocation::Address(_)
+            | VariableLocation::RegisterAddress { .. }
+            | VariableLocation::FrameBaseRelative { .. }
+            | VariableLocation::ComputedAddress(_)
+            | VariableLocation::Pieces(_)
+            | VariableLocation::OptimizedOut
+            | VariableLocation::Unknown => None,
+        }
+    }
+}
+
 impl PlannedAddress {
     pub fn from_location(location: VariableLocation) -> Option<Self> {
         let origin = match &location {
@@ -509,13 +549,6 @@ impl RuntimeCapabilities {
                 self.regular_uprobe || self.sleepable_uprobe || self.copy_from_user_task
             }
         }
-    }
-}
-
-fn direct_value_address_origin(location: &VariableLocation) -> Option<AddressOrigin> {
-    match location {
-        VariableLocation::AbsoluteAddressValue(expr) => Some(address_origin_for_steps(&expr.steps)),
-        _ => None,
     }
 }
 
@@ -1140,15 +1173,46 @@ mod tests {
 
         match materialized.materialization {
             VariableMaterialization::DirectValue {
-                address_origin,
-                location,
-            } => {
-                assert_eq!(address_origin, Some(AddressOrigin::LinkTime));
-                assert!(matches!(
-                    location,
-                    VariableLocation::AbsoluteAddressValue(_)
-                ));
+                value:
+                    PlannedValue::AddressValue {
+                        address:
+                            PlannedAddress {
+                                origin: AddressOrigin::LinkTime,
+                                ..
+                            },
+                    },
+            } => {}
+            VariableMaterialization::DirectValue { value } => {
+                panic!("unexpected direct value: {value:?}");
             }
+            other => panic!("unexpected materialization: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn materialization_plan_converts_constant_direct_value() {
+        let plan = read_plan(VariableLocation::ComputedValue(vec![
+            ComputeStep::PushConstant(42),
+        ]));
+        let materialized = plan.materialization_plan(&capabilities(false));
+
+        match materialized.materialization {
+            VariableMaterialization::DirectValue {
+                value: PlannedValue::Constant(42),
+            } => {}
+            other => panic!("unexpected materialization: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn materialization_plan_converts_register_direct_value() {
+        let plan = read_plan(VariableLocation::RegisterValue { dwarf_reg: 6 });
+        let materialized = plan.materialization_plan(&capabilities(false));
+
+        match materialized.materialization {
+            VariableMaterialization::DirectValue {
+                value: PlannedValue::RegisterValue { dwarf_reg: 6 },
+            } => {}
             other => panic!("unexpected materialization: {other:?}"),
         }
     }


### PR DESCRIPTION
Introduce PlannedValue as the direct-value primitive emitted by DWARF materialization plans. This keeps constants, register values, computed values, implicit bytes, and address values explicit without exposing the full VariableLocation shape to compiler direct-value lowering.

Route compiler direct-value codegen through PlannedValue while keeping the legacy VariableLocation helper as a compatibility entry point. This makes the materialization contract closer to the USDT-style operand model and leaves address IR compaction for a later step.

Refs #148.