### PR TITLE
ci: cache compiler-specific e2e fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   FIXTURE_COMPILER_IMAGE: ghcr.io/swananan/ghostscope-fixture-compiler@sha256:b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89
-  FIXTURE_COMPILER_CACHE_REV: b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89
+  FIXTURE_COMPILER_CACHE_REV: b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89-fixture-archive
 
 jobs:
   fmt:
@@ -180,41 +180,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-target-
 
-      - name: Cache fixture binaries
+      - name: Cache fixture archive
         id: fixture-cache
         uses: actions/cache@v4
         with:
-          path: |
-            e2e-tests/tests/fixtures/sample_program/sample_program
-            e2e-tests/tests/fixtures/sample_program/sample_program_o1
-            e2e-tests/tests/fixtures/sample_program/sample_program_o2
-            e2e-tests/tests/fixtures/sample_program/sample_program_o3
-            e2e-tests/tests/fixtures/sample_program/sample_program_stripped
-            e2e-tests/tests/fixtures/sample_program/sample_program_stripped.debug
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o1
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o2
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o3
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_nopie
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o1
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o2
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o3
-            e2e-tests/tests/fixtures/globals_program/globals_program
-            e2e-tests/tests/fixtures/globals_program/libgvars.so
-            e2e-tests/tests/fixtures/late_globals_program/late_globals_program
-            e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
-            e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program
-            e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
-            e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5
-            e2e-tests/tests/fixtures/inline_call_value_program/inline_call_value_program
-            e2e-tests/tests/fixtures/partitioned_ranges_program/partitioned_ranges_program
-            e2e-tests/tests/fixtures/cpp_complex_program/cpp_complex_program
-            e2e-tests/tests/fixtures/static_scope_program/static_scope_program
-            e2e-tests/tests/fixtures/static_scope_program/static_scope_program_clang_dwarf5
-            e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program
-            e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program_clang_dwarf5
-          key: ${{ runner.os }}-${{ github.job }}-fixtures-${{ env.FIXTURE_COMPILER_CACHE_REV }}-${{ hashFiles('e2e-tests/compile-fixtures.sh', 'e2e-tests/tests/fixtures/**/*.c', 'e2e-tests/tests/fixtures/**/*.h', 'e2e-tests/tests/fixtures/**/*.cpp', 'e2e-tests/tests/fixtures/**/*.rs', 'e2e-tests/tests/fixtures/**/Makefile', 'e2e-tests/tests/fixtures/**/Cargo.toml', 'e2e-tests/tests/fixtures/**/Cargo.lock') }}
+          path: e2e-tests/.fixture-cache/fixture-binaries.tar
+          key: ${{ runner.os }}-${{ github.job }}-fixtures-${{ env.FIXTURE_COMPILER_CACHE_REV }}-${{ hashFiles('e2e-tests/cache-fixtures.sh', 'e2e-tests/compile-fixtures.sh', 'e2e-tests/tests/fixtures/**/*.c', 'e2e-tests/tests/fixtures/**/*.h', 'e2e-tests/tests/fixtures/**/*.cpp', 'e2e-tests/tests/fixtures/**/*.rs', 'e2e-tests/tests/fixtures/**/Makefile', 'e2e-tests/tests/fixtures/**/Cargo.toml', 'e2e-tests/tests/fixtures/**/Cargo.lock') }}
+
+      - name: Restore fixture archive
+        if: steps.fixture-cache.outputs.cache-hit == 'true'
+        run: bash ./e2e-tests/cache-fixtures.sh unpack
 
       - name: Compile fixtures with fixture compiler image
         if: steps.fixture-cache.outputs.cache-hit != 'true'
@@ -225,6 +200,7 @@ jobs:
             "$FIXTURE_COMPILER_IMAGE" \
             bash ./compile-fixtures.sh
           sudo chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}/e2e-tests/tests/fixtures"
+          bash ./e2e-tests/cache-fixtures.sh pack
 
       - name: Build GhostScope CLI and dwarf-tool
         run: cargo build -p ghostscope -p dwarf-tool --all-features

--- a/.github/workflows/container-e2e.yml
+++ b/.github/workflows/container-e2e.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       LLVM_SYS_181_PREFIX: /usr/lib/llvm-18
       FIXTURE_COMPILER_IMAGE: ghcr.io/swananan/ghostscope-fixture-compiler@sha256:b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89
-      FIXTURE_COMPILER_CACHE_REV: b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89
+      FIXTURE_COMPILER_CACHE_REV: b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89-fixture-archive
     strategy:
       fail-fast: false
       matrix:
