### PR TITLE
fix: make DWARF line lookup and cross-CU indexing precise

### DIFF
--- a/e2e-tests/tests/dwarf_index_regressions.rs
+++ b/e2e-tests/tests/dwarf_index_regressions.rs
@@ -1,11 +1,19 @@
 mod common;
 
+use anyhow::Context;
 use common::{fixture_compiler_available, init, FixtureCompiler, OptimizationLevel, FIXTURES};
+use gimli::write::{
+    Address, AttributeValue as WriteAttributeValue, DebugInfoRef as WriteDebugInfoRef,
+    Dwarf as WriteDwarf, EndianVec, LineProgram, Sections, Unit,
+};
 use gimli::Reader;
+use gimli::{Format, SectionId};
 use object::{Object, ObjectSection, ObjectSymbol};
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempPath;
@@ -20,6 +28,34 @@ type TestReader = gimli::EndianArcSlice<gimli::RunTimeEndian>;
 enum RangesAttrEncoding {
     Offset,
     Index,
+}
+
+fn command_available(name: &str) -> bool {
+    StdCommand::new(name)
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn preferred_c_compiler() -> Option<&'static str> {
+    ["cc", "gcc", "clang"]
+        .into_iter()
+        .find(|candidate| command_available(candidate))
+}
+
+fn run_command(command: &mut StdCommand, label: &str) -> anyhow::Result<()> {
+    let output = command
+        .output()
+        .with_context(|| format!("failed to run {label}"))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "{label} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
 }
 
 fn find_symbol_address(binary_path: &std::path::Path, symbol_name: &str) -> anyhow::Result<u64> {
@@ -321,6 +357,226 @@ fn line_sequence_end_and_gap_without_line_rows(binary_path: &Path) -> anyhow::Re
     );
 }
 
+fn write_cross_cu_ref_addr_dwarf_sections(
+    out_dir: &Path,
+) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let encoding = gimli::Encoding {
+        format: Format::Dwarf32,
+        version: 4,
+        address_size: 8,
+    };
+
+    let mut dwarf = WriteDwarf::new();
+
+    let decl_unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+    let decl_unit = dwarf.units.get_mut(decl_unit_id);
+    let decl_root = decl_unit.root();
+    decl_unit.get_mut(decl_root).set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(b"cross_cu_declarations.c".to_vec()),
+    );
+
+    let origin_fn_id = decl_unit.add(decl_root, gimli::constants::DW_TAG_subprogram);
+    decl_unit.get_mut(origin_fn_id).set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(b"cross_cu_origin_fn".to_vec()),
+    );
+
+    let spec_fn_id = decl_unit.add(decl_root, gimli::constants::DW_TAG_subprogram);
+    let spec_fn = decl_unit.get_mut(spec_fn_id);
+    spec_fn.set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(b"cross_cu_spec_fn".to_vec()),
+    );
+    spec_fn.set(
+        gimli::constants::DW_AT_declaration,
+        WriteAttributeValue::Flag(true),
+    );
+
+    let origin_type_id = decl_unit.add(decl_root, gimli::constants::DW_TAG_structure_type);
+    let origin_type = decl_unit.get_mut(origin_type_id);
+    origin_type.set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(b"CrossCuOriginType".to_vec()),
+    );
+    origin_type.set(
+        gimli::constants::DW_AT_declaration,
+        WriteAttributeValue::Flag(true),
+    );
+
+    let spec_type_id = decl_unit.add(decl_root, gimli::constants::DW_TAG_structure_type);
+    let spec_type = decl_unit.get_mut(spec_type_id);
+    spec_type.set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(b"CrossCuSpecType".to_vec()),
+    );
+    spec_type.set(
+        gimli::constants::DW_AT_declaration,
+        WriteAttributeValue::Flag(true),
+    );
+
+    let concrete_unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+    let concrete_unit = dwarf.units.get_mut(concrete_unit_id);
+    let concrete_root = concrete_unit.root();
+    concrete_unit.get_mut(concrete_root).set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(b"cross_cu_concrete.c".to_vec()),
+    );
+
+    let concrete_origin_fn_id =
+        concrete_unit.add(concrete_root, gimli::constants::DW_TAG_subprogram);
+    let concrete_origin_fn = concrete_unit.get_mut(concrete_origin_fn_id);
+    concrete_origin_fn.set(
+        gimli::constants::DW_AT_abstract_origin,
+        WriteAttributeValue::DebugInfoRef(WriteDebugInfoRef::Entry(decl_unit_id, origin_fn_id)),
+    );
+    concrete_origin_fn.set(
+        gimli::constants::DW_AT_low_pc,
+        WriteAttributeValue::Address(Address::Constant(0x501000)),
+    );
+    concrete_origin_fn.set(
+        gimli::constants::DW_AT_high_pc,
+        WriteAttributeValue::Udata(0x20),
+    );
+
+    let concrete_spec_fn_id = concrete_unit.add(concrete_root, gimli::constants::DW_TAG_subprogram);
+    let concrete_spec_fn = concrete_unit.get_mut(concrete_spec_fn_id);
+    concrete_spec_fn.set(
+        gimli::constants::DW_AT_specification,
+        WriteAttributeValue::DebugInfoRef(WriteDebugInfoRef::Entry(decl_unit_id, spec_fn_id)),
+    );
+    concrete_spec_fn.set(
+        gimli::constants::DW_AT_low_pc,
+        WriteAttributeValue::Address(Address::Constant(0x502000)),
+    );
+    concrete_spec_fn.set(
+        gimli::constants::DW_AT_high_pc,
+        WriteAttributeValue::Udata(0x30),
+    );
+
+    let concrete_origin_type_id =
+        concrete_unit.add(concrete_root, gimli::constants::DW_TAG_structure_type);
+    let concrete_origin_type = concrete_unit.get_mut(concrete_origin_type_id);
+    concrete_origin_type.set(
+        gimli::constants::DW_AT_abstract_origin,
+        WriteAttributeValue::DebugInfoRef(WriteDebugInfoRef::Entry(decl_unit_id, origin_type_id)),
+    );
+    concrete_origin_type.set(
+        gimli::constants::DW_AT_byte_size,
+        WriteAttributeValue::Udata(24),
+    );
+
+    let concrete_spec_type_id =
+        concrete_unit.add(concrete_root, gimli::constants::DW_TAG_structure_type);
+    let concrete_spec_type = concrete_unit.get_mut(concrete_spec_type_id);
+    concrete_spec_type.set(
+        gimli::constants::DW_AT_specification,
+        WriteAttributeValue::DebugInfoRef(WriteDebugInfoRef::Entry(decl_unit_id, spec_type_id)),
+    );
+    concrete_spec_type.set(
+        gimli::constants::DW_AT_byte_size,
+        WriteAttributeValue::Udata(16),
+    );
+
+    let mut sections = Sections::new(EndianVec::new(gimli::LittleEndian));
+    dwarf.write(&mut sections)?;
+
+    let mut written = Vec::new();
+    for id in [
+        SectionId::DebugAbbrev,
+        SectionId::DebugInfo,
+        SectionId::DebugStr,
+    ] {
+        let data = sections
+            .get(id)
+            .map(|section| section.slice().to_vec())
+            .unwrap_or_default();
+        if data.is_empty() {
+            continue;
+        }
+        let path = out_dir.join(format!("{}.bin", id.name().trim_start_matches('.')));
+        fs::write(&path, data)?;
+        written.push((id.name().to_string(), path));
+    }
+
+    Ok(written)
+}
+
+fn build_cross_cu_ref_addr_binary(out_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let Some(cc) = preferred_c_compiler() else {
+        eprintln!("Skipping cross-CU ref_addr e2e: no C compiler is available");
+        return Ok(None);
+    };
+    if !command_available("objcopy") {
+        eprintln!("Skipping cross-CU ref_addr e2e: objcopy is unavailable");
+        return Ok(None);
+    }
+
+    let source = out_dir.join("cross_cu_ref_addr_stub.c");
+    let binary = out_dir.join("cross_cu_ref_addr_stub");
+    fs::write(&source, "int main(void) { return 0; }\n")?;
+    run_command(
+        StdCommand::new(cc).arg("-o").arg(&binary).arg(&source),
+        "compile cross-CU ref_addr stub",
+    )?;
+
+    let sections = write_cross_cu_ref_addr_dwarf_sections(out_dir)?;
+    let mut objcopy = StdCommand::new("objcopy");
+    for (section_name, section_path) in &sections {
+        objcopy
+            .arg("--add-section")
+            .arg(format!("{section_name}={}", section_path.display()));
+    }
+    objcopy.arg(&binary);
+    run_command(
+        &mut objcopy,
+        "objcopy --add-section synthetic cross-CU DWARF",
+    )?;
+
+    Ok(Some(binary))
+}
+
+fn cross_cu_ref_addr_attrs(binary_path: &Path) -> anyhow::Result<HashSet<gimli::DwAt>> {
+    let dwarf = load_dwarf_from_binary(binary_path)?;
+    let mut found = HashSet::new();
+    let mut units = dwarf.units();
+
+    while let Some(header) = units.next()? {
+        let unit = dwarf.unit(header)?;
+        let mut entries = unit.entries();
+        while let Some(entry) = entries.next_dfs()? {
+            for attr_name in [
+                gimli::constants::DW_AT_abstract_origin,
+                gimli::constants::DW_AT_specification,
+            ] {
+                let Some(attr) = entry.attr(attr_name) else {
+                    continue;
+                };
+                if let gimli::AttributeValue::DebugInfoRef(offset) = attr.value() {
+                    if offset.to_unit_offset(&unit.header).is_none() {
+                        found.insert(attr_name);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(found)
+}
+
+fn assert_struct_type_size(
+    ty: Option<ghostscope_dwarf::TypeInfo>,
+    expected_name: &str,
+    expected_size: u64,
+) {
+    match ty {
+        Some(ghostscope_dwarf::TypeInfo::StructType { size, .. }) => {
+            assert_eq!(size, expected_size, "unexpected size for {expected_name}");
+        }
+        other => panic!("expected struct type for {expected_name}, got {other:?}"),
+    }
+}
+
 fn partitioned_target_ranges_attr_encoding(
     binary_path: &Path,
 ) -> anyhow::Result<RangesAttrEncoding> {
@@ -474,6 +730,61 @@ async fn test_source_line_query_preserves_same_pc_line_candidate() -> anyhow::Re
                 && result.source_line == Some(COMPLEX_DUPLICATE_PC_LINE)
         }),
         "Expected source-line query to keep requested line {COMPLEX_DUPLICATE_PC_LINE} at duplicate PC 0x{duplicate_pc:x}. Results: {query_results:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cross_cu_ref_addr_origin_and_spec_names_are_indexed() -> anyhow::Result<()> {
+    init();
+
+    let temp_dir = tempfile::tempdir()?;
+    let Some(binary_path) = build_cross_cu_ref_addr_binary(temp_dir.path())? else {
+        return Ok(());
+    };
+
+    let ref_attrs = cross_cu_ref_addr_attrs(&binary_path)?;
+    assert!(
+        ref_attrs.contains(&gimli::constants::DW_AT_abstract_origin),
+        "fixture should contain cross-CU DW_AT_abstract_origin ref_addr"
+    );
+    assert!(
+        ref_attrs.contains(&gimli::constants::DW_AT_specification),
+        "fixture should contain cross-CU DW_AT_specification ref_addr"
+    );
+
+    let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to load synthetic cross-CU DWARF from {}: {e}",
+                binary_path.display()
+            )
+        })?;
+
+    for (name, expected_address) in [
+        ("cross_cu_origin_fn", 0x501000),
+        ("cross_cu_spec_fn", 0x502000),
+    ] {
+        let addrs = analyzer.lookup_function_addresses(name);
+        assert!(
+            addrs.iter().any(|addr| {
+                addr.module_path == binary_path && addr.address == expected_address
+            }),
+            "Expected {name} to be indexed through a cross-CU origin/spec ref. Results: {addrs:?}"
+        );
+    }
+
+    assert_struct_type_size(
+        analyzer.resolve_struct_type_shallow_by_name_in_module(&binary_path, "CrossCuOriginType"),
+        "CrossCuOriginType",
+        24,
+    );
+    assert_struct_type_size(
+        analyzer.resolve_struct_type_shallow_by_name_in_module(&binary_path, "CrossCuSpecType"),
+        "CrossCuSpecType",
+        16,
     );
 
     Ok(())

--- a/e2e-tests/tests/dwarf_index_regressions.rs
+++ b/e2e-tests/tests/dwarf_index_regressions.rs
@@ -260,6 +260,67 @@ fn duplicate_line_row_address_for_source_line(
         })
 }
 
