### PR TITLE
refactor: move C type semantics into dwarf crate

### DIFF
--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -39,29 +39,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     fn cookie_for_module_or_fallback(&mut self, module_path: &str) -> u64 {
         self.fallback_cookie_from_module_path(module_path)
     }
-    /// Helper: unwrap typedef/qualified wrappers to the underlying type
-    fn unwrap_type_aliases(mut t: &TypeInfo) -> &TypeInfo {
-        loop {
-            match t {
-                TypeInfo::TypedefType {
-                    underlying_type, ..
-                } => t = underlying_type.as_ref(),
-                TypeInfo::QualifiedType {
-                    underlying_type, ..
-                } => t = underlying_type.as_ref(),
-                _ => break,
-            }
-        }
-        t
-    }
-
-    /// Helper: determine if a DWARF type represents an aggregate (struct/union/array)
-    fn is_aggregate_type(&self, t: &TypeInfo) -> bool {
-        matches!(
-            Self::unwrap_type_aliases(t),
-            TypeInfo::StructType { .. } | TypeInfo::UnionType { .. } | TypeInfo::ArrayType { .. }
-        )
-    }
     fn planned_value_to_llvm_value(
         &mut self,
         value: &ghostscope_dwarf::PlannedValue,
@@ -305,33 +282,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         MemoryAccessSize::from_size(dwarf_type.size())
     }
 
-    fn is_signed_integer_type(dwarf_type: &TypeInfo) -> bool {
-        match dwarf_type {
-            TypeInfo::BaseType { encoding, .. } => {
-                *encoding == ghostscope_dwarf::constants::DW_ATE_signed.0 as u16
-                    || *encoding == ghostscope_dwarf::constants::DW_ATE_signed_char.0 as u16
-            }
-            TypeInfo::EnumType { base_type, .. } => Self::is_signed_integer_type(base_type),
-            TypeInfo::BitfieldType {
-                underlying_type, ..
-            } => Self::is_signed_integer_type(underlying_type),
-            TypeInfo::TypedefType {
-                underlying_type, ..
-            }
-            | TypeInfo::QualifiedType {
-                underlying_type, ..
-            } => Self::is_signed_integer_type(underlying_type),
-            _ => false,
-        }
-    }
-
     fn sign_extend_memory_read_if_needed(
         &self,
         value: BasicValueEnum<'ctx>,
         dwarf_type: &TypeInfo,
         access_size: MemoryAccessSize,
     ) -> Result<BasicValueEnum<'ctx>> {
-        if !Self::is_signed_integer_type(dwarf_type) || matches!(access_size, MemoryAccessSize::U64)
+        if !ghostscope_dwarf::is_c_signed_integer_type(dwarf_type)
+            || matches!(access_size, MemoryAccessSize::U64)
         {
             return Ok(value);
         }
@@ -463,7 +421,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             module_hint.as_deref(),
         )?;
 