@@ -75,41 +75,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ matrix.name }}-target-
 
-      - name: Cache fixture binaries
+      - name: Cache fixture archive
         id: fixture-cache
         uses: actions/cache@v4
         with:
-          path: |
-            e2e-tests/tests/fixtures/sample_program/sample_program
-            e2e-tests/tests/fixtures/sample_program/sample_program_o1
-            e2e-tests/tests/fixtures/sample_program/sample_program_o2
-            e2e-tests/tests/fixtures/sample_program/sample_program_o3
-            e2e-tests/tests/fixtures/sample_program/sample_program_stripped
-            e2e-tests/tests/fixtures/sample_program/sample_program_stripped.debug
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o1
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o2
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o3
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_nopie
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o1
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o2
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o3
-            e2e-tests/tests/fixtures/globals_program/globals_program
-            e2e-tests/tests/fixtures/globals_program/libgvars.so
-            e2e-tests/tests/fixtures/late_globals_program/late_globals_program
-            e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
-            e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program
-            e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
-            e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5
-            e2e-tests/tests/fixtures/inline_call_value_program/inline_call_value_program
-            e2e-tests/tests/fixtures/partitioned_ranges_program/partitioned_ranges_program
-            e2e-tests/tests/fixtures/cpp_complex_program/cpp_complex_program
-            e2e-tests/tests/fixtures/static_scope_program/static_scope_program
-            e2e-tests/tests/fixtures/static_scope_program/static_scope_program_clang_dwarf5
-            e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program
-            e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program_clang_dwarf5
-          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.name }}-fixtures-${{ env.FIXTURE_COMPILER_CACHE_REV }}-${{ hashFiles('e2e-tests/compile-fixtures.sh', 'e2e-tests/tests/fixtures/**/*.c', 'e2e-tests/tests/fixtures/**/*.h', 'e2e-tests/tests/fixtures/**/*.cpp', 'e2e-tests/tests/fixtures/**/*.rs', 'e2e-tests/tests/fixtures/**/Makefile', 'e2e-tests/tests/fixtures/**/Cargo.toml', 'e2e-tests/tests/fixtures/**/Cargo.lock') }}
+          path: e2e-tests/.fixture-cache/fixture-binaries.tar
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.name }}-fixtures-${{ env.FIXTURE_COMPILER_CACHE_REV }}-${{ hashFiles('e2e-tests/cache-fixtures.sh', 'e2e-tests/compile-fixtures.sh', 'e2e-tests/tests/fixtures/**/*.c', 'e2e-tests/tests/fixtures/**/*.h', 'e2e-tests/tests/fixtures/**/*.cpp', 'e2e-tests/tests/fixtures/**/*.rs', 'e2e-tests/tests/fixtures/**/Makefile', 'e2e-tests/tests/fixtures/**/Cargo.toml', 'e2e-tests/tests/fixtures/**/Cargo.lock') }}
+
+      - name: Restore fixture archive
+        if: steps.fixture-cache.outputs.cache-hit == 'true'
+        run: bash ./e2e-tests/cache-fixtures.sh unpack
 
       - name: Compile fixtures with fixture compiler image
         if: steps.fixture-cache.outputs.cache-hit != 'true'
@@ -120,6 +95,7 @@ jobs:
             "$FIXTURE_COMPILER_IMAGE" \
             bash ./compile-fixtures.sh
           sudo chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}/e2e-tests/tests/fixtures"
+          bash ./e2e-tests/cache-fixtures.sh pack
 
       - name: Build GhostScope CLI and dwarf-tool
         run: cargo build -p ghostscope -p dwarf-tool --all-features
@@ -162,7 +138,7 @@ jobs:
     env:
       LLVM_SYS_181_PREFIX: /usr/lib/llvm-18
       FIXTURE_COMPILER_IMAGE: ghcr.io/swananan/ghostscope-fixture-compiler@sha256:b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89
-      FIXTURE_COMPILER_CACHE_REV: b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89
+      FIXTURE_COMPILER_CACHE_REV: b1e716ec17610673dcaf69497bd93ef0c700a2ad7fe8265d6764d15a8c1edc89-fixture-archive
     strategy:
       fail-fast: false
       matrix:
@@ -211,41 +187,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-${{ matrix.name }}-target-
 
-      - name: Cache fixture binaries
+      - name: Cache fixture archive
         id: fixture-cache
         uses: actions/cache@v4
         with:
