### PR TITLE
fix: respect unsigned C scalar ordering

### DIFF
--- a/e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program.c
+++ b/e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program.c
@@ -1,6 +1,18 @@
 #include <stdint.h>
 #include <unistd.h>
 
+typedef int8_t scalar_i8_alias;
+typedef uint16_t scalar_u16_alias;
+
+enum scalar_signed_enum {
+    SCALAR_ENUM_NEG = -3,
+    SCALAR_ENUM_POS = 7,
+};
+
+enum scalar_big_enum {
+    SCALAR_ENUM_BIG = 4000000000U,
+};
+
 static volatile uintptr_t scalar_sink;
 
 __attribute__((noinline)) static void scalar_anchor(
@@ -39,6 +51,55 @@ __attribute__((noinline)) static void scalar_anchor(
     asm volatile("" ::: "memory");
 }
 
+__attribute__((noinline)) static void scalar_extra_anchor(
+    volatile char *charp,
+    volatile signed char *scharp,
+    volatile unsigned char *ucharp,
+    volatile scalar_i8_alias *alias_i8p,
+    volatile const scalar_u16_alias *qualified_u16p,
+    volatile enum scalar_signed_enum *enum_negp,
+    volatile enum scalar_big_enum *enum_bigp,
+    volatile float *neg_zerop,
+    volatile double *infp,
+    volatile double *nanp)
+{
+    uintptr_t mix = (uintptr_t)charp;
+    mix ^= (uintptr_t)scharp;
+    mix ^= (uintptr_t)ucharp;
+    mix ^= (uintptr_t)alias_i8p;
+    mix ^= (uintptr_t)qualified_u16p;
+    mix ^= (uintptr_t)enum_negp;
+    mix ^= (uintptr_t)enum_bigp;
+    mix ^= (uintptr_t)neg_zerop;
+    mix ^= (uintptr_t)infp;
+    mix ^= (uintptr_t)nanp;
+    scalar_sink ^= mix;
+    asm volatile("" ::: "memory");
+}
+
+__attribute__((noinline)) static void scalar_by_value(
+    int8_t i8v,
+    uint8_t u8v,
+    short i16v,
+    unsigned short u16v,
+    uint32_t u32v,
+    uint64_t u64v,
+    scalar_i8_alias alias_i8v,
+    enum scalar_signed_enum enum_negv,
+    enum scalar_big_enum enum_bigv)
+{
+    scalar_sink ^= (uintptr_t)(uint8_t)i8v;
+    scalar_sink ^= (uintptr_t)u8v;
+    scalar_sink ^= (uintptr_t)(uint16_t)i16v;
+    scalar_sink ^= (uintptr_t)u16v;
+    scalar_sink ^= (uintptr_t)u32v;
+    scalar_sink ^= (uintptr_t)u64v;
+    scalar_sink ^= (uintptr_t)(uint8_t)alias_i8v;
+    scalar_sink ^= (uintptr_t)(int)enum_negv;
+    scalar_sink ^= (uintptr_t)(uint64_t)enum_bigv;
+    asm volatile("" ::: "memory");
+}
+
 __attribute__((noinline)) static void scalar_probe(int iter)
 {
     volatile int8_t i8_neg = (int8_t)-5;
@@ -56,6 +117,16 @@ __attribute__((noinline)) static void scalar_probe(int iter)
     volatile float f32_val = -12.5f;
     volatile double f64_val = 123456.25;
     volatile long double ldouble_val = -3.5L;
+    volatile char plain_char = 'A';
+    volatile signed char schar_neg = (signed char)-7;
+    volatile unsigned char uchar_big = (unsigned char)240u;
+    volatile scalar_i8_alias alias_i8_neg = (scalar_i8_alias)-9;
+    volatile const scalar_u16_alias qualified_u16_big = (scalar_u16_alias)65000u;
+    volatile enum scalar_signed_enum enum_neg = SCALAR_ENUM_NEG;
+    volatile enum scalar_big_enum enum_big = SCALAR_ENUM_BIG;
+    volatile float f32_neg_zero = -0.0f;
+    volatile double f64_inf = __builtin_huge_val();
+    volatile double f64_nan = __builtin_nan("");
 
     scalar_anchor(
         &i8_neg,
@@ -73,6 +144,29 @@ __attribute__((noinline)) static void scalar_probe(int iter)
         &f32_val,
         &f64_val,
         &ldouble_val);
+
+    scalar_extra_anchor(
+        &plain_char,
+        &schar_neg,
+        &uchar_big,
+        &alias_i8_neg,
+        &qualified_u16_big,
+        &enum_neg,
+        &enum_big,
+        &f32_neg_zero,
+        &f64_inf,
+        &f64_nan);
+
+    scalar_by_value(
+        i8_neg,
+        u8_big,
+        i16_neg,
+        u16_big,
+        u32_big,
+        u64_big,
+        alias_i8_neg,
+        enum_neg,
+        enum_big);
 }
 
 int main(void)

--- a/e2e-tests/tests/scalar_types_execution.rs
+++ b/e2e-tests/tests/scalar_types_execution.rs
@@ -79,6 +79,7 @@ trace scalar_anchor {
     if *u16p > 50000 { print "U16_BIG"; }
     if *u32p > 3000000000 { print "U32_BIG"; }
     if *ulongp > 8000000000 { print "ULONG_BIG"; }
+    if *u64p > 9223372036854775807 { print "U64_HIGH"; }
     if *u64p != 0 { print "U64_NONZERO"; }
 }
 "#;
@@ -98,6 +99,7 @@ trace scalar_anchor {
         "U16_BIG",
         "U32_BIG",
         "ULONG_BIG",
+        "U64_HIGH",
         "U64_NONZERO",
     ] {
         assert!(
@@ -140,5 +142,105 @@ trace scalar_anchor {
         stdout.contains("LDOUBLE:<UNSUPPORTED_FLOAT_SIZE_16>"),
         "Expected long double to report the current unsupported 16-byte boundary. STDOUT: {stdout}"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_by_value_parameters_preserve_semantics() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("scalar_types_program")?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_by_value {
+    print "BYVAL_SIGNED:{}:{}:{}", i8v, i16v, alias_i8v;
+    print "BYVAL_UNSIGNED:{}:{}:{}:{}", u8v, u16v, u32v, u64v;
+    if i8v < 0 { print "BYVAL_I8_NEG"; }
+    if i16v < -1000 { print "BYVAL_I16_NEG"; }
+    if alias_i8v < 0 { print "BYVAL_ALIAS_NEG"; }
+    if u64v > 9223372036854775807 { print "BYVAL_U64_HIGH"; }
+    print "BYVAL_ENUMS:{}:{}", enum_negv, enum_bigv;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("BYVAL_SIGNED:-5:-1234:-9"),
+        "Expected signed by-value parameters to preserve negatives. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("BYVAL_UNSIGNED:250:60000:4000000000:18446744073709551610"),
+        "Expected unsigned by-value parameters to preserve full-width values. STDOUT: {stdout}"
+    );
+    for marker in [
+        "BYVAL_I8_NEG",
+        "BYVAL_I16_NEG",
+        "BYVAL_ALIAS_NEG",
+        "BYVAL_U64_HIGH",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected by-value marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("BYVAL_ENUMS:scalar_signed_enum::SCALAR_ENUM_NEG(-3):scalar_big_enum::SCALAR_ENUM_BIG(4000000000)"),
+        "Expected signed and large enum formatting. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_typedef_char_enum_and_float_edges() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("scalar_types_program")?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_extra_anchor {
+    print "CHARS:{}:{}:{}", *charp, *scharp, *ucharp;
+    print "ALIASES:{}:{}", *alias_i8p, *qualified_u16p;
+    print "ENUMS:{}:{}", *enum_negp, *enum_bigp;
+    print "FLOAT_EDGE:{}:{}:{}", *neg_zerop, *infp, *nanp;
+    if *alias_i8p < 0 { print "ALIAS_NEG"; }
+    if *qualified_u16p > 64000 { print "QUAL_U16_BIG"; }
+    if *enum_negp < 0 { print "ENUM_NEG"; }
+    if *enum_bigp > 3000000000 { print "ENUM_BIG"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("CHARS:65:-7:240"),
+        "Expected char/signed char/unsigned char numeric formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("ALIASES:-9:65000"),
+        "Expected typedef and qualified scalar formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("ENUMS:scalar_signed_enum(scalar_signed_enum::SCALAR_ENUM_NEG(-3)):scalar_big_enum(scalar_big_enum::SCALAR_ENUM_BIG(4000000000))"),
+        "Expected enum variant formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("FLOAT_EDGE:-0:inf:NaN"),
+        "Expected float edge formatting for -0.0, infinity, and NaN. STDOUT: {stdout}"
+    );
+    for marker in ["ALIAS_NEG", "QUAL_U16_BIG", "ENUM_NEG", "ENUM_BIG"] {
+        assert!(
+            stdout.contains(marker),
+            "Expected marker {marker}. STDOUT: {stdout}"
+        );
+    }
     Ok(())
 }

--- a/ghostscope-compiler/src/ebpf/expression.rs
+++ b/ghostscope-compiler/src/ebpf/expression.rs
@@ -244,6 +244,36 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
         false
     }
+
+    fn is_unsigned_integer_type(t: &DwarfType) -> bool {
+        match t {
+            DwarfType::BaseType { encoding, .. } => {
+                *encoding == ghostscope_dwarf::constants::DW_ATE_unsigned.0 as u16
+                    || *encoding == ghostscope_dwarf::constants::DW_ATE_unsigned_char.0 as u16
+            }
+            DwarfType::EnumType { base_type, .. } => Self::is_unsigned_integer_type(base_type),
+            DwarfType::BitfieldType {
+                underlying_type, ..
+            } => Self::is_unsigned_integer_type(underlying_type),
+            DwarfType::TypedefType {
+                underlying_type, ..
+            }
+            | DwarfType::QualifiedType {
+                underlying_type, ..
+            } => Self::is_unsigned_integer_type(underlying_type),
+            _ => false,
+        }
+    }
+
+    fn is_dwarf_unsigned_integer_expr(&mut self, expr: &Expr) -> bool {
+        if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
+            if let Some(ref ty) = var.dwarf_type {
+                return Self::is_unsigned_integer_type(ty);
+            }
+        }
+        false
+    }
+
     /// Ensure that when an expression refers to a DWARF-backed variable (not via address-of),
     /// the variable's DWARF type is a pointer or array (decays to pointer for memcmp/strncmp).
     fn ensure_dwarf_pointer_arg(&mut self, e: &Expr, where_ctx: &str) -> Result<()> {
@@ -1662,10 +1692,19 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     return Ok(phi.as_basic_value());
                 }
 
+                let use_unsigned_ordering = is_ordered
+                    && (self.is_dwarf_unsigned_integer_expr(left)
+                        || self.is_dwarf_unsigned_integer_expr(right));
+
                 // Default eager evaluation for other binary ops
                 let left_val = self.compile_expr(left)?;
                 let right_val = self.compile_expr(right)?;
-                self.compile_binary_op(left_val, op.clone(), right_val)
+                self.compile_binary_op_with_ordering(
+                    left_val,
+                    op.clone(),
+                    right_val,
+                    use_unsigned_ordering,
+                )
             }
             Expr::MemberAccess(_, _) => {
                 // Use unified DWARF expression compilation
@@ -1811,6 +1850,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         op: BinaryOp,
         right: BasicValueEnum<'ctx>,
     ) -> Result<BasicValueEnum<'ctx>> {
+        self.compile_binary_op_with_ordering(left, op, right, false)
+    }
+
+    fn compile_binary_op_with_ordering(
+        &mut self,
+        left: BasicValueEnum<'ctx>,
+        op: BinaryOp,
+        right: BasicValueEnum<'ctx>,
+        use_unsigned_ordering: bool,
+    ) -> Result<BasicValueEnum<'ctx>> {
         use inkwell::values::BasicValueEnum::*;
 
         // Debug logging to understand the actual types