-        if self.is_aggregate_type(dwarf_type) {
+        if ghostscope_dwarf::is_c_aggregate_type(dwarf_type) {
             let ptr_ty = self.context.ptr_type(inkwell::AddressSpace::default());
             let as_ptr = self
                 .builder

--- a/ghostscope-compiler/src/ebpf/expression.rs
+++ b/ghostscope-compiler/src/ebpf/expression.rs
@@ -6,45 +6,14 @@ use super::context::{CodeGenError, EbpfContext, Result};
 use crate::script::{BinaryOp, Expr};
 use aya_ebpf_bindings::bindings::bpf_func_id::BPF_FUNC_probe_read_user;
 use ghostscope_dwarf::{
-    AmbiguityReason, Availability, RuntimeRequirement, TypeInfo as DwarfType, UnsupportedReason,
+    AmbiguityReason, Availability, CIntegerComparisonPlan, CIntegerComparisonType,
+    RuntimeRequirement, TypeInfo as DwarfType, UnsupportedReason,
 };
 use inkwell::values::{BasicValueEnum, IntValue};
 use inkwell::AddressSpace;
 use tracing::debug;
 
 // compare cap is provided via compile_options.compare_cap (config: ebpf.compare_cap)
-
-#[derive(Clone, Copy, Debug)]
-struct CIntegerComparisonType {
-    size: u64,
-    is_unsigned: bool,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct CIntegerComparisonPlan {
-    size: u64,
-    is_unsigned: bool,
-}
-
-impl CIntegerComparisonType {
-    fn promoted(self) -> Self {
-        if self.size < 4 {
-            Self {
-                size: 4,
-                is_unsigned: false,
-            }
-        } else {
-            self
-        }
-    }
-
-    fn signed_i64() -> Self {
-        Self {
-            size: 8,
-            is_unsigned: false,
-        }
-    }
-}
 
 impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     pub(crate) fn get_host_pid_tid_values(&mut self) -> Result<(IntValue<'ctx>, IntValue<'ctx>)> {
@@ -215,30 +184,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         Ok((selected_pid, selected_tid))
     }
 
-    fn unwrap_dwarf_type_aliases(mut t: &DwarfType) -> &DwarfType {
-        loop {
-            match t {
-                DwarfType::TypedefType {
-                    underlying_type, ..
-                } => t = underlying_type.as_ref(),
-                DwarfType::QualifiedType {
-                    underlying_type, ..
-                } => t = underlying_type.as_ref(),
-                _ => break,
-            }
-        }
-        t
-    }
-
     fn is_dwarf_aggregate_expr(&mut self, expr: &Expr) -> bool {
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
-                return matches!(
-                    Self::unwrap_dwarf_type_aliases(ty),
-                    DwarfType::StructType { .. }
-                        | DwarfType::UnionType { .. }
-                        | DwarfType::ArrayType { .. }
-                );
+                return ghostscope_dwarf::is_c_aggregate_type(ty);
             }
         }
         false
@@ -265,11 +214,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
-                let t = Self::unwrap_dwarf_type_aliases(ty);
-                if matches!(
-                    t,
-                    DwarfType::PointerType { .. } | DwarfType::ArrayType { .. }
-                ) {
+                if ghostscope_dwarf::is_c_pointer_or_array_type(ty) {
                     return true;
                 }
             }
@@ -277,85 +222,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         false
     }
 
-    fn integer_comparison_type(t: &DwarfType) -> Option<CIntegerComparisonType> {
-        match t {
-            DwarfType::BaseType { encoding, size, .. } => {
-                let is_unsigned = *encoding
-                    == ghostscope_dwarf::constants::DW_ATE_unsigned.0 as u16
-                    || *encoding == ghostscope_dwarf::constants::DW_ATE_unsigned_char.0 as u16;
-                let is_signed = *encoding == ghostscope_dwarf::constants::DW_ATE_signed.0 as u16
-                    || *encoding == ghostscope_dwarf::constants::DW_ATE_signed_char.0 as u16
-                    || *encoding == ghostscope_dwarf::constants::DW_ATE_boolean.0 as u16;
-                if is_unsigned || is_signed {
-                    Some(CIntegerComparisonType {
-                        size: *size,
-                        is_unsigned,
-                    })
-                } else {
-                    None
-                }
-            }
-            DwarfType::EnumType {
-                base_type, size, ..
-            } => Self::integer_comparison_type(base_type).map(|mut ty| {
-                if ty.size == 0 {
-                    ty.size = *size;
-                }
-                ty
-            }),
-            DwarfType::BitfieldType {
-                underlying_type,
-                bit_size,
-                ..
-            } => Self::integer_comparison_type(underlying_type).map(|mut ty| {
-                ty.size = (*bit_size as u64).max(1).div_ceil(8);
-                ty
-            }),
-            DwarfType::TypedefType {
-                underlying_type, ..
-            }
-            | DwarfType::QualifiedType {
-                underlying_type, ..
-            } => Self::integer_comparison_type(underlying_type),
-            _ => None,
-        }
-    }
-
     fn dwarf_integer_comparison_expr(&mut self, expr: &Expr) -> Option<CIntegerComparisonType> {
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
-                return Self::integer_comparison_type(ty);
+                return ghostscope_dwarf::c_integer_comparison_type(ty);
             }
         }
         None