+fn line_sequence_end_and_gap_without_line_rows(binary_path: &Path) -> anyhow::Result<(u64, u64)> {
+    let dwarf = load_dwarf_from_binary(binary_path)?;
+    let mut non_end_addresses = HashSet::new();
+    let mut sequence_ranges = Vec::new();
+    let mut units = dwarf.units();
+
+    while let Some(header) = units.next()? {
+        let unit = dwarf.unit(header)?;
+        let Some(ref line_program) = unit.line_program else {
+            continue;
+        };
+        let (line_program, sequences) = line_program.clone().sequences()?;
+
+        for sequence in sequences {
+            let mut rows = line_program.resume_from(&sequence);
+            let mut sequence_start = None;
+            let mut sequence_end = None;
+
+            while let Some((_, row)) = rows.next_row()? {
+                if row.end_sequence() {
+                    sequence_end = Some(row.address());
+                    continue;
+                }
+
+                sequence_start.get_or_insert(row.address());
+                non_end_addresses.insert(row.address());
+            }
+
+            if let (Some(start), Some(end)) = (sequence_start, sequence_end) {
+                if start < end {
+                    sequence_ranges.push((start, end));
+                }
+            }
+        }
+    }
+
+    sequence_ranges.sort_unstable_by_key(|(start, _)| *start);
+    let Some((_, first_end)) = sequence_ranges.first().copied() else {
+        anyhow::bail!("{} has no line sequences", binary_path.display());
+    };
+    let mut covered_end = first_end;
+
+    for (next_start, next_end) in sequence_ranges.into_iter().skip(1) {
+        if covered_end.saturating_add(1) < next_start {
+            let end_address = covered_end;
+            let gap_address = covered_end + 1;
+            if !non_end_addresses.contains(&end_address)
+                && !non_end_addresses.contains(&gap_address)
+            {
+                return Ok((end_address, gap_address));
+            }
+        }
+        covered_end = covered_end.max(next_end);
+    }
+
+    anyhow::bail!(
+        "{} has no line-sequence gap without regular line rows",
+        binary_path.display()
+    );
+}
+
 fn partitioned_target_ranges_attr_encoding(
     binary_path: &Path,
 ) -> anyhow::Result<RangesAttrEncoding> {
@@ -357,6 +418,27 @@ async fn assert_partitioned_ranges_source_line_query_recovers_function_scope(
         }),
         "Expected partitioned_target scope recovery with parameter x for {scenario}. Results: {query_results:?}"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_source_lookup_ignores_line_sequence_end_and_gap() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("complex_types_program", OptimizationLevel::O3)?;
+    let (end_address, gap_address) = line_sequence_end_and_gap_without_line_rows(&binary_path)?;
+    let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path).await?;
+
+    for address in [end_address, gap_address] {
+        let module_address = ghostscope_dwarf::ModuleAddress::new(binary_path.clone(), address);
+        let source_location = analyzer.lookup_source_location(&module_address);
+        assert!(
+            source_location.is_none(),
+            "Expected no source location for line-sequence boundary/gap address 0x{address:x}. Got {source_location:?}"
+        );
+    }
 
     Ok(())
 }

--- a/e2e-tests/tests/dwarf_index_regressions.rs
+++ b/e2e-tests/tests/dwarf_index_regressions.rs
@@ -1,9 +1,9 @@
 mod common;
 
-use common::{fixture_compiler_available, init, FixtureCompiler, FIXTURES};
+use common::{fixture_compiler_available, init, FixtureCompiler, OptimizationLevel, FIXTURES};
 use gimli::Reader;
 use object::{Object, ObjectSection, ObjectSymbol};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -12,6 +12,7 @@ use tempfile::TempPath;
 
 // Keep these on the executable inline-body lines in inline_callsite_program.c.
 const INLINE_TRACE_LINE: u32 = 43;
+const COMPLEX_DUPLICATE_PC_LINE: u32 = 20;
 
 type TestReader = gimli::EndianArcSlice<gimli::RunTimeEndian>;
 
@@ -196,6 +197,69 @@ fn load_dwarf_from_binary(path: &Path) -> anyhow::Result<gimli::Dwarf<TestReader
     Ok(dwarf)
 }
 
+fn duplicate_line_row_address_for_source_line(
+    binary_path: &Path,
+    source_basename: &str,
+    target_line: u64,
+) -> anyhow::Result<u64> {
+    let dwarf = load_dwarf_from_binary(binary_path)?;
+    let mut rows_by_address: HashMap<u64, Vec<u64>> = HashMap::new();
+    let mut units = dwarf.units();
+
+    while let Some(header) = units.next()? {
+        let unit = dwarf.unit(header)?;
+        let Some(ref line_program) = unit.line_program else {
+            continue;
+        };
+        let line_header = line_program.header();
+        let (line_program, sequences) = line_program.clone().sequences()?;
+
+        for sequence in sequences {
+            let mut rows = line_program.resume_from(&sequence);
+            while let Some((_, row)) = rows.next_row()? {
+                if row.end_sequence() {
+                    continue;
+                }
+                let Some(line) = row.line().map(|line| line.get()) else {
+                    continue;
+                };
+                let Some(file) = row.file(line_header) else {
+                    continue;
+                };
+                let Ok(path) = dwarf.attr_string(&unit, file.path_name()) else {
+                    continue;
+                };
+                let Ok(path) = path.to_string_lossy() else {
+                    continue;
+                };
+                let basename_matches = Path::new(path.as_ref())
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    == Some(source_basename);
+                if basename_matches || path.as_ref().ends_with(source_basename) {
+                    rows_by_address.entry(row.address()).or_default().push(line);
+                }
+            }
+        }
+    }
+
+    rows_by_address
+        .into_iter()
+        .filter(|(_, lines)| {
+            lines.contains(&target_line) && lines.iter().any(|line| *line != target_line)
+        })
+        .map(|(address, _)| address)
+        .min()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} has no same-PC line rows for {}:{}",
+                binary_path.display(),
+                source_basename,
+                target_line
+            )
+        })
+}
+
 fn partitioned_target_ranges_attr_encoding(
     binary_path: &Path,
 ) -> anyhow::Result<RangesAttrEncoding> {
@@ -292,6 +356,42 @@ async fn assert_partitioned_ranges_source_line_query_recovers_function_scope(
                 && result.parameters.iter().any(|param| param.name == "x")
         }),
         "Expected partitioned_target scope recovery with parameter x for {scenario}. Results: {query_results:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_source_line_query_preserves_same_pc_line_candidate() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("complex_types_program", OptimizationLevel::O3)?;