-          path: |
-            e2e-tests/tests/fixtures/sample_program/sample_program
-            e2e-tests/tests/fixtures/sample_program/sample_program_o1
-            e2e-tests/tests/fixtures/sample_program/sample_program_o2
-            e2e-tests/tests/fixtures/sample_program/sample_program_o3
-            e2e-tests/tests/fixtures/sample_program/sample_program_stripped
-            e2e-tests/tests/fixtures/sample_program/sample_program_stripped.debug
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o1
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o2
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_o3
-            e2e-tests/tests/fixtures/complex_types_program/complex_types_program_nopie
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o1
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o2
-            e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program_o3
-            e2e-tests/tests/fixtures/globals_program/globals_program
-            e2e-tests/tests/fixtures/globals_program/libgvars.so
-            e2e-tests/tests/fixtures/late_globals_program/late_globals_program
-            e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
-            e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program
-            e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program
-            e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5
-            e2e-tests/tests/fixtures/inline_call_value_program/inline_call_value_program
-            e2e-tests/tests/fixtures/partitioned_ranges_program/partitioned_ranges_program
-            e2e-tests/tests/fixtures/cpp_complex_program/cpp_complex_program
-            e2e-tests/tests/fixtures/static_scope_program/static_scope_program
-            e2e-tests/tests/fixtures/static_scope_program/static_scope_program_clang_dwarf5
-            e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program
-            e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program_clang_dwarf5
-          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.name }}-fixtures-${{ env.FIXTURE_COMPILER_CACHE_REV }}-${{ hashFiles('e2e-tests/compile-fixtures.sh', 'e2e-tests/tests/fixtures/**/*.c', 'e2e-tests/tests/fixtures/**/*.h', 'e2e-tests/tests/fixtures/**/*.cpp', 'e2e-tests/tests/fixtures/**/*.rs', 'e2e-tests/tests/fixtures/**/Makefile', 'e2e-tests/tests/fixtures/**/Cargo.toml', 'e2e-tests/tests/fixtures/**/Cargo.lock') }}
+          path: e2e-tests/.fixture-cache/fixture-binaries.tar
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.name }}-fixtures-${{ env.FIXTURE_COMPILER_CACHE_REV }}-${{ hashFiles('e2e-tests/cache-fixtures.sh', 'e2e-tests/compile-fixtures.sh', 'e2e-tests/tests/fixtures/**/*.c', 'e2e-tests/tests/fixtures/**/*.h', 'e2e-tests/tests/fixtures/**/*.cpp', 'e2e-tests/tests/fixtures/**/*.rs', 'e2e-tests/tests/fixtures/**/Makefile', 'e2e-tests/tests/fixtures/**/Cargo.toml', 'e2e-tests/tests/fixtures/**/Cargo.lock') }}
+
+      - name: Restore fixture archive
+        if: steps.fixture-cache.outputs.cache-hit == 'true'
+        run: bash ./e2e-tests/cache-fixtures.sh unpack
 
       - name: Compile fixtures with fixture compiler image
         if: steps.fixture-cache.outputs.cache-hit != 'true'
@@ -256,6 +207,7 @@ jobs:
             "$FIXTURE_COMPILER_IMAGE" \
             bash ./compile-fixtures.sh
           sudo chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}/e2e-tests/tests/fixtures"
+          bash ./e2e-tests/cache-fixtures.sh pack
 
       - name: Build GhostScope CLI and dwarf-tool
         run: cargo build -p ghostscope -p dwarf-tool --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 /target/
 .target_tmp
+e2e-tests/.fixture-cache/
 ghostscope-process/ebpf/sysmon-bpf/target/
 ghostscope-process/ebpf/xtask/target/
 
@@ -52,6 +53,7 @@ test_*
 !scripts/**/*.sh
 # Keep fixture compiler entrypoint tracked
 !e2e-tests/compile-fixtures.sh