@@ -1871,50 +1920,50 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         return Ok(result.into());
                     }
                     BinaryOp::LessThan => {
+                        let predicate = if use_unsigned_ordering {
+                            inkwell::IntPredicate::ULT
+                        } else {
+                            inkwell::IntPredicate::SLT
+                        };
                         let result = self
                             .builder
-                            .build_int_compare(
-                                inkwell::IntPredicate::SLT,
-                                left_int,
-                                right_int,
-                                "lt",
-                            )
+                            .build_int_compare(predicate, left_int, right_int, "lt")
                             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
                         return Ok(result.into());
                     }
                     BinaryOp::LessEqual => {
+                        let predicate = if use_unsigned_ordering {
+                            inkwell::IntPredicate::ULE
+                        } else {
+                            inkwell::IntPredicate::SLE
+                        };
                         let result = self
                             .builder
-                            .build_int_compare(
-                                inkwell::IntPredicate::SLE,
-                                left_int,
-                                right_int,
-                                "le",
-                            )
+                            .build_int_compare(predicate, left_int, right_int, "le")
                             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
                         return Ok(result.into());
                     }
                     BinaryOp::GreaterThan => {
+                        let predicate = if use_unsigned_ordering {
+                            inkwell::IntPredicate::UGT
+                        } else {
+                            inkwell::IntPredicate::SGT
+                        };
                         let result = self
                             .builder
-                            .build_int_compare(
-                                inkwell::IntPredicate::SGT,
-                                left_int,
-                                right_int,
-                                "gt",
-                            )
+                            .build_int_compare(predicate, left_int, right_int, "gt")
                             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
                         return Ok(result.into());
                     }
                     BinaryOp::GreaterEqual => {
+                        let predicate = if use_unsigned_ordering {
+                            inkwell::IntPredicate::UGE
+                        } else {
+                            inkwell::IntPredicate::SGE
+                        };
                         let result = self
                             .builder
-                            .build_int_compare(
-                                inkwell::IntPredicate::SGE,
-                                left_int,
-                                right_int,
-                                "ge",
-                            )
+                            .build_int_compare(predicate, left_int, right_int, "ge")
                             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
                         return Ok(result.into());
                     }


### PR DESCRIPTION
Extend scalar e2e coverage for by-value C scalars, typedef and qualified aliases, enum formatting, and float edge values. Use DWARF unsigned type information for ordered integer comparisons so high-bit unsigned values compare correctly.