+    let duplicate_pc = duplicate_line_row_address_for_source_line(
+        &binary_path,
+        "complex_types_program.c",
+        u64::from(COMPLEX_DUPLICATE_PC_LINE),
+    )?;
+
+    let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path).await?;
+    let addrs = analyzer
+        .lookup_addresses_by_source_line("complex_types_program.c", COMPLEX_DUPLICATE_PC_LINE);
+    assert!(
+        addrs
+            .iter()
+            .any(|addr| addr.module_path == binary_path && addr.address == duplicate_pc),
+        "Expected source-line lookup to include duplicate-PC row 0x{duplicate_pc:x}. Results: {addrs:?}"
+    );
+
+    let query_results = analyzer
+        .query_source_line_best_effort("complex_types_program.c", COMPLEX_DUPLICATE_PC_LINE)?;
+    assert!(
+        query_results.iter().any(|result| {
+            result.module_path == binary_path
+                && result.address == duplicate_pc
+                && result.source_line == Some(COMPLEX_DUPLICATE_PC_LINE)
+        }),
+        "Expected source-line query to keep requested line {COMPLEX_DUPLICATE_PC_LINE} at duplicate PC 0x{duplicate_pc:x}. Results: {query_results:?}"
     );
 
     Ok(())

--- a/e2e-tests/tests/member_pointer_compilation.rs
+++ b/e2e-tests/tests/member_pointer_compilation.rs
@@ -232,8 +232,7 @@ async fn test_visible_variables_consumes_pc_context() -> anyhow::Result<()> {
         diagnostics
             .iter()
             .all(|diagnostic| diagnostic.pc == ctx.normalized_pc),
-        "diagnostics should be tied to the queried PC: {:?}",
-        diagnostics
+        "diagnostics should be tied to the queried PC: {diagnostics:?}"
     );
 
     Ok(())

--- a/ghostscope-dwarf/src/analyzer/mod.rs
+++ b/ghostscope-dwarf/src/analyzer/mod.rs
@@ -102,6 +102,14 @@ impl DwarfAnalyzer {
         &self,
         module_address: &ModuleAddress,
     ) -> Result<AddressQueryResult> {
+        self.build_address_query_result_with_source_hint(module_address, None)
+    }
+
+    fn build_address_query_result_with_source_hint(
+        &self,
+        module_address: &ModuleAddress,
+        source_hint: Option<(&str, u32)>,
+    ) -> Result<AddressQueryResult> {
         let mut variables = Vec::new();
         let mut parameters = Vec::new();
 
@@ -113,7 +121,19 @@ impl DwarfAnalyzer {
             }
         }
 
-        let source_location = self.lookup_source_location(module_address);
+        let source_location = if let Some((file_path, line_number)) = source_hint {
+            self.modules
+                .get(&module_address.module_path)
+                .and_then(|module_data| {
+                    module_data.lookup_source_location_for_source_line(
+                        module_address.address,
+                        file_path,
+                        line_number,
+                    )
+                })
+        } else {
+            self.lookup_source_location(module_address)
+        };
         let function_name = self.find_function_name_by_module_address(module_address);
         let is_inline = self.is_inline_at(module_address);
 
@@ -140,6 +160,23 @@ impl DwarfAnalyzer {
             .collect()
     }
 