+!e2e-tests/cache-fixtures.sh
 # Keep other C files in test fixtures but exclude random C files in root
 /*.c
 e2e-tests/tests/fixtures/complex_types_program/complex_types_program
@@ -71,10 +73,14 @@ e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program
 e2e-tests/tests/fixtures/sample_program/sample_lib.o
 e2e-tests/tests/fixtures/sample_program/sample_program
 e2e-tests/tests/fixtures/sample_program/sample_program.o
+e2e-tests/tests/fixtures/sample_program/sample_program_o*
 e2e-tests/tests/fixtures/sample_program/sample_program_stripped
 e2e-tests/tests/fixtures/sample_program/sample_program_stripped.debug
 e2e-tests/tests/fixtures/static_scope_program/static_scope_program
 e2e-tests/tests/fixtures/static_scope_program/static_scope_program_clang_dwarf5
+e2e-tests/tests/fixtures/inline_callsite_program/inline_callsite_program_clang_dwarf5
+e2e-tests/tests/fixtures/partitioned_ranges_program/partitioned_ranges_program_*
+e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program
 e2e-tests/tests/fixtures/entry_value_recovery_program/entry_value_recovery_program_clang_dwarf5
 e2e-tests/tests/fixtures/entry_value_breg_program/entry_value_breg_program_clang_debuglink
 e2e-tests/tests/fixtures/entry_value_breg_program/entry_value_breg_program_clang_debuglink.debug

--- a/e2e-tests/cache-fixtures.sh
+++ b/e2e-tests/cache-fixtures.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$ROOT_DIR/.." && pwd)"
+CACHE_DIR="$ROOT_DIR/.fixture-cache"
+ARCHIVE="$CACHE_DIR/fixture-binaries.tar"
+
+# Keep this discovery logic aligned with compile-fixtures.sh and the fixture
+# registry in tests/common/mod.rs. CI caches this generated archive instead of
+# maintaining a separate hand-written list of fixture binaries.
+log() {
+    printf '==> %s\n' "$*"
+}
+
+fixture_cache_paths() {
+    (
+        cd "$REPO_DIR"
+        # C and C++ fixture binaries are generated directly under each
+        # *_program directory. Exclude object files and source files by keeping
+        # executable outputs plus standalone debug files for split-debug tests.
+        find e2e-tests/tests/fixtures \
+            -mindepth 2 \
+            -maxdepth 2 \
+            -type f \
+            ! -path '*/entry_value_breg_program/*' \
+            \( -perm -111 -o -name '*.debug' \) \
+            -print
+
+        # Cargo places the Rust fixture binary below target/debug, outside the
+        # maxdepth-limited C/C++ fixture output convention above.
+        local rust_binary="e2e-tests/tests/fixtures/rust_global_program/target/debug/rust_global_program"
+        if [[ -f "$rust_binary" ]]; then
+            printf '%s\n' "$rust_binary"
+        fi
+    ) | LC_ALL=C sort -u
+}
+
+pack_fixture_cache() {
+    local paths=()
+    mapfile -t paths < <(fixture_cache_paths)
+
+    if [[ "${#paths[@]}" -eq 0 ]]; then
+        printf 'no fixture outputs found to cache\n' >&2
+        return 1
+    fi
+
+    mkdir -p "$CACHE_DIR"
+    tar -cf "$ARCHIVE" -C "$REPO_DIR" "${paths[@]}"
+    log "packed ${#paths[@]} fixture cache outputs into ${ARCHIVE#$REPO_DIR/}"
+}
+
+unpack_fixture_cache() {
+    if [[ ! -f "$ARCHIVE" ]]; then
+        printf 'fixture cache archive not found: %s\n' "$ARCHIVE" >&2
+        return 1
+    fi
+
+    tar -xf "$ARCHIVE" -C "$REPO_DIR"
+    log "restored fixture cache outputs from ${ARCHIVE#$REPO_DIR/}"
+}
+
+case "${1:-}" in
+    list)
+        fixture_cache_paths
+        ;;
+    pack)
+        pack_fixture_cache
+        ;;
+    unpack)
+        unpack_fixture_cache
+        ;;
+    *)
+        printf 'usage: %s {list|pack|unpack}\n' "$0" >&2
+        exit 2
+        ;;
+esac

--- a/e2e-tests/compile-fixtures.sh
+++ b/e2e-tests/compile-fixtures.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES_DIR="$ROOT_DIR/tests/fixtures"
 RUST_FIXTURE_DIR="$FIXTURES_DIR/rust_global_program"
 
+# cache-fixtures.sh discovers CI cache contents from the compiled outputs this
+# script leaves under tests/fixtures. If a new fixture writes binaries outside a
+# *_program directory or below a deeper target path, update that helper too.
 if [[ -n "${CLANG_BIN:-}" ]]; then
     CLANG_BIN="$CLANG_BIN"
 elif command -v clang-18 >/dev/null 2>&1; then

--- a/e2e-tests/tests/common/mod.rs
+++ b/e2e-tests/tests/common/mod.rs
@@ -87,6 +87,11 @@ struct RegisteredFixture {
 // TODO: Replace this string-keyed registry with a strongly typed FixtureId enum
 // and move the per-fixture behavior behind impl methods. This table is an
 // intermediate step to remove scattered name-based special cases.
+//
+// Keep CI fixture-cache discovery in e2e-tests/cache-fixtures.sh aligned with
+// this registry and the fixture build outputs. Most C/C++ fixtures are cached
+// by executable outputs directly under tests/fixtures/*_program; rust_global is
+// the explicit target/debug exception.
 const REGISTERED_FIXTURES: &[RegisteredFixture] = &[
     RegisteredFixture {
         name: "sample_program",

--- a/e2e-tests/tests/common_fixture_builds.rs
+++ b/e2e-tests/tests/common_fixture_builds.rs
@@ -25,47 +25,64 @@ fn clean_fixture_outputs(fixture_name: &str) -> anyhow::Result<()> {
 fn compiler_specific_builds_keep_sibling_fixture_outputs() -> anyhow::Result<()> {
     init();
 
-    if !common::fixture_compiler_available(FixtureCompiler::ClangDwarf5) {
-        eprintln!("Skipping fixture coexistence regression test because clang is unavailable");
-        return Ok(());
-    }
-
     let fixtures = [
-        ("inline_callsite_program", "-Wall -Wextra -gdwarf-5 -O3"),
-        ("static_scope_program", "-Wall -Wextra -gdwarf-5 -O0"),
+        (
+            "inline_callsite_program",
+            FixtureCompiler::ClangDwarf5,
+            "-Wall -Wextra -gdwarf-5 -O3",
+        ),
+        (
+            "static_scope_program",
+            FixtureCompiler::ClangDwarf5,
+            "-Wall -Wextra -gdwarf-5 -O0",
+        ),
+        (
+            "entry_value_recovery_program",
+            FixtureCompiler::ClangDwarf5,
+            "-Wall -Wextra -gdwarf-5 -O3",
+        ),
+        (
+            "partitioned_ranges_program",
+            FixtureCompiler::GccDwarf5FunctionSections,
+            "-Wall -Wextra -gdwarf-5 -O3 -DNDEBUG -ffunction-sections -freorder-blocks-and-partition",
+        ),
+        (
+            "partitioned_ranges_program",
+            FixtureCompiler::ClangDwarf5Rnglistx,
+            "-Wall -Wextra -gdwarf-5 -O3 -DNDEBUG -ffunction-sections -fbasic-block-sections=all",
+        ),
     ];
 
-    for (fixture_name, clang_dwarf5_cflags) in fixtures {
+    for (fixture_name, compiler, compiler_cflags) in fixtures {
+        if !common::fixture_compiler_available(compiler) {
+            eprintln!(
+                "Skipping fixture coexistence regression for {fixture_name} because {compiler:?} is unavailable"
+            );
+            continue;
+        }
+
         clean_fixture_outputs(fixture_name)?;
 
         let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures")
             .join(fixture_name);
         let default_binary = base.join(FixtureCompiler::Default.binary_name(fixture_name));
-        let clang_binary = base.join(FixtureCompiler::ClangDwarf5.binary_name(fixture_name));
+        let compiler_binary = base.join(compiler.binary_name(fixture_name));
 
-        common::compile_c_make_fixture(
-            fixture_name,
-            FixtureCompiler::Default,
-            clang_dwarf5_cflags,
-        )?;
+        common::compile_c_make_fixture(fixture_name, FixtureCompiler::Default, compiler_cflags)?;
         assert!(
             default_binary.exists(),
             "default binary should exist after default build for {fixture_name}"
         );
 
-        common::compile_c_make_fixture(
-            fixture_name,
-            FixtureCompiler::ClangDwarf5,
-            clang_dwarf5_cflags,
-        )?;
+        common::compile_c_make_fixture(fixture_name, compiler, compiler_cflags)?;
         assert!(
             default_binary.exists(),
-            "default binary should survive clang build for {fixture_name}"
+            "default binary should survive compiler-specific build for {fixture_name}"
         );
         assert!(
-            clang_binary.exists(),
-            "clang binary should exist after clang build for {fixture_name}"
+            compiler_binary.exists(),
+            "compiler-specific binary should exist after build for {fixture_name}"
         );
 
         clean_fixture_outputs(fixture_name)?;


### PR DESCRIPTION
CI builds E2E fixtures in the fixture-compiler image and skips that build when the fixture cache is restored. The partitioned-ranges regressions need GCC DWARF5 section output and Clang DWARF5 rnglistx output, but those binaries were easy to miss when every cache path was listed manually in workflow YAML.

Cache a single generated fixture archive instead. On cache misses, CI builds fixtures and packs the compiled outputs that the fixture build actually produced. On cache hits, CI restores and unpacks that archive before running E2E. This keeps compiler-specific sibling binaries tied to the fixture build instead of a duplicated workflow manifest.