### PR TITLE
test: add dwarf semantic e2e coverage

### DIFF
--- a/e2e-tests/tests/fixtures/globals_program/globals_program.c
+++ b/e2e-tests/tests/fixtures/globals_program/globals_program.c
@@ -6,7 +6,7 @@
 
 // Executable-level globals
 int g_counter = 42;                         // .data
-static int s_internal = 7;                  // .data
+static int s_internal = 7, module_duplicate_counter = 1000; // .data
 static int s_bss_counter;                    // .bss
 const char g_message[] = "Hello, Global!";   // .rodata
 char g_bss_buffer[1024];                     // .bss
@@ -30,7 +30,7 @@ static void tick_once(int i) {
     char* lb = lib_bss;
     // mutate executable globals
     g_counter += 1;
-    s_internal += 2;
+    s_internal += 2; module_duplicate_counter += 11;
     s_bss_counter += 3;
 
     // update complex state

--- a/e2e-tests/tests/fixtures/globals_program/gvars_lib.c
+++ b/e2e-tests/tests/fixtures/globals_program/gvars_lib.c
@@ -10,12 +10,12 @@ GlobalState LIB_STATE = {"LIB", 1, {123, 4.5}, {9,8,7,6}}; // .data
 unsigned char lib_pattern[300]; // .bss -> becomes .data after constructor fills
 
 // Internal file-scope static (should appear as static in DWARF)
-static int lib_internal_counter;        // .bss
+static int lib_internal_counter, module_duplicate_counter = 5000; // .data/.bss
 static const char lib_internal_const[] = "LIB_INTERNAL"; // .rodata
 
 void lib_tick(void) {
     lib_counter += 3;
-    lib_internal_counter += 5;
+    lib_internal_counter += 5; module_duplicate_counter += 101;
     if (LIB_STATE.counter < 0) {
         LIB_STATE.counter = 0;
     }

--- a/e2e-tests/tests/globals_execution.rs
+++ b/e2e-tests/tests/globals_execution.rs
@@ -2034,6 +2034,57 @@ trace globals_program.c:32 {
 }
 
 #[tokio::test]
+async fn test_duplicate_global_name_prefers_current_module() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("globals_program")?;
+    let target = spawn_globals_program(&binary_path).await?;
+
+    let script = r#"
+trace globals_program.c:32 {
+    print "MAIN_DUP:{}", module_duplicate_counter;
+}
+trace lib_tick {
+    print "LIB_DUP:{}", module_duplicate_counter;
+}
+"#;
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    let re_main = Regex::new(r"MAIN_DUP:(-?\d+)").unwrap();
+    let re_lib = Regex::new(r"LIB_DUP:(-?\d+)").unwrap();
+    let mut main_vals = Vec::new();
+    let mut lib_vals = Vec::new();
+    for line in stdout.lines() {
+        if let Some(c) = re_main.captures(line) {
+            main_vals.push(c[1].parse::<i64>()?);
+        }
+        if let Some(c) = re_lib.captures(line) {
+            lib_vals.push(c[1].parse::<i64>()?);
+        }
+    }
+
+    assert!(
+        main_vals.len() >= 2 && lib_vals.len() >= 2,
+        "Insufficient duplicate-global events. STDOUT: {stdout}"
+    );
+    assert_eq!(
+        main_vals[1] - main_vals[0],
+        11,
+        "main trace should bind executable static, not library static. STDOUT: {stdout}"
+    );
+    assert_eq!(
+        lib_vals[1] - lib_vals[0],
+        101,
+        "library trace should bind library static, not executable static. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_print_format_global_member_direct() -> anyhow::Result<()> {
     init();
 

--- a/e2e-tests/tests/optimized_inline_call_value_execution.rs
+++ b/e2e-tests/tests/optimized_inline_call_value_execution.rs
@@ -214,6 +214,72 @@ async fn test_optimized_inline_parameters_have_exact_values_before_internal_call
 }
 
 #[tokio::test]
+async fn test_optimized_out_local_print_emits_marker_at_runtime() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("inline_call_value_program")?;
+    let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path).await?;
+    let query_results = analyzer.query_source_line_best_effort(
+        "inline_call_value_program.c",
+        INLINE_BEFORE_CALL_TRACE_LINE,
+    )?;
+    anyhow::ensure!(
+        query_results.iter().any(|result| {
+            result.variables.iter().any(|variable| {
+                variable.name == "local_x"
+                    && matches!(variable.location, VariableLocation::OptimizedOut)
+            })
+        }),
+        "Expected local_x to be visible but optimized out at inline_call_value_program.c:{INLINE_BEFORE_CALL_TRACE_LINE}: {query_results:?}"
+    );
+
+    let target = spawn_inline_call_value_program(&binary_path).await?;
+    let script = format!(
+        "trace inline_call_value_program.c:{INLINE_BEFORE_CALL_TRACE_LINE} {{\n    print local_x;\n}}\n"
+    );
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(&script, 4, &target).await?;
+    target.terminate().await?;
+
+    if should_skip_for_ebpf_env(exit_code, &stderr) {
+        return Ok(());
+    }
+
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(
+        stdout.contains("<optimized out>") || stdout.contains("<optimized_out>"),
+        "Expected direct print of optimized-out local_x to emit an optimized-out marker. STDOUT: {stdout}\nSTDERR: {stderr}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimized_out_local_value_expression_is_rejected() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("inline_call_value_program")?;
+    let target = spawn_inline_call_value_program(&binary_path).await?;
+    let script = format!(
+        "trace inline_call_value_program.c:{INLINE_BEFORE_CALL_TRACE_LINE} {{\n    if local_x == 0 {{ print \"VALUE\"; }}\n}}\n"
+    );
+    let (_exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(&script, 3, &target).await?;
+    target.terminate().await?;
+
+    let has_banner = stderr.contains("Script compilation failed")
+        || stderr.contains("No uprobe configurations created");
+    let has_message =
+        stderr.contains("local_x") && stderr.contains("optimized out at the selected probe PC");
+    assert!(
+        has_banner && has_message,
+        "Expected optimized-out local_x to be rejected in a value expression.\nSTDOUT: {stdout}\nSTDERR: {stderr}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_optimized_inline_parameters_survive_internal_call_sites() -> anyhow::Result<()> {
     init();
 


### PR DESCRIPTION
Cover optimized-out local variable handling in runtime e2e. Direct print now verifies that GhostScope emits an optimized-out marker, while condition use verifies that value-expression contexts reject the unavailable value.

Add duplicate module-local globals to the executable and shared-library globals fixture. The e2e case verifies that unqualified lookup prefers the current module by checking each trace observes the module-specific update rate.