+    fn query_module_addresses_for_source_line(
+        &self,
+        module_addresses: Vec<ModuleAddress>,
+        file_path: &str,
+        line_number: u32,
+    ) -> Result<Vec<AddressQueryResult>> {
+        module_addresses
+            .iter()
+            .map(|module_address| {
+                self.build_address_query_result_with_source_hint(
+                    module_address,
+                    Some((file_path, line_number)),
+                )
+            })
+            .collect()
+    }
+
     fn query_module_addresses_best_effort(
         &self,
         module_addresses: Vec<ModuleAddress>,
@@ -150,6 +187,54 @@ impl DwarfAnalyzer {
 
         for module_address in &module_addresses {
             match self.build_address_query_result(module_address) {
+                Ok(result) => results.push(result),
+                Err(error) => {
+                    let error_string = error.to_string();
+                    tracing::warn!(
+                        "Skipping failed address query for {} at {}:0x{:x}: {}",
+                        query_label,
+                        module_address.module_display(),
+                        module_address.address,
+                        error_string
+                    );
+
+                    if first_error.is_none() {
+                        first_error = Some((module_address.clone(), error_string));
+                    }
+                }
+            }
+        }
+
+        if results.is_empty() {
+            if let Some((module_address, error)) = first_error {
+                return Err(anyhow::anyhow!(
+                    "Failed to analyze any address for {} (first failure at {}:0x{:x}: {})",
+                    query_label,
+                    module_address.module_display(),
+                    module_address.address,
+                    error
+                ));
+            }
+        }
+
+        Ok(results)
+    }
+
+    fn query_module_addresses_for_source_line_best_effort(
+        &self,
+        module_addresses: Vec<ModuleAddress>,
+        file_path: &str,
+        line_number: u32,
+        query_label: &str,
+    ) -> Result<Vec<AddressQueryResult>> {
+        let mut results = Vec::new();
+        let mut first_error: Option<(ModuleAddress, String)> = None;
+
+        for module_address in &module_addresses {
+            match self.build_address_query_result_with_source_hint(
+                module_address,
+                Some((file_path, line_number)),
+            ) {
                 Ok(result) => results.push(result),
                 Err(error) => {
                     let error_string = error.to_string();
@@ -741,7 +826,7 @@ impl DwarfAnalyzer {
         line_number: u32,
     ) -> Result<Vec<AddressQueryResult>> {
         let module_addresses = self.lookup_addresses_by_source_line(file_path, line_number);
-        self.query_module_addresses(module_addresses)
+        self.query_module_addresses_for_source_line(module_addresses, file_path, line_number)
     }
 
     /// Query source-line debug information across all modules, skipping
@@ -753,8 +838,10 @@ impl DwarfAnalyzer {
         line_number: u32,
     ) -> Result<Vec<AddressQueryResult>> {
         let module_addresses = self.lookup_addresses_by_source_line(file_path, line_number);
-        self.query_module_addresses_best_effort(
+        self.query_module_addresses_for_source_line_best_effort(
             module_addresses,
+            file_path,
+            line_number,
             &format!("source line '{file_path}:{line_number}'"),
         )
     }

--- a/ghostscope-dwarf/src/core/types.rs
+++ b/ghostscope-dwarf/src/core/types.rs
@@ -138,6 +138,12 @@ pub struct IndexFlags {
 #[derive(Debug, Clone)]
 pub struct LineEntry {
     pub address: u64,
+    /// First address after this row's covered instruction range.
+    ///
+    /// DWARF line rows describe half-open ranges ending at the next row or the
+    /// sequence terminator. `None` is kept for synthetic/test rows and malformed
+    /// line programs where no end can be derived.
+    pub end_address: Option<u64>,
     pub file_path: String, // Full file path for direct lookup
     pub file_index: u64,   // Original DWARF file index (kept for compatibility)
     pub compilation_unit: std::sync::Arc<str>, // Pooled CU name to reduce duplication
@@ -145,6 +151,12 @@ pub struct LineEntry {
     pub column: u64,
     pub is_stmt: bool,
     pub prologue_end: bool,
+}
+
+impl LineEntry {
+    pub fn contains_address(&self, address: u64) -> bool {
+        address >= self.address && self.end_address.is_none_or(|end| address < end)
+    }
 }
 
 /// Program section classification for global/static variables

--- a/ghostscope-dwarf/src/index/line_mapping.rs
+++ b/ghostscope-dwarf/src/index/line_mapping.rs
@@ -7,8 +7,13 @@ use std::path::Path;
 /// Pure line mapping table for fast address→line lookup
 #[derive(Debug)]
 pub struct LineMappingTable {
-    /// Complete address to line mapping (built at startup)
-    address_to_line_map: BTreeMap<u64, LineEntry>,
+    /// Complete address to line mapping (built at startup).
+    ///
+    /// Multiple DWARF line rows can legitimately point at the same PC, for
+    /// example inline/header locations sharing one instruction. Keep every row
+    /// so source-location selection can score all candidates instead of being
+    /// decided by insertion order.
+    address_to_line_map: BTreeMap<u64, Vec<LineEntry>>,
 
     /// Path-based reverse mapping: (file_path, line_number) → addresses
     /// Uses full paths as keys for accurate lookup
@@ -28,7 +33,7 @@ impl LineMappingTable {
         mut entries: Vec<LineEntry>,
         scoped: &crate::index::ScopedFileIndexManager,
     ) -> Self {
-        let mut address_to_line_map = BTreeMap::new();
+        let mut address_to_line_map: BTreeMap<u64, Vec<LineEntry>> = BTreeMap::new();
         let mut path_line_to_addresses: HashMap<(String, u64), Vec<u64>> = HashMap::new();
         let mut basename_to_paths: HashMap<String, HashSet<String>> = HashMap::new();
 
@@ -43,7 +48,10 @@ impl LineMappingTable {
             }
 
             // Always populate the address→line map
-            address_to_line_map.insert(e.address, e.clone());
+            address_to_line_map
+                .entry(e.address)
+                .or_default()
+                .push(e.clone());
 
             // Populate path→(line→addresses) only when we have a resolved path
             if !e.file_path.is_empty() {
@@ -72,6 +80,10 @@ impl LineMappingTable {
         }
     }
 
+    fn representative_entry(entries: &[LineEntry]) -> Option<&LineEntry> {
+        entries.last()
+    }
+
     /// Find best matching line (closest address <= target address)
     pub(crate) fn lookup_line(&self, address: u64) -> Option<&LineEntry> {
         // Use BTreeMap's range to find the largest address <= target address
@@ -79,7 +91,7 @@ impl LineMappingTable {
             .address_to_line_map
             .range(..=address)
             .next_back()
-            .map(|(_, entry)| entry);
+            .and_then(|(_, entries)| Self::representative_entry(entries));
 
         if let Some(entry) = result {
             tracing::debug!(
@@ -97,18 +109,14 @@ impl LineMappingTable {
     }
 
     /// Find all line entries at exact address (for handling overlapping instructions)
-    /// Current map stores a single entry per address; use O(1) get to avoid O(N) scans.
     pub(crate) fn lookup_all_lines_at_address(&self, address: u64) -> Vec<&LineEntry> {
-        if let Some(entry) = self.address_to_line_map.get(&address) {
+        if let Some(entries) = self.address_to_line_map.get(&address) {
             tracing::debug!(
-                "LineMapping::lookup_all_lines_at_address: address=0x{:x} -> 1 entry (file='{}', line={}, cu='{}', is_stmt={})",
+                "LineMapping::lookup_all_lines_at_address: address=0x{:x} -> {} entries",
                 address,
-                entry.file_path,
-                entry.line,
-                entry.compilation_unit,
-                entry.is_stmt
+                entries.len()
             );
-            vec![entry]
+            entries.iter().collect()
         } else {
             tracing::debug!(
                 "LineMapping::lookup_all_lines_at_address: address=0x{:x} -> 0 entries",
@@ -213,6 +221,7 @@ impl LineMappingTable {
         // Sort addresses
         let mut sorted_addrs = addresses.clone();
         sorted_addrs.sort_unstable();
+        sorted_addrs.dedup();
 
         // Group consecutive addresses (within 32 bytes of each other)
         const CONSECUTIVE_THRESHOLD: u64 = 32;
@@ -242,8 +251,8 @@ impl LineMappingTable {
             if group.len() == 1 {
                 // Single address - check if it's is_stmt
                 let addr = group[0];
-                if let Some(entry) = self.address_to_line_map.get(&addr) {
-                    if entry.is_stmt {
+                if let Some(entries) = self.address_to_line_map.get(&addr) {
+                    if entries.iter().any(|entry| entry.is_stmt) {
                         result.push(addr);
                     }
                     // Note: Unlike GDB, we still include non-is_stmt single addresses
@@ -262,8 +271,8 @@ impl LineMappingTable {
                 // Multiple consecutive addresses - find the first is_stmt address
                 let mut selected = None;
                 for &addr in &group {
-                    if let Some(entry) = self.address_to_line_map.get(&addr) {
-                        if entry.is_stmt {
+                    if let Some(entries) = self.address_to_line_map.get(&addr) {
+                        if entries.iter().any(|entry| entry.is_stmt) {
                             selected = Some(addr);
                             break;
                         }
@@ -341,7 +350,10 @@ impl LineMappingTable {
         let mut best_address: Option<u64> = None;
 
         // Iterate through addresses starting from function_start
-        for (&address, entry) in self.address_to_line_map.range(function_start..) {
+        for (&address, entries) in self.address_to_line_map.range(function_start..) {
+            let Some(entry) = Self::representative_entry(entries) else {
+                continue;
+            };
             if entry.prologue_end {
                 tracing::debug!(
                     "LineMappingTable: found prologue_end=true at 0x{:x} (line {}, file {})",
@@ -388,8 +400,11 @@ impl LineMappingTable {
         );
 
         // Look for the first is_stmt=true address after function_start
-        for (&address, entry) in self.address_to_line_map.range((function_start + 1)..) {
-            if entry.is_stmt {
+        for (&address, entries) in self
+            .address_to_line_map
+            .range((function_start.saturating_add(1))..)
+        {
+            if let Some(entry) = Self::representative_entry(entries).filter(|entry| entry.is_stmt) {
                 tracing::debug!(
                     "LineMappingTable: found is_stmt=true at 0x{:x} (line {}, file {})",
                     address,
@@ -397,7 +412,7 @@ impl LineMappingTable {
                     entry.file_path
                 );
                 return Some(address);
-            } else {
+            } else if let Some(entry) = Self::representative_entry(entries) {
                 // Extra diagnostics to understand why we didn't pick nearer addresses
                 tracing::debug!(
                     "LineMappingTable: skipping non-is_stmt at 0x{:x} (offset +{}, line {}, file {}, prologue_end={})",
@@ -424,6 +439,64 @@ impl LineMappingTable {
         start_addr: u64,
         end_addr: u64,
     ) -> impl Iterator<Item = (&u64, &LineEntry)> {
-        self.address_to_line_map.range(start_addr..=end_addr)
+        self.address_to_line_map
+            .range(start_addr..=end_addr)
+            .flat_map(|(address, entries)| entries.iter().map(move |entry| (address, entry)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn line_entry(address: u64, file_path: &str, line: u64, is_stmt: bool) -> LineEntry {
+        LineEntry {
+            address,
+            file_path: file_path.to_string(),
+            file_index: 1,
+            compilation_unit: Arc::from("main.c"),
+            line,
+            column: 0,
+            is_stmt,
+            prologue_end: false,
+        }
+    }
+
+    #[test]
+    fn preserves_same_address_line_entries() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let table = LineMappingTable::from_entries_with_scoped_manager(
+            vec![
+                line_entry(0x1000, "/src/include/header.h", 12, false),
+                line_entry(0x1000, "/src/main.c", 42, true),
+            ],
+            &scoped,
+        );
+
+        let entries = table.lookup_all_lines_at_address(0x1000);
+
+        assert_eq!(entries.len(), 2);
+        assert!(entries
+            .iter()
+            .any(|entry| entry.file_path == "/src/include/header.h"));
+        assert!(entries.iter().any(|entry| entry.file_path == "/src/main.c"));
+    }
+
+    #[test]
+    fn lookup_line_uses_representative_row_with_duplicate_address() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let table = LineMappingTable::from_entries_with_scoped_manager(
+            vec![
+                line_entry(0x1000, "/src/main.c", 42, true),
+                line_entry(0x1000, "/src/include/header.h", 12, false),
+            ],
+            &scoped,
+        );
+
+        let entry = table.lookup_line(0x1004).expect("nearest line entry");
+
+        assert_eq!(entry.file_path, "/src/include/header.h");
+        assert_eq!(entry.line, 12);
     }
 }

--- a/ghostscope-dwarf/src/index/line_mapping.rs
+++ b/ghostscope-dwarf/src/index/line_mapping.rs
@@ -91,7 +91,9 @@ impl LineMappingTable {
             .address_to_line_map
             .range(..=address)
             .next_back()
-            .and_then(|(_, entries)| Self::representative_entry(entries));
+            .and_then(|(_, entries)| {
+                Self::representative_entry(entries).filter(|entry| entry.contains_address(address))
+            });
 
         if let Some(entry) = result {
             tracing::debug!(
@@ -140,7 +142,7 @@ impl LineMappingTable {
             .get(&(file_path.to_string(), line_number))
         {
             tracing::debug!("Found addresses via exact path match: {}", file_path);
-            return self.filter_consecutive_addresses(addresses.clone());
+            return self.filter_consecutive_addresses(addresses.clone(), file_path, line_number);
         }
 
         // Strategy 2: Basename candidates + suffix check (avoid global scans)
@@ -162,7 +164,11 @@ impl LineMappingTable {
                                 file_path,
                                 full_path
                             );
-                            return self.filter_consecutive_addresses(addresses.clone());
+                            return self.filter_consecutive_addresses(
+                                addresses.clone(),
+                                full_path,
+                                line_number,
+                            );
                         }
                     }
                 }
@@ -185,7 +191,11 @@ impl LineMappingTable {
                         full_path,
                         addresses.len()
                     );
-                    return self.filter_consecutive_addresses(addresses.clone());
+                    return self.filter_consecutive_addresses(
+                        addresses.clone(),
+                        full_path,
+                        line_number,
+                    );
                 }
             } else {
                 // Multiple files with same basename - try to match with partial path (best effort)
@@ -200,7 +210,11 @@ impl LineMappingTable {
                                 file_path,
                                 full_path
                             );
-                            return self.filter_consecutive_addresses(addresses.clone());
+                            return self.filter_consecutive_addresses(
+                                addresses.clone(),
+                                full_path,
+                                line_number,
+                            );
                         }
                     }
                 }
@@ -213,7 +227,12 @@ impl LineMappingTable {
 
     /// Filter consecutive addresses to keep only statement boundaries
     /// This helps avoid setting multiple breakpoints on the same logical line
-    fn filter_consecutive_addresses(&self, addresses: Vec<u64>) -> Vec<u64> {
+    fn filter_consecutive_addresses(
+        &self,
+        addresses: Vec<u64>,
+        file_path: &str,
+        line_number: u64,
+    ) -> Vec<u64> {
         if addresses.is_empty() {
             return addresses;
         }
@@ -252,7 +271,9 @@ impl LineMappingTable {
                 // Single address - check if it's is_stmt
                 let addr = group[0];
                 if let Some(entries) = self.address_to_line_map.get(&addr) {
-                    if entries.iter().any(|entry| entry.is_stmt) {
+                    if entries.iter().any(|entry| {
+                        entry.is_stmt && entry.file_path == file_path && entry.line == line_number
+                    }) {
                         result.push(addr);
                     }
                     // Note: Unlike GDB, we still include non-is_stmt single addresses
@@ -272,7 +293,11 @@ impl LineMappingTable {
                 let mut selected = None;
                 for &addr in &group {
                     if let Some(entries) = self.address_to_line_map.get(&addr) {
-                        if entries.iter().any(|entry| entry.is_stmt) {
+                        if entries.iter().any(|entry| {
+                            entry.is_stmt
+                                && entry.file_path == file_path
+                                && entry.line == line_number
+                        }) {
                             selected = Some(addr);
                             break;
                         }
@@ -453,6 +478,7 @@ mod tests {
     fn line_entry(address: u64, file_path: &str, line: u64, is_stmt: bool) -> LineEntry {
         LineEntry {
             address,
+            end_address: None,
             file_path: file_path.to_string(),
             file_index: 1,
             compilation_unit: Arc::from("main.c"),
@@ -498,5 +524,54 @@ mod tests {
 
         assert_eq!(entry.file_path, "/src/include/header.h");
         assert_eq!(entry.line, 12);
+    }
+
+    #[test]
+    fn lookup_addresses_by_path_uses_stmt_rows_for_requested_line_only() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let table = LineMappingTable::from_entries_with_scoped_manager(
+            vec![
+                line_entry(0x1000, "/src/include/header.h", 12, true),
+                line_entry(0x1000, "/src/main.c", 42, false),
+                line_entry(0x1008, "/src/main.c", 42, true),
+            ],
+            &scoped,
+        );
+
+        assert_eq!(
+            table.lookup_addresses_by_path("/src/main.c", 42),
+            vec![0x1008]
+        );
+    }
+
+    #[test]
+    fn lookup_line_does_not_cross_known_row_end() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let mut first = line_entry(0x1000, "/src/main.c", 10, true);
+        first.end_address = Some(0x1010);
+        let mut second = line_entry(0x2000, "/src/main.c", 20, true);
+        second.end_address = Some(0x2010);
+        let table =
+            LineMappingTable::from_entries_with_scoped_manager(vec![first, second], &scoped);
+
+        assert_eq!(table.lookup_line(0x100f).map(|entry| entry.line), Some(10));
+        assert!(table.lookup_line(0x1010).is_none());
+        assert!(table.lookup_line(0x1fff).is_none());
+        assert_eq!(table.lookup_line(0x2000).map(|entry| entry.line), Some(20));
+    }
+
+    #[test]
+    fn lookup_line_ignores_zero_length_row() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let mut zero_length = line_entry(0x1000, "/src/main.c", 10, true);
+        zero_length.end_address = Some(0x1000);
+        let mut next = line_entry(0x2000, "/src/main.c", 20, true);
+        next.end_address = Some(0x2010);
+        let table =
+            LineMappingTable::from_entries_with_scoped_manager(vec![zero_length, next], &scoped);
+
+        assert!(table.lookup_line(0x1000).is_none());
+        assert!(table.lookup_line(0x1fff).is_none());
+        assert_eq!(table.lookup_line(0x2000).map(|entry| entry.line), Some(20));
     }
 }

--- a/ghostscope-dwarf/src/index/line_mapping.rs
+++ b/ghostscope-dwarf/src/index/line_mapping.rs
@@ -1,8 +1,7 @@
 //! Pure address→line mapping lookup (no parsing, no file operations)
 
-use crate::core::LineEntry;
+use crate::{core::LineEntry, path_match};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::Path;
 
 /// Pure line mapping table for fast address→line lookup
 #[derive(Debug)]
@@ -113,12 +112,16 @@ impl LineMappingTable {
     /// Find all line entries at exact address (for handling overlapping instructions)
     pub(crate) fn lookup_all_lines_at_address(&self, address: u64) -> Vec<&LineEntry> {
         if let Some(entries) = self.address_to_line_map.get(&address) {
+            let active_entries: Vec<_> = entries
+                .iter()
+                .filter(|entry| entry.contains_address(address))
+                .collect();
             tracing::debug!(
-                "LineMapping::lookup_all_lines_at_address: address=0x{:x} -> {} entries",
+                "LineMapping::lookup_all_lines_at_address: address=0x{:x} -> {} active entries",
                 address,
-                entries.len()
+                active_entries.len()
             );
-            entries.iter().collect()
+            active_entries
         } else {
             tracing::debug!(
                 "LineMapping::lookup_all_lines_at_address: address=0x{:x} -> 0 entries",
@@ -146,15 +149,14 @@ impl LineMappingTable {
         }
 
         // Strategy 2: Basename candidates + suffix check (avoid global scans)
-        let basename = Path::new(file_path)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(file_path);
+        let basename = path_match::file_name(file_path);
         if let Some(full_paths) = self.basename_to_paths.get(basename) {
-            let has_sep = file_path.contains('/') || file_path.contains('\\');
+            let has_sep = path_match::has_path_separator(file_path);
             if has_sep {
                 for full_path in full_paths {
-                    if full_path.ends_with(file_path) || file_path.ends_with(full_path) {
+                    if path_match::path_component_suffix_matches(full_path, file_path)
+                        || path_match::path_component_suffix_matches(file_path, full_path)
+                    {
                         if let Some(addresses) = self
                             .path_line_to_addresses
                             .get(&(full_path.clone(), line_number))
@@ -200,7 +202,9 @@ impl LineMappingTable {
             } else {
                 // Multiple files with same basename - try to match with partial path (best effort)
                 for full_path in full_paths {
-                    if full_path.ends_with(file_path) || file_path.ends_with(full_path) {
+                    if path_match::path_component_suffix_matches(full_path, file_path)
+                        || path_match::path_component_suffix_matches(file_path, full_path)
+                    {
                         if let Some(addresses) = self
                             .path_line_to_addresses
                             .get(&(full_path.clone(), line_number))
@@ -545,6 +549,23 @@ mod tests {
     }
 
     #[test]
+    fn lookup_addresses_by_path_requires_component_suffix_match() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let table = LineMappingTable::from_entries_with_scoped_manager(
+            vec![
+                line_entry(0x1000, "/src/myfoo/bar.c", 42, true),
+                line_entry(0x2000, "/src/foo/bar.c", 42, true),
+            ],
+            &scoped,
+        );
+
+        assert_eq!(
+            table.lookup_addresses_by_path("foo/bar.c", 42),
+            vec![0x2000]
+        );
+    }
+
+    #[test]
     fn lookup_line_does_not_cross_known_row_end() {
         let scoped = crate::index::ScopedFileIndexManager::new();
         let mut first = line_entry(0x1000, "/src/main.c", 10, true);
@@ -573,5 +594,21 @@ mod tests {
         assert!(table.lookup_line(0x1000).is_none());
         assert!(table.lookup_line(0x1fff).is_none());
         assert_eq!(table.lookup_line(0x2000).map(|entry| entry.line), Some(20));
+    }
+
+    #[test]
+    fn lookup_all_lines_at_address_ignores_zero_length_row() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let mut zero_length = line_entry(0x1000, "/src/main.c", 10, true);
+        zero_length.end_address = Some(0x1000);
+        let mut active = line_entry(0x1000, "/src/main.c", 11, true);
+        active.end_address = Some(0x1010);
+        let table =
+            LineMappingTable::from_entries_with_scoped_manager(vec![zero_length, active], &scoped);
+
+        let entries = table.lookup_all_lines_at_address(0x1000);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].line, 11);
     }
 }

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod index;
 pub(crate) mod loader;
 pub(crate) mod objfile;
 pub(crate) mod parser;
+pub(crate) mod path_match;
 pub mod semantics;
 
 // Main entry point

--- a/ghostscope-dwarf/src/objfile/source_location.rs
+++ b/ghostscope-dwarf/src/objfile/source_location.rs
@@ -1,6 +1,6 @@
 use super::LoadedObjfile;
-use crate::{core::SourceLocation, parser::SourceFile};
-use std::{collections::HashSet, path::Path};
+use crate::{core::SourceLocation, parser::SourceFile, path_match};
+use std::collections::HashSet;
 
 mod file_selection_scoring {
     pub const SEARCH_RANGE_BYTES: u64 = 100;
@@ -64,21 +64,7 @@ impl LoadedObjfile {
         let Some(candidate_path) = self.get_file_path_for_entry(entry) else {
             return false;
         };
-        if candidate_path == requested_file_path
-            || candidate_path.ends_with(requested_file_path)
-            || requested_file_path.ends_with(&candidate_path)
-        {
-            return true;
-        }
-
-        let requested_basename = Path::new(requested_file_path)
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or(requested_file_path);
-        Path::new(&candidate_path)
-            .file_name()
-            .and_then(|name| name.to_str())
-            == Some(requested_basename)
+        path_match::source_path_matches(&candidate_path, requested_file_path)
     }
 
     fn find_alternative_source_file<'a>(

--- a/ghostscope-dwarf/src/objfile/source_location.rs
+++ b/ghostscope-dwarf/src/objfile/source_location.rs
@@ -1,6 +1,6 @@
 use super::LoadedObjfile;
 use crate::{core::SourceLocation, parser::SourceFile};
-use std::collections::HashSet;
+use std::{collections::HashSet, path::Path};
 
 mod file_selection_scoring {
     pub const SEARCH_RANGE_BYTES: u64 = 100;
@@ -31,6 +31,56 @@ impl LoadedObjfile {
 
         self.create_source_location_from_entry(best_entry)
     }
+
+    pub(crate) fn lookup_source_location_for_source_line(
+        &self,
+        address: u64,
+        file_path: &str,
+        line_number: u32,
+    ) -> Option<SourceLocation> {
+        let all_line_entries = self.line_mapping.lookup_all_lines_at_address(address);
+        let matching_entries: Vec<_> = all_line_entries
+            .iter()
+            .copied()
+            .filter(|entry| {
+                entry.line == u64::from(line_number)
+                    && self.line_entry_matches_requested_source(entry, file_path)
+            })
+            .collect();
+
+        if matching_entries.is_empty() {
+            return self.lookup_source_location(address);
+        }
+
+        let best_entry = self.select_best_line_entry(&matching_entries);
+        self.create_source_location_from_entry(best_entry)
+    }
+
+    fn line_entry_matches_requested_source(
+        &self,
+        entry: &crate::core::LineEntry,
+        requested_file_path: &str,
+    ) -> bool {
+        let Some(candidate_path) = self.get_file_path_for_entry(entry) else {
+            return false;
+        };
+        if candidate_path == requested_file_path
+            || candidate_path.ends_with(requested_file_path)
+            || requested_file_path.ends_with(&candidate_path)
+        {
+            return true;
+        }
+
+        let requested_basename = Path::new(requested_file_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(requested_file_path);
+        Path::new(&candidate_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(requested_basename)
+    }
+
     fn find_alternative_source_file<'a>(
         &'a self,
         entry: &'a crate::core::LineEntry,
@@ -134,7 +184,10 @@ impl LoadedObjfile {
                 score
             );
 
-            if score > best_score {
+            // Equal-scored rows are still distinct debug-line candidates. Prefer
+            // the later row to preserve the old single-entry map replacement
+            // behavior for generic PC lookups.
+            if score >= best_score {
                 best = entry;
                 best_score = score;
             }

--- a/ghostscope-dwarf/src/parser/fast_parser.rs
+++ b/ghostscope-dwarf/src/parser/fast_parser.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     binary::DwarfReader,
-    core::{FunctionDieKind, IndexEntry, Result},
+    core::{FunctionDieKind, IndexEntry, LineEntry, Result},
     index::{
         directory_from_index, resolve_file_path, LightweightFileIndex, LightweightIndex,
         LightweightIndexShard, LineMappingTable, ScopedFileIndexManager,
@@ -710,6 +710,18 @@ impl<'a> DwarfParser<'a> {
         }
     }
 
+    fn flush_pending_line_entries(
+        out: &mut Vec<LineEntry>,
+        pending: &mut Vec<LineEntry>,
+        end_address: Option<u64>,
+    ) {
+        for mut entry in std::mem::take(pending) {
+            // Equal endpoints are zero-length rows, not unknown-length rows.
+            entry.end_address = end_address;
+            out.push(entry);
+        }
+    }
+
     fn high_pc_offset_value(value: gimli::AttributeValue<DwarfReader>) -> Option<u64> {
         match value {
             gimli::AttributeValue::Udata(offset) => Some(offset),
@@ -1001,13 +1013,47 @@ impl<'a> DwarfParser<'a> {
                     let (line_program, sequences) = line_program.clone().sequences()?;
                     for seq in sequences {
                         let mut rows = line_program.resume_from(&seq);
+                        let mut pending_entries: Vec<LineEntry> = Vec::new();
+                        let mut pending_address: Option<u64> = None;
                         while let Some((_, line_row)) = rows.next_row()? {
+                            let row_address = line_row.address();
+                            if line_row.end_sequence() {
+                                Self::flush_pending_line_entries(
+                                    &mut shard.line_entries,
+                                    &mut pending_entries,
+                                    Some(row_address),
+                                );
+                                pending_address = None;
+                                continue;
+                            }
+
+                            if let Some(address) = pending_address {
+                                if row_address > address {
+                                    Self::flush_pending_line_entries(
+                                        &mut shard.line_entries,
+                                        &mut pending_entries,
+                                        Some(row_address),
+                                    );
+                                    pending_address = Some(row_address);
+                                } else if row_address < address {
+                                    Self::flush_pending_line_entries(
+                                        &mut shard.line_entries,
+                                        &mut pending_entries,
+                                        None,
+                                    );
+                                    pending_address = Some(row_address);
+                                }
+                            } else {
+                                pending_address = Some(row_address);
+                            }
+
                             let column = match line_row.column() {
                                 gimli::ColumnType::LeftEdge => 0,
                                 gimli::ColumnType::Column(x) => x.get(),
                             };
-                            shard.line_entries.push(crate::core::LineEntry {
-                                address: line_row.address(),
+                            pending_entries.push(LineEntry {
+                                address: row_address,
+                                end_address: None,
                                 file_path: String::new(),
                                 file_index: line_row.file_index(),
                                 compilation_unit: std::sync::Arc::from(cu_name.as_str()),
@@ -1017,6 +1063,11 @@ impl<'a> DwarfParser<'a> {
                                 prologue_end: line_row.prologue_end(),
                             });
                         }
+                        Self::flush_pending_line_entries(
+                            &mut shard.line_entries,
+                            &mut pending_entries,
+                            None,
+                        );
                     }
                 }
                 Ok(shard)
@@ -1313,6 +1364,34 @@ mod tests {
     use std::process::Command;
     use std::sync::Arc;
     use tempfile::TempPath;
+
+    fn test_line_entry(address: u64) -> LineEntry {
+        LineEntry {
+            address,
+            end_address: None,
+            file_path: "/src/main.c".to_string(),
+            file_index: 1,
+            compilation_unit: Arc::from("main.c"),
+            line: 10,
+            column: 0,
+            is_stmt: true,
+            prologue_end: false,
+        }
+    }
+
+    #[test]
+    fn flush_pending_line_entries_keeps_equal_end_bounded() {
+        let mut out = Vec::new();
+        let mut pending = vec![test_line_entry(0x1000)];
+
+        DwarfParser::flush_pending_line_entries(&mut out, &mut pending, Some(0x1000));
+
+        assert!(pending.is_empty());
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].end_address, Some(0x1000));
+        assert!(!out[0].contains_address(0x1000));
+        assert!(!out[0].contains_address(0x1001));
+    }
 
     fn build_variable_index_fixture() -> gimli::Dwarf<DwarfReader> {
         let encoding = gimli::Encoding {

--- a/ghostscope-dwarf/src/parser/fast_parser.rs
+++ b/ghostscope-dwarf/src/parser/fast_parser.rs
@@ -50,8 +50,21 @@ struct RawDieAttrs {
     entry_pc: Option<u64>,
     location_attr: Option<gimli::AttributeValue<DwarfReader>>,
     has_main_subprogram: bool,
-    abstract_origin: Option<gimli::UnitOffset>,
-    specification: Option<gimli::UnitOffset>,
+    abstract_origin: Option<DieRef>,
+    specification: Option<DieRef>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum DieRef {
+    Unit(gimli::UnitOffset),
+    DebugInfo(gimli::DebugInfoOffset),
+}
+
+struct ResolvedRawDieAttrs {
+    unit: Option<gimli::Unit<DwarfReader>>,
+    offset: gimli::UnitOffset,
+    absolute_offset: gimli::DebugInfoOffset,
+    attrs: RawDieAttrs,
 }
 
 /// Compilation unit information with associated directories and files.
@@ -136,7 +149,7 @@ impl<'a> DwarfParser<'a> {
     ) -> Result<InfoShard> {
         let mut shard = InfoShard::default();
         let mut entries = unit.entries_raw(None)?;
-        let mut metadata_cache: HashMap<gimli::UnitOffset, FunctionMetadata> = HashMap::new();
+        let mut metadata_cache: HashMap<gimli::DebugInfoOffset, FunctionMetadata> = HashMap::new();
         let mut tag_stack: Vec<gimli::DwTag> = Vec::new();
         while !entries.is_empty() {
             let d: usize = entries.next_depth() as usize;
@@ -476,13 +489,19 @@ impl<'a> DwarfParser<'a> {
 
     /// Process single compilation unit - decoupled debug_line and debug_info processing
     // Helper methods (extracted from unified_builder.rs)
-    fn same_unit_ref(
+    fn die_ref(
         unit: &gimli::Unit<DwarfReader>,
         value: gimli::AttributeValue<DwarfReader>,
-    ) -> Option<gimli::UnitOffset> {
+    ) -> Option<DieRef> {
         match value {
-            gimli::AttributeValue::UnitRef(offset) => Some(offset),
-            gimli::AttributeValue::DebugInfoRef(offset) => offset.to_unit_offset(&unit.header),
+            gimli::AttributeValue::UnitRef(offset) => Some(DieRef::Unit(offset)),
+            gimli::AttributeValue::DebugInfoRef(offset) => {
+                if let Some(unit_offset) = offset.to_unit_offset(&unit.header) {
+                    Some(DieRef::Unit(unit_offset))
+                } else {
+                    Some(DieRef::DebugInfo(offset))
+                }
+            }
             _ => None,
         }
     }
@@ -572,15 +591,64 @@ impl<'a> DwarfParser<'a> {
                     attrs.has_main_subprogram = true;
                 }
                 gimli::constants::DW_AT_abstract_origin => {
-                    attrs.abstract_origin = Self::same_unit_ref(unit, value);
+                    attrs.abstract_origin = Self::die_ref(unit, value);
                 }
                 gimli::constants::DW_AT_specification => {
-                    attrs.specification = Self::same_unit_ref(unit, value);
+                    attrs.specification = Self::die_ref(unit, value);
                 }
                 _ => {}
             }
         }
         Ok(attrs)
+    }
+
+    fn read_attrs_for_die_ref(
+        &self,
+        current_unit: &gimli::Unit<DwarfReader>,
+        reference: DieRef,
+    ) -> Result<Option<ResolvedRawDieAttrs>> {
+        match reference {
+            DieRef::Unit(unit_offset) => {
+                let Some(debug_info_offset) =
+                    unit_offset.to_debug_info_offset(&current_unit.header)
+                else {
+                    return Ok(None);
+                };
+                let attrs = self.read_selected_raw_attrs_at(current_unit, unit_offset)?;
+                Ok(Some(ResolvedRawDieAttrs {
+                    unit: None,
+                    offset: unit_offset,
+                    absolute_offset: debug_info_offset,
+                    attrs,
+                }))
+            }
+            DieRef::DebugInfo(debug_info_offset) => {
+                if let Some(unit_offset) = debug_info_offset.to_unit_offset(&current_unit.header) {
+                    let attrs = self.read_selected_raw_attrs_at(current_unit, unit_offset)?;
+                    return Ok(Some(ResolvedRawDieAttrs {
+                        unit: None,
+                        offset: unit_offset,
+                        absolute_offset: debug_info_offset,
+                        attrs,
+                    }));
+                }
+
+                let mut units = self.dwarf.units();
+                while let Some(header) = units.next()? {
+                    if let Some(unit_offset) = debug_info_offset.to_unit_offset(&header) {
+                        let unit = self.dwarf.unit(header)?;
+                        let attrs = self.read_selected_raw_attrs_at(&unit, unit_offset)?;
+                        return Ok(Some(ResolvedRawDieAttrs {
+                            unit: Some(unit),
+                            offset: unit_offset,
+                            absolute_offset: debug_info_offset,
+                            attrs,
+                        }));
+                    }
+                }
+                Ok(None)
+            }
+        }
     }
 
     fn read_selected_raw_attrs_at(
@@ -600,35 +668,41 @@ impl<'a> DwarfParser<'a> {
         unit: &gimli::Unit<DwarfReader>,
         entry_offset: gimli::UnitOffset,
         attrs: &RawDieAttrs,
-        visited: &mut HashSet<gimli::UnitOffset>,
+        visited: &mut HashSet<gimli::DebugInfoOffset>,
     ) -> Result<Option<Arc<str>>> {
         if let Some(name) = attrs.name.as_ref() {
             return Ok(Some(Arc::clone(name)));
         }
 
-        if !visited.insert(entry_offset) {
+        let Some(entry_abs) = entry_offset.to_debug_info_offset(&unit.header) else {
+            return Ok(None);
+        };
+        if !visited.insert(entry_abs) {
             return Ok(None);
         }
 
         let mut resolved = None;
-        for origin_offset in [attrs.specification, attrs.abstract_origin]
+        for origin_ref in [attrs.specification, attrs.abstract_origin]
             .into_iter()
             .flatten()
         {
-            if visited.contains(&origin_offset) {
+            let Some(origin) = self.read_attrs_for_die_ref(unit, origin_ref)? else {
+                continue;
+            };
+            if visited.contains(&origin.absolute_offset) {
                 continue;
             }
 
-            let origin_attrs = self.read_selected_raw_attrs_at(unit, origin_offset)?;
+            let origin_unit = origin.unit.as_ref().unwrap_or(unit);
             if let Some(name) =
-                self.resolve_name_from_raw(unit, origin_offset, &origin_attrs, visited)?
+                self.resolve_name_from_raw(origin_unit, origin.offset, &origin.attrs, visited)?
             {
                 resolved = Some(name);
                 break;
             }
         }
 
-        visited.remove(&entry_offset);
+        visited.remove(&entry_abs);
         Ok(resolved)
     }
 
@@ -637,14 +711,17 @@ impl<'a> DwarfParser<'a> {
         unit: &gimli::Unit<DwarfReader>,
         entry_offset: gimli::UnitOffset,
         attrs: &RawDieAttrs,
-        cache: &mut HashMap<gimli::UnitOffset, FunctionMetadata>,
-        visited: &mut HashSet<gimli::UnitOffset>,
+        cache: &mut HashMap<gimli::DebugInfoOffset, FunctionMetadata>,
+        visited: &mut HashSet<gimli::DebugInfoOffset>,
     ) -> Result<FunctionMetadata> {
-        if let Some(cached) = cache.get(&entry_offset) {
+        let Some(entry_abs) = entry_offset.to_debug_info_offset(&unit.header) else {
+            return Ok(FunctionMetadata::default());
+        };
+        if let Some(cached) = cache.get(&entry_abs) {
             return Ok(cached.clone());
         }
 
-        if !visited.insert(entry_offset) {
+        if !visited.insert(entry_abs) {
             return Ok(FunctionMetadata::default());
         }
 
@@ -662,19 +739,22 @@ impl<'a> DwarfParser<'a> {
         metadata.has_inline_attribute = attrs.has_inline_attribute;
         metadata.is_external = attrs.is_external;
 
-        let mut merge_from_origin = |origin_offset: gimli::UnitOffset| -> Result<()> {
-            if visited.contains(&origin_offset) {
+        let mut merge_from_origin = |origin_ref: DieRef| -> Result<()> {
+            let Some(origin) = self.read_attrs_for_die_ref(unit, origin_ref)? else {
+                return Ok(());
+            };
+            if visited.contains(&origin.absolute_offset) {
                 return Ok(());
             }
 
-            let origin_metadata = if let Some(cached) = cache.get(&origin_offset) {
+            let origin_metadata = if let Some(cached) = cache.get(&origin.absolute_offset) {
                 cached.clone()
             } else {
-                let origin_attrs = self.read_selected_raw_attrs_at(unit, origin_offset)?;
+                let origin_unit = origin.unit.as_ref().unwrap_or(unit);
                 self.resolve_function_metadata_from_raw(
-                    unit,
-                    origin_offset,
-                    &origin_attrs,
+                    origin_unit,
+                    origin.offset,
+                    &origin.attrs,
                     cache,
                     visited,
                 )?
@@ -698,8 +778,8 @@ impl<'a> DwarfParser<'a> {
             merge_from_origin(origin_offset)?;
         }
 
-        visited.remove(&entry_offset);
-        cache.insert(entry_offset, metadata.clone());
+        visited.remove(&entry_abs);
+        cache.insert(entry_abs, metadata.clone());
         Ok(metadata)
     }
 
@@ -1354,8 +1434,8 @@ mod tests {
     use super::*;
     use crate::binary::dwarf_reader_from_arc;
     use gimli::write::{
-        Address, AttributeValue as WriteAttributeValue, Dwarf as WriteDwarf, EndianVec,
-        Expression as WriteExpression, LineProgram, Sections, Unit,
+        Address, AttributeValue as WriteAttributeValue, DebugInfoRef as WriteDebugInfoRef,
+        Dwarf as WriteDwarf, EndianVec, Expression as WriteExpression, LineProgram, Sections, Unit,
     };
     use gimli::{Format, LittleEndian};
     use object::{Object, ObjectSection};
@@ -1377,6 +1457,24 @@ mod tests {
             is_stmt: true,
             prologue_end: false,
         }
+    }
+
+    fn write_dwarf_to_read(mut dwarf: WriteDwarf) -> gimli::Dwarf<DwarfReader> {
+        let mut sections = Sections::new(EndianVec::new(LittleEndian));
+        dwarf.write(&mut sections).unwrap();
+
+        let dwarf_sections: gimli::DwarfSections<Vec<u8>> = gimli::DwarfSections::load(|id| {
+            Ok::<_, gimli::Error>(
+                sections
+                    .get(id)
+                    .map(|section| section.slice().to_vec())
+                    .unwrap_or_default(),
+            )
+        })
+        .unwrap();
+
+        dwarf_sections
+            .borrow(|section| dwarf_reader_from_arc(Arc::<[u8]>::from(section.as_slice())))
     }
 
     #[test]
@@ -1535,6 +1633,81 @@ mod tests {
 
         dwarf_sections
             .borrow(|section| dwarf_reader_from_arc(Arc::<[u8]>::from(section.as_slice())))
+    }
+
+    fn build_cross_cu_origin_fixture() -> gimli::Dwarf<DwarfReader> {
+        let encoding = gimli::Encoding {
+            format: Format::Dwarf32,
+            version: 4,
+            address_size: 8,
+        };
+
+        let mut dwarf = WriteDwarf::new();
+
+        let decl_unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+        let decl_unit = dwarf.units.get_mut(decl_unit_id);
+        let decl_root = decl_unit.root();
+        decl_unit.get_mut(decl_root).set(
+            gimli::constants::DW_AT_name,
+            WriteAttributeValue::String(b"decl_unit.c".to_vec()),
+        );
+
+        let abstract_fn_id = decl_unit.add(decl_root, gimli::constants::DW_TAG_subprogram);
+        let abstract_fn = decl_unit.get_mut(abstract_fn_id);
+        abstract_fn.set(
+            gimli::constants::DW_AT_name,
+            WriteAttributeValue::String(b"cross_cu_origin_fn".to_vec()),
+        );
+        abstract_fn.set(
+            gimli::constants::DW_AT_external,
+            WriteAttributeValue::Flag(true),
+        );
+
+        let spec_type_id = decl_unit.add(decl_root, gimli::constants::DW_TAG_structure_type);
+        let spec_type = decl_unit.get_mut(spec_type_id);
+        spec_type.set(
+            gimli::constants::DW_AT_name,
+            WriteAttributeValue::String(b"CrossCuOriginType".to_vec()),
+        );
+        spec_type.set(
+            gimli::constants::DW_AT_declaration,
+            WriteAttributeValue::Flag(true),
+        );
+
+        let concrete_unit_id = dwarf.units.add(Unit::new(encoding, LineProgram::none()));
+        let concrete_unit = dwarf.units.get_mut(concrete_unit_id);
+        let concrete_root = concrete_unit.root();
+        concrete_unit.get_mut(concrete_root).set(
+            gimli::constants::DW_AT_name,
+            WriteAttributeValue::String(b"concrete_unit.c".to_vec()),
+        );
+
+        let concrete_fn_id = concrete_unit.add(concrete_root, gimli::constants::DW_TAG_subprogram);
+        let concrete_fn = concrete_unit.get_mut(concrete_fn_id);
+        concrete_fn.set(
+            gimli::constants::DW_AT_abstract_origin,
+            WriteAttributeValue::DebugInfoRef(WriteDebugInfoRef::Entry(
+                decl_unit_id,
+                abstract_fn_id,
+            )),
+        );
+        concrete_fn.set(
+            gimli::constants::DW_AT_low_pc,
+            WriteAttributeValue::Address(Address::Constant(0x501000)),
+        );
+        concrete_fn.set(
+            gimli::constants::DW_AT_high_pc,
+            WriteAttributeValue::Udata(0x40),
+        );
+
+        let concrete_type_id =
+            concrete_unit.add(concrete_root, gimli::constants::DW_TAG_structure_type);
+        concrete_unit.get_mut(concrete_type_id).set(
+            gimli::constants::DW_AT_specification,
+            WriteAttributeValue::DebugInfoRef(WriteDebugInfoRef::Entry(decl_unit_id, spec_type_id)),
+        );
+
+        write_dwarf_to_read(dwarf)
     }
 
     fn build_multi_cu_shared_function_fixture() -> gimli::Dwarf<DwarfReader> {
@@ -1930,6 +2103,44 @@ mod tests {
         assert!(
             abstract_entries[0].flags.has_inline_attribute,
             "abstract definition should retain its original DW_AT_inline attribute: {entries:?}"
+        );
+    }
+
+    #[test]
+    fn parse_debug_info_resolves_cross_cu_origin_names_for_index_entries() {
+        let dwarf = build_cross_cu_origin_fixture();
+        let parser = DwarfParser { dwarf: &dwarf };
+
+        let result = parser.parse_debug_info("synthetic").unwrap();
+        let function_entries = result
+            .lightweight_index
+            .find_dies_by_function_name("cross_cu_origin_fn");
+        assert!(
+            function_entries.iter().any(|entry| {
+                entry.function_kind() == crate::core::FunctionDieKind::ConcreteSubprogram
+                    && entry.representative_addr == Some(0x501000)
+            }),
+            "concrete function should inherit its name through a cross-CU origin: {function_entries:?}"
+        );
+
+        let mut has_concrete_type = false;
+        result
+            .lightweight_index
+            .for_each_type_map_entry(|name, entry_base, indices| {
+                if name != "CrossCuOriginType" {
+                    return;
+                }
+                has_concrete_type |= indices.iter().any(|local_idx| {
+                    result
+                        .lightweight_index
+                        .entry(entry_base + *local_idx)
+                        .is_some_and(|entry| !entry.flags.is_type_declaration)
+                });
+            });
+
+        assert!(
+            has_concrete_type,
+            "concrete type should inherit its name through a cross-CU specification"
         );
     }
 

--- a/ghostscope-dwarf/src/path_match.rs
+++ b/ghostscope-dwarf/src/path_match.rs
@@ -1,0 +1,83 @@
+use std::borrow::Cow;
+
+pub(crate) fn has_path_separator(path: &str) -> bool {
+    path.contains('/') || path.contains('\\')
+}
+
+pub(crate) fn file_name(path: &str) -> &str {
+    path.rsplit(['/', '\\'])
+        .find(|component| !component.is_empty())
+        .unwrap_or(path)
+}
+
+pub(crate) fn path_component_suffix_matches(path: &str, suffix: &str) -> bool {
+    let path = normalize_separators(path);
+    let suffix = normalize_separators(suffix);
+    component_suffix_matches(path.as_ref(), suffix.as_ref())
+}
+
+pub(crate) fn source_path_matches(candidate_path: &str, requested_file_path: &str) -> bool {
+    let candidate = normalize_separators(candidate_path);
+    let requested = normalize_separators(requested_file_path);
+
+    if component_suffix_matches(candidate.as_ref(), requested.as_ref())
+        || component_suffix_matches(requested.as_ref(), candidate.as_ref())
+    {
+        return true;
+    }
+
+    // Directory-qualified hints were already narrowed by reverse lookup; do not
+    // re-admit unrelated same-basename rows that share the queried PC.
+    !has_path_separator(requested.as_ref()) && file_name(candidate.as_ref()) == requested.as_ref()
+}
+
+fn normalize_separators(path: &str) -> Cow<'_, str> {
+    if path.contains('\\') {
+        Cow::Owned(path.replace('\\', "/"))
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+fn component_suffix_matches(path: &str, suffix: &str) -> bool {
+    if path == suffix {
+        return true;
+    }
+    if suffix.is_empty() || !path.ends_with(suffix) {
+        return false;
+    }
+
+    let prefix_len = path.len() - suffix.len();
+    if prefix_len == 0 || suffix.starts_with('/') {
+        return true;
+    }
+
+    path.as_bytes().get(prefix_len - 1) == Some(&b'/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_path_matches_keeps_directory_qualified_hints_narrow() {
+        assert!(source_path_matches("/a/foo.c", "/a/foo.c"));
+        assert!(source_path_matches("/build/src/foo.c", "src/foo.c"));
+        assert!(source_path_matches("foo.c", "/src/foo.c"));
+        assert!(!source_path_matches("/b/foo.c", "/a/foo.c"));
+    }
+
+    #[test]
+    fn source_path_matches_requires_component_boundaries() {
+        assert!(source_path_matches("/src/foo/bar.c", "foo/bar.c"));
+        assert!(!source_path_matches("/src/myfoo/bar.c", "foo/bar.c"));
+        assert!(!source_path_matches("/src/foobar.c", "bar.c"));
+    }
+
+    #[test]
+    fn source_path_matches_allows_basename_queries() {
+        assert!(source_path_matches("/a/foo.c", "foo.c"));
+        assert!(source_path_matches("C:\\project\\foo.c", "foo.c"));
+        assert!(!source_path_matches("/a/foobar.c", "bar.c"));
+    }
+}


### PR DESCRIPTION
This PR fixes a set of DWARF lightweight-index and source-line lookup regressions around duplicate line rows, line-sequence boundaries, and cross-CU origin/specification references.