-    }
-
-    fn usual_arithmetic_comparison_plan(
-        left: CIntegerComparisonType,
-        right: CIntegerComparisonType,
-    ) -> CIntegerComparisonPlan {
-        let left = left.promoted();
-        let right = right.promoted();
-        if left.is_unsigned == right.is_unsigned {
-            return CIntegerComparisonPlan {
-                size: left.size.max(right.size),
-                is_unsigned: left.is_unsigned,
-            };
-        }
-
-        let unsigned = if left.is_unsigned { left } else { right };
-        let signed = if left.is_unsigned { right } else { left };
-        if unsigned.size >= signed.size {
-            CIntegerComparisonPlan {
-                size: unsigned.size,
-                is_unsigned: true,
-            }
-        } else {
-            CIntegerComparisonPlan {
-                size: signed.size,
-                is_unsigned: false,
-            }
-        }
     }
 
     fn integer_comparison_plan_for_exprs(
@@ -369,7 +242,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             return None;
         }
 
-        Some(Self::usual_arithmetic_comparison_plan(
+        Some(ghostscope_dwarf::usual_c_arithmetic_comparison_plan(
             left_ty.unwrap_or_else(CIntegerComparisonType::signed_i64),
             right_ty.unwrap_or_else(CIntegerComparisonType::signed_i64),
         ))

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -36,13 +36,15 @@ pub use core::{
 
 // Re-export semantic contract types.
 pub use semantics::{
-    AddressOrigin, AddressSpaceInfo, CfaRulePlan, CompactUnwindRow, CompactUnwindStats,
-    CompactUnwindTable, InlineFrame, LvalueAddressPlan, PcContext, PcLineInfo, PcRange,
-    PlannedAddress, PlannedAddressKind, PlannedValue, RegisterRecoveryPlan, RuntimeComputedExpr,
-    RuntimeComputedKind, UnwindDiagnostic, UnwindDiagnosticKind, VariableAccessPath,
-    VariableAccessSegment, VariableLoweringKind, VariableLoweringPlan, VariableMaterialization,
-    VariableMaterializationPlan, VariablePlan, VariableQueryDiagnostic, VariableReadPlan,
-    VisibleVariable, VisibleVariablesResult,
+    c_integer_comparison_type, is_c_aggregate_type, is_c_pointer_or_array_type,
+    is_c_signed_integer_type, strip_type_aliases, usual_c_arithmetic_comparison_plan,
+    AddressOrigin, AddressSpaceInfo, CIntegerComparisonPlan, CIntegerComparisonType, CfaRulePlan,
+    CompactUnwindRow, CompactUnwindStats, CompactUnwindTable, InlineFrame, LvalueAddressPlan,
+    PcContext, PcLineInfo, PcRange, PlannedAddress, PlannedAddressKind, PlannedValue,
+    RegisterRecoveryPlan, RuntimeComputedExpr, RuntimeComputedKind, UnwindDiagnostic,
+    UnwindDiagnosticKind, VariableAccessPath, VariableAccessSegment, VariableLoweringKind,
+    VariableLoweringPlan, VariableMaterialization, VariableMaterializationPlan, VariablePlan,
+    VariableQueryDiagnostic, VariableReadPlan, VisibleVariable, VisibleVariablesResult,
 };
 
 // Re-export type definitions from protocol (avoiding circular dependencies)

--- a/ghostscope-dwarf/src/semantics/c_types.rs
+++ b/ghostscope-dwarf/src/semantics/c_types.rs
@@ -1,0 +1,301 @@
+//! C type semantics derived from DWARF type information.
+//!
+//! This module keeps language-level type classification close to the DWARF
+//! semantic layer so compiler backends do not need to duplicate C rules.
+
+use crate::TypeInfo;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CIntegerComparisonType {
+    pub size: u64,
+    pub is_unsigned: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CIntegerComparisonPlan {
+    pub size: u64,
+    pub is_unsigned: bool,
+}
+
+impl CIntegerComparisonType {
+    pub fn promoted(self) -> Self {
+        if self.size < 4 {
+            Self {
+                size: 4,
+                is_unsigned: false,
+            }
+        } else {
+            self
+        }
+    }
+
+    pub fn signed_i64() -> Self {
+        Self {
+            size: 8,
+            is_unsigned: false,
+        }
+    }
+}
+
+pub fn strip_type_aliases(mut ty: &TypeInfo) -> &TypeInfo {
+    while let TypeInfo::TypedefType {
+        underlying_type, ..
+    }
+    | TypeInfo::QualifiedType {
+        underlying_type, ..
+    } = ty
+    {
+        ty = underlying_type.as_ref();
+    }
+    ty
+}
+
+pub fn is_c_aggregate_type(ty: &TypeInfo) -> bool {
+    matches!(
+        strip_type_aliases(ty),
+        TypeInfo::StructType { .. } | TypeInfo::UnionType { .. } | TypeInfo::ArrayType { .. }
+    )
+}
+
+pub fn is_c_pointer_or_array_type(ty: &TypeInfo) -> bool {
+    matches!(
+        strip_type_aliases(ty),
+        TypeInfo::PointerType { .. } | TypeInfo::ArrayType { .. }
+    )
+}
+
+pub fn c_integer_comparison_type(ty: &TypeInfo) -> Option<CIntegerComparisonType> {
+    match ty {
+        TypeInfo::BaseType { encoding, size, .. } => {
+            let is_unsigned = *encoding == crate::constants::DW_ATE_unsigned.0 as u16
+                || *encoding == crate::constants::DW_ATE_unsigned_char.0 as u16;
+            let is_signed = *encoding == crate::constants::DW_ATE_signed.0 as u16
+                || *encoding == crate::constants::DW_ATE_signed_char.0 as u16
+                || *encoding == crate::constants::DW_ATE_boolean.0 as u16;
+            if is_unsigned || is_signed {
+                Some(CIntegerComparisonType {
+                    size: *size,
+                    is_unsigned,
+                })
+            } else {
+                None
+            }
+        }
+        TypeInfo::EnumType {
+            base_type, size, ..
+        } => c_integer_comparison_type(base_type).map(|mut ty| {
+            if ty.size == 0 {
+                ty.size = *size;
+            }
+            ty
+        }),
+        TypeInfo::BitfieldType {
+            underlying_type,
+            bit_size,
+            ..
+        } => c_integer_comparison_type(underlying_type).map(|mut ty| {
+            ty.size = (*bit_size as u64).max(1).div_ceil(8);
+            ty
+        }),
+        TypeInfo::TypedefType {
+            underlying_type, ..
+        }
+        | TypeInfo::QualifiedType {
+            underlying_type, ..
+        } => c_integer_comparison_type(underlying_type),
+        _ => None,
+    }
+}
+
+pub fn is_c_signed_integer_type(ty: &TypeInfo) -> bool {
+    match ty {
+        TypeInfo::BaseType { encoding, .. } => {
+            *encoding == crate::constants::DW_ATE_signed.0 as u16
+                || *encoding == crate::constants::DW_ATE_signed_char.0 as u16
+        }
+        TypeInfo::EnumType { base_type, .. } => is_c_signed_integer_type(base_type),
+        TypeInfo::BitfieldType {
+            underlying_type, ..
+        } => is_c_signed_integer_type(underlying_type),
+        TypeInfo::TypedefType {
+            underlying_type, ..
+        }
+        | TypeInfo::QualifiedType {
+            underlying_type, ..
+        } => is_c_signed_integer_type(underlying_type),
+        _ => false,
+    }
+}
+
+pub fn usual_c_arithmetic_comparison_plan(
+    left: CIntegerComparisonType,
+    right: CIntegerComparisonType,
+) -> CIntegerComparisonPlan {
+    let left = left.promoted();
+    let right = right.promoted();
+    if left.is_unsigned == right.is_unsigned {
+        return CIntegerComparisonPlan {
+            size: left.size.max(right.size),
+            is_unsigned: left.is_unsigned,
+        };
+    }
+
+    let unsigned = if left.is_unsigned { left } else { right };
+    let signed = if left.is_unsigned { right } else { left };
+    if unsigned.size >= signed.size {
+        CIntegerComparisonPlan {
+            size: unsigned.size,
+            is_unsigned: true,
+        }
+    } else {
+        CIntegerComparisonPlan {
+            size: signed.size,
+            is_unsigned: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StructMember;
+
+    fn int_type(name: &str, size: u64, encoding: u16) -> TypeInfo {
+        TypeInfo::BaseType {
+            name: name.to_string(),
+            size,
+            encoding,
+        }
+    }
+
+    fn signed_int() -> TypeInfo {
+        int_type("int", 4, crate::constants::DW_ATE_signed.0 as u16)
+    }
+
+    #[test]
+    fn aggregate_classification_strips_aliases() {
+        let struct_type = TypeInfo::StructType {
+            name: "Request".to_string(),
+            size: 4,
+            members: vec![StructMember {
+                name: "fd".to_string(),
+                member_type: signed_int(),
+                offset: 0,
+                bit_offset: None,
+                bit_size: None,
+            }],
+        };
+        let typedef = TypeInfo::TypedefType {
+            name: "request_t".to_string(),
+            underlying_type: Box::new(TypeInfo::QualifiedType {
+                qualifier: crate::TypeQualifier::Const,
+                underlying_type: Box::new(struct_type),
+            }),
+        };
+
+        assert!(is_c_aggregate_type(&typedef));
+    }
+
+    #[test]
+    fn pointer_or_array_classification_strips_aliases() {
+        let array_type = TypeInfo::ArrayType {
+            element_type: Box::new(signed_int()),
+            element_count: Some(4),
+            total_size: Some(16),
+        };
+        let typedef = TypeInfo::TypedefType {
+            name: "int_array_t".to_string(),
+            underlying_type: Box::new(array_type),
+        };
+
+        assert!(is_c_pointer_or_array_type(&typedef));
+    }
+
+    #[test]
+    fn integer_comparison_type_handles_enums_and_bitfields() {
+        let enum_type = TypeInfo::EnumType {
+            name: "Mode".to_string(),
+            size: 4,
+            variants: vec![],
+            base_type: Box::new(int_type(
+                "unsigned int",
+                0,
+                crate::constants::DW_ATE_unsigned.0 as u16,
+            )),
+        };
+        assert_eq!(
+            c_integer_comparison_type(&enum_type),
+            Some(CIntegerComparisonType {
+                size: 4,
+                is_unsigned: true,
+            })
+        );
+
+        let bitfield_type = TypeInfo::BitfieldType {
+            underlying_type: Box::new(signed_int()),
+            bit_offset: 0,
+            bit_size: 9,
+        };
+        assert_eq!(
+            c_integer_comparison_type(&bitfield_type),
+            Some(CIntegerComparisonType {
+                size: 2,
+                is_unsigned: false,
+            })
+        );
+    }
+
+    #[test]
+    fn signed_integer_classification_excludes_boolean() {
+        let bool_type = int_type("bool", 1, crate::constants::DW_ATE_boolean.0 as u16);
+        assert_eq!(
+            c_integer_comparison_type(&bool_type),
+            Some(CIntegerComparisonType {
+                size: 1,
+                is_unsigned: false,
+            })
+        );
+        assert!(!is_c_signed_integer_type(&bool_type));
+        assert!(is_c_signed_integer_type(&signed_int()));
+    }
+
+    #[test]
+    fn usual_comparison_plan_applies_integer_promotions() {
+        let u8_type = CIntegerComparisonType {
+            size: 1,
+            is_unsigned: true,
+        };
+        let i8_type = CIntegerComparisonType {
+            size: 1,
+            is_unsigned: false,
+        };
+
+        assert_eq!(
+            usual_c_arithmetic_comparison_plan(u8_type, i8_type),
+            CIntegerComparisonPlan {
+                size: 4,
+                is_unsigned: false,
+            }
+        );
+    }
+
+    #[test]
+    fn usual_comparison_plan_respects_unsigned_rank() {
+        let u64_type = CIntegerComparisonType {
+            size: 8,
+            is_unsigned: true,
+        };
+        let i32_type = CIntegerComparisonType {
+            size: 4,
+            is_unsigned: false,
+        };
+
+        assert_eq!(
+            usual_c_arithmetic_comparison_plan(u64_type, i32_type),
+            CIntegerComparisonPlan {
+                size: 8,
+                is_unsigned: true,
+            }
+        );
+    }
+}

--- a/ghostscope-dwarf/src/semantics/mod.rs
+++ b/ghostscope-dwarf/src/semantics/mod.rs
@@ -1,3 +1,4 @@
+pub mod c_types;
 pub mod pc_context;
 pub mod unwind_plan;
 pub mod variable_plan;
@@ -6,6 +7,7 @@ pub(crate) mod origins;
 pub(crate) mod pc;
 pub(crate) mod types;
 
+pub use c_types::*;
 pub(crate) use origins::{
     resolve_attr_with_unit_origins, resolve_name_with_origins, resolve_origin_entry,
 };

--- a/ghostscope-dwarf/src/semantics/variable_plan.rs
+++ b/ghostscope-dwarf/src/semantics/variable_plan.rs
@@ -5,7 +5,7 @@ use crate::core::{
     PieceLocation, PlanExprOp, Provenance, Result, RuntimeCapabilities, RuntimeRequirement, TypeId,
     UnsupportedReason, VariableId, VariableLocation, VerifierRisk,
 };
-use crate::semantics::PcRange;
+use crate::semantics::{strip_type_aliases, PcRange};
 use crate::TypeInfo;
 
 /// Owned semantic view returned by PC-context variable queries.
@@ -493,15 +493,15 @@ impl VariableReadPlan {
     }
 
     fn plan_field_access(&self, dwarf_type: &TypeInfo, field: &str) -> Result<Self> {
-        let (base_location, aggregate_type) = match strip_alias_type(dwarf_type) {
+        let (base_location, aggregate_type) = match strip_type_aliases(dwarf_type) {
             TypeInfo::PointerType { target_type, .. } => (
                 dereference_location(&self.location)?,
-                strip_alias_type(target_type).clone(),
+                strip_type_aliases(target_type).clone(),
             ),
             ty => (self.location.clone(), ty.clone()),
         };
 
-        let member = match strip_alias_type(&aggregate_type) {
+        let member = match strip_type_aliases(&aggregate_type) {
             TypeInfo::StructType { name, members, .. } => members
                 .iter()
                 .find(|member| member.name == field)
@@ -539,7 +539,7 @@ impl VariableReadPlan {
         index: i64,
         context: ElementIndexContext,
     ) -> Result<Self> {
-        let (base_location, element_type, stride) = match strip_alias_type(dwarf_type) {
+        let (base_location, element_type, stride) = match strip_type_aliases(dwarf_type) {
             TypeInfo::ArrayType { element_type, .. } => {
                 let stride = element_type.size().max(1);
                 (self.location.clone(), element_type.as_ref().clone(), stride)
@@ -574,7 +574,7 @@ impl VariableReadPlan {
     }
 
     fn plan_pointer_deref(&self, dwarf_type: &TypeInfo) -> Result<Self> {
-        let target_type = match strip_alias_type(dwarf_type) {
+        let target_type = match strip_type_aliases(dwarf_type) {
             TypeInfo::PointerType { target_type, .. } => target_type.as_ref().clone(),
             ty => {
                 return Err(PlanError::InvalidPointerDereference {
@@ -1055,18 +1055,6 @@ fn requirement_rank(requirement: &RuntimeRequirement) -> u8 {
         RuntimeRequirement::SleepableUprobe => 1,
         RuntimeRequirement::UserMemoryRead => 2,
         RuntimeRequirement::DwarfCfiRecovery => 3,
-    }
-}
-
-fn strip_alias_type(ty: &TypeInfo) -> &TypeInfo {
-    match ty {
-        TypeInfo::TypedefType {
-            underlying_type, ..
-        }
-        | TypeInfo::QualifiedType {
-            underlying_type, ..
-        } => strip_alias_type(underlying_type),
-        _ => ty,
     }
 }
 


### PR DESCRIPTION
Move C/DWARF type classification helpers into ghostscope-dwarf so compiler backends can consume the semantic API instead of carrying local copies.

Reuse the shared alias stripping helper in variable planning and keep boolean comparison semantics distinct from signed memory-read extension.