### PR TITLE
test: c cases optimization bugbash

### DIFF
--- a/e2e-tests/tests/common/mod.rs
+++ b/e2e-tests/tests/common/mod.rs
@@ -27,8 +27,12 @@ lazy_static! {
     static ref COMPILE_MEMBER_POINTER_OPTIMIZED_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
     static ref COMPILE_GLOBALS_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
+    static ref COMPILE_GLOBALS_OPTIMIZED_RESULT: Mutex<Option<anyhow::Result<()>>> =
+        Mutex::new(None);
     static ref COMPILE_LATE_GLOBALS_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_SCALAR_TYPES_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
+    static ref COMPILE_SCALAR_TYPES_OPTIMIZED_RESULT: Mutex<Option<anyhow::Result<()>>> =
+        Mutex::new(None);
     static ref COMPILE_RUST_GLOBAL_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_INLINE_CALLSITE_DEFAULT_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
@@ -391,22 +395,60 @@ impl RegisteredFixture {
                 Ok(dir.join(bin_name))
             }
             RegisteredFixtureKind::Globals => {
-                ensure_globals_program_compiled()?;
-                Ok(dir.join("globals_program"))
+                let bin_name = match opt_level {
+                    OptimizationLevel::Debug => {
+                        ensure_globals_program_compiled()?;
+                        "globals_program"
+                    }
+                    OptimizationLevel::O1 => {
+                        ensure_globals_program_optimized_variants_compiled()?;
+                        "globals_program_o1"
+                    }
+                    OptimizationLevel::O2 => {
+                        ensure_globals_program_optimized_variants_compiled()?;
+                        "globals_program_o2"
+                    }
+                    OptimizationLevel::O3 => {
+                        ensure_globals_program_optimized_variants_compiled()?;
+                        "globals_program_o3"
+                    }
+                    OptimizationLevel::Stripped => {
+                        anyhow::bail!(
+                            "Stripped optimization level not supported for globals_program"
+                        )
+                    }
+                };
+                Ok(dir.join(bin_name))
             }
             RegisteredFixtureKind::LateGlobals => {
                 ensure_late_globals_program_compiled()?;
                 Ok(dir.join("late_globals_program"))
             }
             RegisteredFixtureKind::ScalarTypes => {
-                if !matches!(opt_level, OptimizationLevel::Debug) {
-                    anyhow::bail!(
-                        "Optimization level {} not supported for scalar_types_program",
-                        opt_level.description()
-                    );
-                }
-                ensure_scalar_types_program_compiled()?;
-                Ok(dir.join("scalar_types_program"))
+                let bin_name = match opt_level {
+                    OptimizationLevel::Debug => {
+                        ensure_scalar_types_program_compiled()?;
+                        "scalar_types_program"
+                    }
+                    OptimizationLevel::O1 => {
+                        ensure_scalar_types_program_optimized_variants_compiled()?;
+                        "scalar_types_program_o1"
+                    }
+                    OptimizationLevel::O2 => {
+                        ensure_scalar_types_program_optimized_variants_compiled()?;
+                        "scalar_types_program_o2"
+                    }
+                    OptimizationLevel::O3 => {
+                        ensure_scalar_types_program_optimized_variants_compiled()?;
+                        "scalar_types_program_o3"
+                    }
+                    OptimizationLevel::Stripped => {
+                        anyhow::bail!(
+                            "Stripped optimization level not supported for scalar_types_program"
+                        )
+                    }
+                };
+                Ok(dir.join(bin_name))
             }
             RegisteredFixtureKind::RustGlobal => {
                 ensure_rust_global_program_compiled()?;
@@ -636,7 +678,11 @@ pub fn ensure_test_program_compiled_with_opt(opt_level: OptimizationLevel) -> an
         }
         _ => {
             COMPILE_OPTIMIZED.call_once(|| {
-                let compile_result = compile_sample_program(opt_level);
+                let compile_result = compile_sample_program_variants(&[
+                    OptimizationLevel::O1,
+                    OptimizationLevel::O2,
+                    OptimizationLevel::O3,
+                ]);
                 *COMPILE_OPT_RESULT.lock().unwrap() = Some(compile_result);
             });
             match COMPILE_OPT_RESULT.lock().unwrap().as_ref() {
@@ -645,6 +691,51 @@ pub fn ensure_test_program_compiled_with_opt(opt_level: OptimizationLevel) -> an
                 None => panic!("Compilation result should be set after call_once"),
             }
         }
+    }
+}
+
+fn compile_sample_program_variants(opt_levels: &[OptimizationLevel]) -> anyhow::Result<()> {
+    let fixtures_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let sample_program_dir = fixtures_path.join("sample_program");
+    let outputs = opt_levels
+        .iter()
+        .map(|opt_level| sample_program_dir.join(opt_level.as_binary_name()))
+        .collect::<Vec<_>>();
+    if let Some(result) = use_precompiled_outputs("sample_program variants", &outputs) {
+        return result;
+    }
+
+    let requested = opt_levels
+        .iter()
+        .map(OptimizationLevel::description)
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("Compiling sample_program variants [{requested}] in {sample_program_dir:?}");
+
+    let mut command = Command::new("make");
+    for opt_level in opt_levels {
+        command.arg(opt_level.as_make_target());
+    }
+
+    let output = command
+        .current_dir(sample_program_dir)
+        .output()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to run make for sample_program variants [{requested}]: {}",
+                e
+            )
+        })?;
+
+    if output.status.success() {
+        println!("✓ Successfully compiled sample_program variants [{requested}]");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!(
+            "Failed to compile sample_program variants [{requested}]: {}",
+            stderr
+        ))
     }
 }
 
@@ -714,7 +805,11 @@ fn ensure_complex_program_compiled_with_opt(opt_level: OptimizationLevel) -> any
         }
         _ => {
             COMPILE_COMPLEX_OPT.call_once(|| {
-                let compile_result = compile_complex_program(opt_level);
+                let compile_result = compile_complex_program_variants(&[
+                    OptimizationLevel::O1,
+                    OptimizationLevel::O2,
+                    OptimizationLevel::O3,
+                ]);
                 *COMPILE_COMPLEX_OPT_RESULT.lock().unwrap() = Some(compile_result);
             });
             match COMPILE_COMPLEX_OPT_RESULT.lock().unwrap().as_ref() {
@@ -722,6 +817,18 @@ fn ensure_complex_program_compiled_with_opt(opt_level: OptimizationLevel) -> any
                 Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
                 None => panic!("Compilation result should be set after call_once"),
             }
+        }
+    }
+}
+
+fn complex_program_binary_name(opt_level: OptimizationLevel) -> anyhow::Result<&'static str> {
+    match opt_level {
+        OptimizationLevel::Debug => Ok("complex_types_program"),
+        OptimizationLevel::O1 => Ok("complex_types_program_o1"),
+        OptimizationLevel::O2 => Ok("complex_types_program_o2"),
+        OptimizationLevel::O3 => Ok("complex_types_program_o3"),
+        OptimizationLevel::Stripped => {
+            anyhow::bail!("Stripped optimization level not supported for complex_types_program")
         }
     }
 }
@@ -735,15 +842,7 @@ fn compile_complex_program(opt_level: OptimizationLevel) -> anyhow::Result<()> {
         opt_level.description()
     );
 
-    let target = match opt_level {
-        OptimizationLevel::Debug => "complex_types_program",
-        OptimizationLevel::O1 => "complex_types_program_o1",
-        OptimizationLevel::O2 => "complex_types_program_o2",
-        OptimizationLevel::O3 => "complex_types_program_o3",
-        OptimizationLevel::Stripped => {
-            anyhow::bail!("Stripped optimization level not supported for complex_types_program")
-        }
-    };
+    let target = complex_program_binary_name(opt_level)?;
     if let Some(result) =
         use_precompiled_outputs("complex_types_program", &[program_dir.join(target)])
     {
@@ -773,6 +872,50 @@ fn compile_complex_program(opt_level: OptimizationLevel) -> anyhow::Result<()> {
         Err(anyhow::anyhow!(
             "Failed to compile complex_types_program {}: {}",
             opt_level.description(),
+            stderr
+        ))
+    }
+}
+
+fn compile_complex_program_variants(opt_levels: &[OptimizationLevel]) -> anyhow::Result<()> {
+    let fixtures_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let program_dir = fixtures_path.join("complex_types_program");
+    let outputs = opt_levels
+        .iter()
+        .map(|opt_level| {
+            Ok::<_, anyhow::Error>(program_dir.join(complex_program_binary_name(*opt_level)?))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    if let Some(result) = use_precompiled_outputs("complex_types_program variants", &outputs) {
+        return result;
+    }
+
+    let requested = opt_levels
+        .iter()
+        .map(OptimizationLevel::description)
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("Compiling complex_types_program variants [{requested}] in {program_dir:?}");
+
+    let mut command = Command::new("make");
+    for opt_level in opt_levels {
+        command.arg(complex_program_binary_name(*opt_level)?);
+    }
+
+    let output = command.current_dir(program_dir).output().map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to run make for complex_types_program variants [{requested}]: {}",
+            e
+        )
+    })?;
+
+    if output.status.success() {
+        println!("✓ Successfully compiled complex_types_program variants [{requested}]");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!(
+            "Failed to compile complex_types_program variants [{requested}]: {}",
             stderr
         ))
     }
@@ -1060,8 +1203,10 @@ pub mod targets;
 pub mod termination;
 
 static COMPILE_GLOBALS: Once = Once::new();
+static COMPILE_GLOBALS_OPTIMIZED: Once = Once::new();
 static COMPILE_LATE_GLOBALS: Once = Once::new();
 static COMPILE_SCALAR_TYPES: Once = Once::new();
+static COMPILE_SCALAR_TYPES_OPTIMIZED: Once = Once::new();
 static COMPILE_RUST_GLOBAL: Once = Once::new();
 static COMPILE_INLINE_CALLSITE_DEFAULT: Once = Once::new();
 static COMPILE_INLINE_CALLSITE_CLANG_DWARF5: Once = Once::new();
@@ -1114,6 +1259,51 @@ fn ensure_globals_program_compiled() -> anyhow::Result<()> {
     }
 }
 
+fn ensure_globals_program_optimized_variants_compiled() -> anyhow::Result<()> {
+    COMPILE_GLOBALS_OPTIMIZED.call_once(|| {
+        let compile_result = (|| -> anyhow::Result<()> {
+            let base =
+                PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/globals_program");
+            let outputs = [
+                base.join("globals_program_o1"),
+                base.join("globals_program_o2"),
+                base.join("globals_program_o3"),
+                base.join("libgvars.so"),
+            ];
+            if let Some(result) =
+                use_precompiled_outputs("globals_program optimized variants", &outputs)
+            {
+                return result;
+            }
+
+            println!("Compiling globals_program optimized variants in {base:?}");
+            let out = Command::new("make")
+                .arg("globals_program_o1")
+                .arg("globals_program_o2")
+                .arg("globals_program_o3")
+                .current_dir(base)
+                .output()?;
+            if out.status.success() {
+                println!("✓ Successfully compiled globals_program optimized variants");
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                Err(anyhow::anyhow!(
+                    "Failed to compile globals_program optimized variants: {}",
+                    stderr
+                ))
+            }
+        })();
+        *COMPILE_GLOBALS_OPTIMIZED_RESULT.lock().unwrap() = Some(compile_result);
+    });
+
+    match COMPILE_GLOBALS_OPTIMIZED_RESULT.lock().unwrap().as_ref() {
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+        None => panic!("Compilation result should be set after call_once"),
+    }
+}
+
 fn ensure_late_globals_program_compiled() -> anyhow::Result<()> {
     COMPILE_LATE_GLOBALS.call_once(|| {
         let compile_result = (|| -> anyhow::Result<()> {
@@ -1155,15 +1345,86 @@ fn ensure_late_globals_program_compiled() -> anyhow::Result<()> {
 
 fn ensure_scalar_types_program_compiled() -> anyhow::Result<()> {
     COMPILE_SCALAR_TYPES.call_once(|| {
-        let compile_result = compile_c_make_fixture(
+        let compile_result = compile_scalar_types_program_target(
             "scalar_types_program",
-            FixtureCompiler::Default,
-            "-Wall -Wextra -g -O0",
+            OptimizationLevel::Debug.description(),
         );
         *COMPILE_SCALAR_TYPES_RESULT.lock().unwrap() = Some(compile_result);
     });
 
     match COMPILE_SCALAR_TYPES_RESULT.lock().unwrap().as_ref() {
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+        None => panic!("Compilation result should be set after call_once"),
+    }
+}
+
+fn compile_scalar_types_program_target(target: &str, description: &str) -> anyhow::Result<()> {
+    let base =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scalar_types_program");
+    if let Some(result) = use_precompiled_outputs("scalar_types_program", &[base.join(target)]) {
+        return result;
+    }
+
+    println!("Compiling scalar_types_program {description} in {base:?}");
+    let out = Command::new("make")
+        .arg(target)
+        .current_dir(base)
+        .output()?;
+    if out.status.success() {
+        println!("✓ Successfully compiled scalar_types_program {description}");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        Err(anyhow::anyhow!(
+            "Failed to compile scalar_types_program {description}: {}",
+            stderr
+        ))
+    }
+}
+
+fn ensure_scalar_types_program_optimized_variants_compiled() -> anyhow::Result<()> {
+    COMPILE_SCALAR_TYPES_OPTIMIZED.call_once(|| {
+        let compile_result = (|| -> anyhow::Result<()> {
+            let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/scalar_types_program");
+            let outputs = [
+                base.join("scalar_types_program_o1"),
+                base.join("scalar_types_program_o2"),
+                base.join("scalar_types_program_o3"),
+            ];
+            if let Some(result) =
+                use_precompiled_outputs("scalar_types_program optimized variants", &outputs)
+            {
+                return result;
+            }
+
+            println!("Compiling scalar_types_program optimized variants in {base:?}");
+            let out = Command::new("make")
+                .arg("scalar_types_program_o1")
+                .arg("scalar_types_program_o2")
+                .arg("scalar_types_program_o3")
+                .current_dir(base)
+                .output()?;
+            if out.status.success() {
+                println!("✓ Successfully compiled scalar_types_program optimized variants");
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                Err(anyhow::anyhow!(
+                    "Failed to compile scalar_types_program optimized variants: {}",
+                    stderr
+                ))
+            }
+        })();
+        *COMPILE_SCALAR_TYPES_OPTIMIZED_RESULT.lock().unwrap() = Some(compile_result);
+    });
+
+    match COMPILE_SCALAR_TYPES_OPTIMIZED_RESULT
+        .lock()
+        .unwrap()
+        .as_ref()
+    {
         Some(Ok(())) => Ok(()),
         Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
         None => panic!("Compilation result should be set after call_once"),

--- a/e2e-tests/tests/common_fixture_builds.rs
+++ b/e2e-tests/tests/common_fixture_builds.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{init, FixtureCompiler};
+use common::{init, FixtureCompiler, OptimizationLevel};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -88,5 +88,86 @@ fn compiler_specific_builds_keep_sibling_fixture_outputs() -> anyhow::Result<()>
         clean_fixture_outputs(fixture_name)?;
     }
 
+    Ok(())
+}
+
+#[test]
+fn sample_program_optimized_build_compiles_all_variants() -> anyhow::Result<()> {
+    init();
+
+    clean_fixture_outputs("sample_program")?;
+
+    common::ensure_test_program_compiled_with_opt(OptimizationLevel::O2)?;
+
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("sample_program");
+    for binary_name in [
+        "sample_program_o1",
+        "sample_program_o2",
+        "sample_program_o3",
+    ] {
+        assert!(
+            base.join(binary_name).exists(),
+            "{binary_name} should exist after compiling optimized sample variants"
+        );
+    }
+
+    clean_fixture_outputs("sample_program")?;
+    Ok(())
+}
+
+#[test]
+fn complex_program_optimized_build_compiles_all_variants() -> anyhow::Result<()> {
+    init();
+
+    clean_fixture_outputs("complex_types_program")?;
+
+    common::TestFixtures::new()
+        .get_test_binary_with_opt("complex_types_program", OptimizationLevel::O2)?;
+
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("complex_types_program");
+    for binary_name in [
+        "complex_types_program_o1",
+        "complex_types_program_o2",
+        "complex_types_program_o3",
+    ] {
+        assert!(
+            base.join(binary_name).exists(),
+            "{binary_name} should exist after compiling optimized complex variants"
+        );
+    }
+
+    clean_fixture_outputs("complex_types_program")?;
+    Ok(())
+}
+
+#[test]
+fn globals_program_optimized_build_compiles_all_variants() -> anyhow::Result<()> {
+    init();
+
+    clean_fixture_outputs("globals_program")?;
+
+    common::TestFixtures::new()
+        .get_test_binary_with_opt("globals_program", OptimizationLevel::O2)?;
+
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("globals_program");
+    for binary_name in [
+        "globals_program_o1",
+        "globals_program_o2",
+        "globals_program_o3",
+        "libgvars.so",
+    ] {
+        assert!(
+            base.join(binary_name).exists(),
+            "{binary_name} should exist after compiling optimized globals variants"
+        );
+    }
+
+    clean_fixture_outputs("globals_program")?;
     Ok(())
 }

--- a/e2e-tests/tests/complex_types_execution.rs
+++ b/e2e-tests/tests/complex_types_execution.rs
@@ -75,6 +75,335 @@ trace update_complex {
 }
 
 #[tokio::test]
+async fn test_complex_o3_pointer_members_after_volatile_path() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("complex_types_program", OptimizationLevel::O3)?;
+    let target = spawn_complex_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace complex_types_program.c:15 {
+    print "O3_COMPLEX I={} AGE={} DATA={} ACTIVE={} FLAGS={}", i, c.age, c.data.i, c.active, c.flags;
+    print "O3_COMPLEX_ARITH AGE1={} DATA2={} FLAGS1={}", c.age - 0x1, c.data.i + 0b10, c.flags + -0x1;
+    print "O3_COMPLEX_DIV AGE={} DATA={} FLAGS={}", c.age / 0x3, c.data.i / 0x2, c.flags / 0x2;
+    print "O3_FRIEND_MEMBERS AGE={} DATA={} FLAGS={}", c.friend_ref.age, c.friend_ref.data.i, c.friend_ref.flags;
+    print "O3_FRIEND_DIV AGE={} DATA={} FLAGS={}", c.friend_ref.age / 0x5, c.friend_ref.data.i / (i + 0x1), c.friend_ref.flags / -0x2;
+    let dyn_idx = i - (i / 0x8) * 0x8;
+    let dyn_zero = i - i;
+    let c_dyn = c + dyn_zero;
+    print "O3_DYNAMIC_ARR IDX={} VAL={}", dyn_idx, c.arr[dyn_idx];
+    print "O3_DYNAMIC_ARR_DIV:{}", c.arr[dyn_idx] / 0x2;
+    print "O3_C_DYN AGE={} DATA={} FLAGS={} ARR={}", c_dyn.age, c_dyn.data.i, c_dyn.flags, c_dyn.arr[dyn_idx];
+    print "O3_C_DYN_FRIEND DATA={} FLAGS={}", c_dyn.friend_ref.data.i, c_dyn.friend_ref.flags;
+    print "O3_NAME={:s.5}", &c.name[0];
+    print "O3_FRIEND={:p}", c.friend_ref;
+    if c.flags < 0 { print "O3_FLAGS_NEG"; }
+    if c.flags == -0x4 { print "O3_FLAGS_EQ_NEG4"; }
+    if c.flags / 0x2 == -0x2 { print "O3_FLAGS_DIV_NEG2"; }
+    if c.data.i / 0x2 >= 0 { print "O3_DATA_DIV_NONNEG"; }
+    if c.friend_ref.data.i == i { print "O3_FRIEND_DATA_EQ_I"; }
+    if c.friend_ref.flags / -0x2 >= -0x1 { print "O3_FRIEND_FLAGS_DIV_RANGE"; }
+    if c.arr[dyn_idx] / 0x2 == i { print "O3_DYNAMIC_ARR_DIV_OK"; }
+    if c_dyn.data.i == i { print "O3_C_DYN_DATA_EQ_I"; }
+    if c_dyn.arr[dyn_idx] / 0x2 == i { print "O3_C_DYN_ARR_OK"; }
+    if c_dyn.friend_ref.data.i == i { print "O3_C_DYN_FRIEND_DATA_EQ_I"; }
+    if c.active == 1 { print "O3_ACTIVE_ONE"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    use regex::Regex;
+    let re = Regex::new(
+        r"O3_COMPLEX I=([0-9]+)\s+AGE=([0-9]+)\s+DATA=(-?[0-9]+)\s+ACTIVE=([0-9]+)\s+FLAGS=(-?[0-9]+)",
+    )
+    .unwrap();
+    let samples: Vec<(u64, u64, i64, u64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<u64>().ok()?,
+                caps.get(2)?.as_str().parse::<u64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+                caps.get(4)?.as_str().parse::<u64>().ok()?,
+                caps.get(5)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !samples.is_empty(),
+        "Missing O3 complex member samples. STDOUT: {stdout}"
+    );
+
+    let saw_consistent_sample =
+        samples
+            .iter()
+            .any(|&(i_val, _age_val, data_val, active_val, flags_val)| {
+                let raw3 = (i_val & 7) as i64;
+                let expected_flags = if raw3 >= 4 { raw3 - 8 } else { raw3 };
+                data_val == i_val as i64 && active_val == (i_val & 1) && flags_val == expected_flags
+            });
+    assert!(
+        saw_consistent_sample,
+        "Expected a consistent O3 bitfield/data sample. Samples={samples:?} STDOUT: {stdout}"
+    );
+    let arith_re =
+        Regex::new(r"O3_COMPLEX_ARITH AGE1=(-?[0-9]+)\s+DATA2=(-?[0-9]+)\s+FLAGS1=(-?[0-9]+)")
+            .unwrap();
+    let arith_samples: Vec<(i64, i64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = arith_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<i64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !arith_samples.is_empty(),
+        "Missing O3 complex arithmetic samples. STDOUT: {stdout}"
+    );
+    let saw_consistent_arithmetic = samples.iter().zip(arith_samples.iter()).any(
+        |(
+            &(_i_val, age_val, data_val, _active_val, flags_val),
+            &(age_minus, data_plus, flags_minus),
+        )| {
+            age_minus == age_val as i64 - 1
+                && data_plus == data_val + 2
+                && flags_minus == flags_val - 1
+        },
+    );
+    assert!(
+        saw_consistent_arithmetic,
+        "Expected O3 member arithmetic to match printed member values. Samples={samples:?} Arith={arith_samples:?} STDOUT: {stdout}"
+    );
+    let div_re =
+        Regex::new(r"O3_COMPLEX_DIV AGE=(-?[0-9]+)\s+DATA=(-?[0-9]+)\s+FLAGS=(-?[0-9]+)").unwrap();
+    let div_samples: Vec<(i64, i64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = div_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<i64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !div_samples.is_empty(),
+        "Missing O3 complex division samples. STDOUT: {stdout}"
+    );
+    let saw_consistent_division = samples.iter().zip(div_samples.iter()).any(
+        |(
+            &(_i_val, age_val, data_val, _active_val, flags_val),
+            &(age_div, data_div, flags_div),
+        )| {
+            age_div == age_val as i64 / 3 && data_div == data_val / 2 && flags_div == flags_val / 2
+        },
+    );
+    assert!(
+        saw_consistent_division,
+        "Expected O3 member and bitfield division to match printed member values. Samples={samples:?} Div={div_samples:?} STDOUT: {stdout}"
+    );
+    let friend_re =
+        Regex::new(r"O3_FRIEND_MEMBERS AGE=([0-9]+)\s+DATA=(-?[0-9]+)\s+FLAGS=(-?[0-9]+)").unwrap();
+    let friend_samples: Vec<(u64, i64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = friend_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<u64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !friend_samples.is_empty(),
+        "Missing O3 friend member samples. STDOUT: {stdout}"
+    );
+    let saw_consistent_friend = samples.iter().zip(friend_samples.iter()).any(
+        |(
+            &(i_val, _age_val, _data_val, _active_val, _flags_val),
+            &(_friend_age, friend_data, friend_flags),
+        )| {
+            let raw3 = (i_val & 7) as i64;
+            let expected_flags = if raw3 >= 4 { raw3 - 8 } else { raw3 };
+            friend_data == i_val as i64 && friend_flags == expected_flags
+        },
+    );
+    assert!(
+        saw_consistent_friend,
+        "Expected O3 friend member chain to match loop state. Samples={samples:?} Friend={friend_samples:?} STDOUT: {stdout}"
+    );
+    let friend_div_re =
+        Regex::new(r"O3_FRIEND_DIV AGE=(-?[0-9]+)\s+DATA=(-?[0-9]+)\s+FLAGS=(-?[0-9]+)").unwrap();
+    let friend_div_samples: Vec<(i64, i64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = friend_div_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<i64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !friend_div_samples.is_empty(),
+        "Missing O3 friend division samples. STDOUT: {stdout}"
+    );
+    let saw_consistent_friend_division = samples
+        .iter()
+        .zip(friend_samples.iter())
+        .zip(friend_div_samples.iter())
+        .any(
+            |(
+                (
+                    &(i_val, _age_val, _data_val, _active_val, _flags_val),
+                    &(friend_age, friend_data, friend_flags),
+                ),
+                &(friend_age_div, friend_data_div, friend_flags_div),
+            )| {
+                friend_age_div == friend_age as i64 / 5
+                    && friend_data_div == friend_data / (i_val as i64 + 1)
+                    && friend_flags_div == friend_flags / -2
+            },
+        );
+    assert!(
+        saw_consistent_friend_division,
+        "Expected O3 friend member division to match printed friend values. Samples={samples:?} Friend={friend_samples:?} FriendDiv={friend_div_samples:?} STDOUT: {stdout}"
+    );
+    let dynamic_arr_re = Regex::new(r"O3_DYNAMIC_ARR IDX=([0-9]+)\s+VAL=(-?[0-9]+)").unwrap();
+    let dynamic_arr_samples: Vec<(u64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = dynamic_arr_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<u64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !dynamic_arr_samples.is_empty(),
+        "Missing O3 dynamic array-index samples. STDOUT: {stdout}"
+    );
+    let dynamic_arr_div_re = Regex::new(r"O3_DYNAMIC_ARR_DIV:([0-9-]+)").unwrap();
+    let dynamic_arr_div_samples: Vec<i64> = dynamic_arr_div_re
+        .captures_iter(&stdout)
+        .map(|caps| caps[1].parse::<i64>())
+        .collect::<Result<Vec<_>, _>>()?;
+    anyhow::ensure!(
+        !dynamic_arr_div_samples.is_empty(),
+        "Missing O3 dynamic array-index division samples. STDOUT: {stdout}"
+    );
+    let saw_consistent_dynamic_arr = samples
+        .iter()
+        .zip(dynamic_arr_samples.iter())
+        .zip(dynamic_arr_div_samples.iter())
+        .any(
+            |(
+                (&(i_val, _age_val, _data_val, _active_val, _flags_val), &(idx, arr_val)),
+                &arr_div,
+            )| {
+                idx == (i_val & 7) && arr_val == (i_val as i64) * 2 && arr_div == i_val as i64
+            },
+        );
+    assert!(
+        saw_consistent_dynamic_arr,
+        "Expected O3 dynamic array index to match loop state. Samples={samples:?} DynamicArr={dynamic_arr_samples:?} DynamicArrDiv={dynamic_arr_div_samples:?} STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_FLAGS_NEG",
+        "O3_FLAGS_EQ_NEG4",
+        "O3_FLAGS_DIV_NEG2",
+        "O3_DATA_DIV_NONNEG",
+        "O3_FRIEND_DATA_EQ_I",
+        "O3_FRIEND_FLAGS_DIV_RANGE",
+        "O3_DYNAMIC_ARR_DIV_OK",
+        "O3_C_DYN_DATA_EQ_I",
+        "O3_C_DYN_ARR_OK",
+        "O3_C_DYN_FRIEND_DATA_EQ_I",
+        "O3_ACTIVE_ONE",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 bitfield comparison marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("O3_NAME=Alice") || stdout.contains("O3_NAME=Bob"),
+        "Expected optimized char array name formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_FRIEND=0x"),
+        "Expected optimized friend_ref pointer formatting. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_complex_o3_memcmp_array_decay_and_base_lengths() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("complex_types_program", OptimizationLevel::O3)?;
+    let target = spawn_complex_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace complex_types_program.c:15 {
+    if memcmp(&c.name[0], &c.name[0], 0x3) { print "O3_NAME_SELF_EQ"; }
+    if memcmp(c.arr, c.arr, 0b100) { print "O3_ARR_SELF_EQ"; }
+    let n = 3;
+    print "O3_NAME_HEX={:x.0x3}", &c.name[0];
+    print "O3_NAME_ASCII={:s.n$}", &c.name[0];
+    print "O3_ARR_HEX={:x.0x8}", c.arr;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_NAME_SELF_EQ"),
+        "Expected optimized self memcmp for c.name. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ARR_SELF_EQ"),
+        "Expected optimized array-decay memcmp for c.arr. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NAME_HEX=41 6c 69") || stdout.contains("O3_NAME_HEX=42 6f 62"),
+        "Expected optimized base-prefixed hex name bytes. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NAME_ASCII=Ali") || stdout.contains("O3_NAME_ASCII=Bob"),
+        "Expected optimized named-length ASCII formatting. STDOUT: {stdout}"
+    );
+
+    use regex::Regex;
+    let re_arr_hex = Regex::new(r"O3_ARR_HEX=(?:[0-9a-f]{2}\s+){7}[0-9a-f]{2}").unwrap();
+    assert!(
+        stdout.lines().any(|line| re_arr_hex.is_match(line)),
+        "Expected optimized array raw hex bytes. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_entry_prints() -> anyhow::Result<()> {
     init();
 

--- a/e2e-tests/tests/entry_value_recovery_execution.rs
+++ b/e2e-tests/tests/entry_value_recovery_execution.rs
@@ -456,6 +456,9 @@ async fn test_non_inline_entry_value_recovers_touch_parameters_at_runtime() -> a
     let script = format!(
         "trace {FIXTURE_SOURCE}:{TOUCH_TRACE_LINE} {{
     print \"TOUCH:{{}}:{{}}:{{}}\", x, state.total_bytes, state.stream_id;
+    print \"TOUCH_CALC:{{}}:{{}}\", x * 0x3, state.total_bytes + (x * 0b11);
+    print \"TOUCH_DIV:{{}}:{{}}:{{}}\", x / 0x2, state.total_bytes / 0x5, (state.stream_id + -0x10) / 0x2;
+    if state.stream_id + -0x7 > 0 {{ print \"TOUCH_STREAM_OK\"; }}
 }}
 "
     );
@@ -503,8 +506,29 @@ async fn test_non_inline_entry_value_recovers_touch_parameters_at_runtime() -> a
     );
 
     let trace_re = Regex::new(r"TOUCH:([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let calc_re = Regex::new(r"TOUCH_CALC:([0-9-]+):([0-9-]+)")?;
+    let div_re = Regex::new(r"TOUCH_DIV:([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let calc_samples: Vec<(i64, i64)> = calc_re
+        .captures_iter(&ghostscope_stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let div_samples: Vec<(i64, i64, i64)> = div_re
+        .captures_iter(&ghostscope_stdout)
+        .map(|caps| {
+            Ok((
+                caps[1].parse::<i64>()?,
+                caps[2].parse::<i64>()?,
+                caps[3].parse::<i64>()?,
+            ))
+        })
+        .collect::<anyhow::Result<_>>()?;
     let mut seen = 0;
-    for caps in trace_re.captures_iter(&ghostscope_stdout) {
+    for ((caps, (seed_times_3, total_plus_seed_times_3)), (seed_div, total_div, stream_neg_div)) in
+        trace_re
+            .captures_iter(&ghostscope_stdout)
+            .zip(calc_samples.iter().copied())
+            .zip(div_samples.iter().copied())
+    {
         let seed = caps[1].parse::<i64>()?;
         let total_bytes = caps[2].parse::<i64>()?;
         let stream_id = caps[3].parse::<i64>()?;
@@ -524,12 +548,47 @@ async fn test_non_inline_entry_value_recovers_touch_parameters_at_runtime() -> a
             actual.2, expected_result,
             "touch() recovered an inconsistent seed/result for seed={seed}; ghostscope stdout={ghostscope_stdout}"
         );
+        assert_eq!(
+            seed_times_3,
+            seed * 3,
+            "ghostscope stdout={ghostscope_stdout}"
+        );
+        assert_eq!(
+            total_plus_seed_times_3,
+            total_bytes + (seed * 3),
+            "ghostscope stdout={ghostscope_stdout}"
+        );
+        assert_eq!(seed_div, seed / 2, "ghostscope stdout={ghostscope_stdout}");
+        assert_eq!(
+            total_div,
+            total_bytes / 5,
+            "ghostscope stdout={ghostscope_stdout}"
+        );
+        assert_eq!(
+            stream_neg_div,
+            (stream_id - 16) / 2,
+            "ghostscope stdout={ghostscope_stdout}"
+        );
         seen += 1;
     }
 
     assert!(
         seen >= 2,
         "Expected multiple touch() trace events. GhostScope STDOUT: {ghostscope_stdout}\nTarget STDOUT: {target_stdout}"
+    );
+    assert_eq!(
+        calc_samples.len(),
+        seen,
+        "Expected matching TOUCH and TOUCH_CALC samples. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    assert_eq!(
+        div_samples.len(),
+        seen,
+        "Expected matching TOUCH and TOUCH_DIV samples. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    assert!(
+        ghostscope_stdout.contains("TOUCH_STREAM_OK"),
+        "Expected stream-id arithmetic comparison marker. GhostScope STDOUT: {ghostscope_stdout}"
     );
     Ok(())
 }
@@ -554,7 +613,11 @@ async fn test_post_call_entry_value_recovers_state_members_at_runtime() -> anyho
     let target = spawn_logged_target(&binary_path).await?;
     let script = format!(
         "trace {FIXTURE_SOURCE}:{POST_CALL_TRACE_LINE} {{
+    let total = state.total_bytes + state.stream_id;
     print \"POSTCALL:{{}}:{{}}\", state.total_bytes, state.stream_id;
+    print \"POSTCALL_CALC:{{}}:{{}}\", total, state.total_bytes - 0xa;
+    print \"POSTCALL_DIV:{{}}:{{}}\", state.total_bytes / 0x5, (state.stream_id + -0x10) / 0x2;
+    if state.stream_id == 0x8 || state.stream_id == 0x9 {{ print \"POSTCALL_STREAM_OK\"; }}
 }}
 "
     );
@@ -604,8 +667,22 @@ STDERR: {ghostscope_stderr}"
     );
 
     let trace_re = Regex::new(r"POSTCALL:([0-9-]+):([0-9-]+)")?;
+    let calc_re = Regex::new(r"POSTCALL_CALC:([0-9-]+):([0-9-]+)")?;
+    let div_re = Regex::new(r"POSTCALL_DIV:([0-9-]+):([0-9-]+)")?;
+    let calc_samples: Vec<(i64, i64)> = calc_re
+        .captures_iter(&ghostscope_stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let div_samples: Vec<(i64, i64)> = div_re
+        .captures_iter(&ghostscope_stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
     let mut seen = 0;
-    for caps in trace_re.captures_iter(&ghostscope_stdout) {
+    for ((caps, (total, delta_from_first_state)), (total_div, stream_neg_div)) in trace_re
+        .captures_iter(&ghostscope_stdout)
+        .zip(calc_samples.iter().copied())
+        .zip(div_samples.iter().copied())
+    {
         let total_bytes = caps[1].parse::<i64>()?;
         let stream_id = caps[2].parse::<i64>()?;
         assert!(
@@ -614,6 +691,22 @@ STDERR: {ghostscope_stderr}"
                 .any(|actual| actual.0 == total_bytes && actual.1 == stream_id),
             "missing ACTUAL record for total_bytes={total_bytes}, stream_id={stream_id}; target stdout={target_stdout}"
         );
+        assert_eq!(
+            total,
+            total_bytes + stream_id,
+            "STDOUT: {ghostscope_stdout}"
+        );
+        assert_eq!(
+            delta_from_first_state,
+            total_bytes - 10,
+            "STDOUT: {ghostscope_stdout}"
+        );
+        assert_eq!(total_div, total_bytes / 5, "STDOUT: {ghostscope_stdout}");
+        assert_eq!(
+            stream_neg_div,
+            (stream_id - 16) / 2,
+            "STDOUT: {ghostscope_stdout}"
+        );
         seen += 1;
     }
 
@@ -621,6 +714,74 @@ STDERR: {ghostscope_stderr}"
         seen >= 2,
         "Expected multiple post-call trace events. GhostScope STDOUT: {ghostscope_stdout}
 Target STDOUT: {target_stdout}"
+    );
+    assert_eq!(
+        calc_samples.len(),
+        seen,
+        "Expected matching POSTCALL and POSTCALL_CALC samples. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    assert_eq!(
+        div_samples.len(),
+        seen,
+        "Expected matching POSTCALL and POSTCALL_DIV samples. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    assert!(
+        ghostscope_stdout.contains("POSTCALL_STREAM_OK"),
+        "Expected post-call stream-id comparison marker. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_post_call_entry_value_state_pointer_memory_formats() -> anyhow::Result<()> {
+    init();
+    if !fixture_compiler_available(FixtureCompiler::ClangDwarf5) {
+        eprintln!("Skipping entry_value memory-format test because clang is unavailable");
+        return Ok(());
+    }
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_compiler(FIXTURE_NAME, FixtureCompiler::ClangDwarf5)?;
+    let target = spawn_logged_target(&binary_path).await?;
+    let script = format!(
+        "trace {FIXTURE_SOURCE}:{POST_CALL_TRACE_LINE} {{
+    print \"POST_STATE_PTR={{:p}}\", state + 0;
+    print \"POST_STATE_HEX={{:x.0x8}}\", state + 0;
+    if memcmp(state + 0, hex(\"1400000009000000\"), 0x8) {{ print \"POST_STATE_20_9\"; }}
+    if memcmp(state + 0, hex(\"0a00000008000000\"), 0b1000) {{ print \"POST_STATE_10_8\"; }}
+}}
+"
+    );
+    let (exit_code, ghostscope_stdout, ghostscope_stderr) = GhostscopeRunner::new()
+        .with_script(&script)
+        .attach_to(&target.target)
+        .timeout_secs(4)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await?;
+    let (_target_stdout, target_stderr) = target.terminate_and_collect().await?;
+
+    if should_skip_for_ebpf_env(exit_code, &ghostscope_stderr) {
+        return Ok(());
+    }
+
+    assert_eq!(
+        exit_code, 0,
+        "ghostscope stderr={ghostscope_stderr} ghostscope stdout={ghostscope_stdout} target stderr={target_stderr}"
+    );
+    assert!(
+        ghostscope_stdout.contains("POST_STATE_PTR=0x"),
+        "Expected entry_value state pointer formatting. STDOUT: {ghostscope_stdout}"
+    );
+    assert!(
+        ghostscope_stdout.contains("POST_STATE_HEX=14 00 00 00 09 00 00 00")
+            || ghostscope_stdout.contains("POST_STATE_HEX=0a 00 00 00 08 00 00 00"),
+        "Expected entry_value state raw memory bytes. STDOUT: {ghostscope_stdout}"
+    );
+    assert!(
+        ghostscope_stdout.contains("POST_STATE_20_9")
+            && ghostscope_stdout.contains("POST_STATE_10_8"),
+        "Expected both entry_value state memcmp markers. STDOUT: {ghostscope_stdout}"
     );
     Ok(())
 }
@@ -644,6 +805,9 @@ async fn test_entry_value_breg_stack_parameter_recovers_at_runtime() -> anyhow::
     let script = format!(
         "trace 0x{anchor_pc:x} {{
     print \"STACKPAYLOAD:{{}}\", payload;
+    print \"STACKPAYLOAD_CALC:{{}}:{{}}\", payload + 0x1, payload * 0b10;
+    print \"STACKPAYLOAD_DIV:{{}}\", payload / 0x2;
+    if payload > 0 {{ print \"STACKPAYLOAD_POS\"; }}
 }}
 "
     );
@@ -684,9 +848,23 @@ async fn test_entry_value_breg_stack_parameter_recovers_at_runtime() -> anyhow::
     );
 
     let trace_re = Regex::new(r"STACKPAYLOAD:([0-9-]+)")?;
+    let calc_re = Regex::new(r"STACKPAYLOAD_CALC:([0-9-]+):([0-9-]+)")?;
+    let div_re = Regex::new(r"STACKPAYLOAD_DIV:([0-9-]+)")?;
+    let calc_samples: Vec<(i64, i64)> = calc_re
+        .captures_iter(&ghostscope_stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let div_samples: Vec<i64> = div_re
+        .captures_iter(&ghostscope_stdout)
+        .map(|caps| caps[1].parse::<i64>())
+        .collect::<Result<_, _>>()?;
     let mut next_actual_index = 0usize;
     let mut seen = 0;
-    for caps in trace_re.captures_iter(&ghostscope_stdout) {
+    for ((caps, (payload_plus_1, payload_times_2)), payload_div) in trace_re
+        .captures_iter(&ghostscope_stdout)
+        .zip(calc_samples.iter().copied())
+        .zip(div_samples.iter().copied())
+    {
         let payload = caps[1].parse::<i64>()?;
         let relative_index = actual_seeds[next_actual_index..]
             .iter()
@@ -695,14 +873,43 @@ async fn test_entry_value_breg_stack_parameter_recovers_at_runtime() -> anyhow::
                 anyhow::anyhow!(
                     "missing ordered ACTUAL seed for payload={payload}; ghostscope stdout={ghostscope_stdout} target stdout={target_stdout}"
                 )
-            })?;
+        })?;
         next_actual_index += relative_index + 1;
+        assert_eq!(
+            payload_plus_1,
+            payload + 1,
+            "ghostscope stdout={ghostscope_stdout}"
+        );
+        assert_eq!(
+            payload_times_2,
+            payload * 2,
+            "ghostscope stdout={ghostscope_stdout}"
+        );
+        assert_eq!(
+            payload_div,
+            payload / 2,
+            "ghostscope stdout={ghostscope_stdout}"
+        );
         seen += 1;
     }
 
     assert!(
         seen >= 2,
         "Expected multiple stack-parameter trace events. GhostScope STDOUT: {ghostscope_stdout}\nTarget STDOUT: {target_stdout}"
+    );
+    assert_eq!(
+        calc_samples.len(),
+        seen,
+        "Expected matching STACKPAYLOAD and STACKPAYLOAD_CALC samples. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    assert_eq!(
+        div_samples.len(),
+        seen,
+        "Expected matching STACKPAYLOAD and STACKPAYLOAD_DIV samples. GhostScope STDOUT: {ghostscope_stdout}"
+    );
+    assert!(
+        ghostscope_stdout.contains("STACKPAYLOAD_POS"),
+        "Expected stack payload comparison marker. GhostScope STDOUT: {ghostscope_stdout}"
     );
     Ok(())
 }

--- a/e2e-tests/tests/fixtures/complex_types_program/complex_types_program.c
+++ b/e2e-tests/tests/fixtures/complex_types_program/complex_types_program.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include "complex_types_program.h"
 
-void update_complex(struct Complex* c, int i) {
+__attribute__((noinline)) void update_complex(struct Complex* c, int i) {
     if (!c) return;
     c->age += 1;
     c->status = (i % 2) ? STATUS_ACTIVE : STATUS_INACTIVE;
@@ -12,7 +12,7 @@ void update_complex(struct Complex* c, int i) {
     c->active = (i & 1);
     c->flags = (i & 0x7);
     if (c->friend_ref) {
-        c->friend_ref->age += 1;
+        c->friend_ref->age += 1; GHOSTSCOPE_COMPLEX_TOUCH(c, i);
     }
 }
 
@@ -30,3 +30,4 @@ int main() {
     return 0;
 }
 
+volatile unsigned long long ghostscope_complex_sink;

--- a/e2e-tests/tests/fixtures/complex_types_program/complex_types_program.h
+++ b/e2e-tests/tests/fixtures/complex_types_program/complex_types_program.h
@@ -23,7 +23,17 @@ struct Complex {
     struct Complex* friend_ref;
 };
 
+extern volatile unsigned long long ghostscope_complex_sink;
+
+#define GHOSTSCOPE_COMPLEX_TOUCH(c_, i_) \
+    do { \
+        ghostscope_complex_sink += (unsigned long long)(c_)->age + \
+                                   (unsigned long long)(c_)->data.i + \
+                                   (unsigned long long)(c_)->arr[(i_) % 8] + \
+                                   (unsigned long long)(c_)->active + \
+                                   (unsigned long long)(c_)->flags; \
+    } while (0)
+
 void update_complex(struct Complex* c, int i);
 
 #endif // COMPLEX_TYPES_PROGRAM_H
-

--- a/e2e-tests/tests/fixtures/globals_program/Makefile
+++ b/e2e-tests/tests/fixtures/globals_program/Makefile
@@ -10,6 +10,24 @@ SHARED_OBJ ?= gvars_lib.o
 
 all: $(BINARY) $(SHARED_LIB)
 
+globals_program_o1: globals_program_o1.o $(SHARED_LIB)
+	$(CC) $(BASE_CFLAGS) -O1 -o $@ $< -L. -lgvars -Wl,-rpath,'$$ORIGIN'
+
+globals_program_o2: globals_program_o2.o $(SHARED_LIB)
+	$(CC) $(BASE_CFLAGS) -O2 -o $@ $< -L. -lgvars -Wl,-rpath,'$$ORIGIN'
+
+globals_program_o3: globals_program_o3.o $(SHARED_LIB)
+	$(CC) $(BASE_CFLAGS) -O3 -o $@ $< -L. -lgvars -Wl,-rpath,'$$ORIGIN'
+
+globals_program_o1.o: globals_program.c globals_program.h globals_shared.h gvars_lib.h
+	$(CC) $(BASE_CFLAGS) -O1 -fPIC -c -o $@ globals_program.c
+
+globals_program_o2.o: globals_program.c globals_program.h globals_shared.h gvars_lib.h
+	$(CC) $(BASE_CFLAGS) -O2 -fPIC -c -o $@ globals_program.c
+
+globals_program_o3.o: globals_program.c globals_program.h globals_shared.h gvars_lib.h
+	$(CC) $(BASE_CFLAGS) -O3 -fPIC -c -o $@ globals_program.c
+
 # Shared library
 $(SHARED_LIB): $(SHARED_OBJ) globals_shared.h
 	$(CC) -shared -o $@ $(SHARED_OBJ)
@@ -25,6 +43,6 @@ $(OBJ): globals_program.c globals_program.h globals_shared.h gvars_lib.h
 	$(CC) $(CFLAGS) -c -o $@ globals_program.c
 
 clean:
-	rm -f *.o globals_program libgvars.so
+	rm -f *.o globals_program globals_program_o* libgvars.so
 
 .PHONY: clean all

--- a/e2e-tests/tests/fixtures/globals_program/globals_program.c
+++ b/e2e-tests/tests/fixtures/globals_program/globals_program.c
@@ -17,7 +17,7 @@ GlobalState G_STATE = {"INIT", 0, {0, 0.0}, {1, 2, 3, 4}}; // .data
 // Top-level array of structs for arr[const].field tests
 Inner g_slots[2] = {{10, 1.0}, {20, 2.0}}; // .data
 
-static void tick_once(int i) {
+__attribute__((noinline)) static void tick_once(int i) {
     // Local aliases to globals to expose via DWARF at this PC
     GlobalState* s = &G_STATE;
     GlobalState* ls = &LIB_STATE;

--- a/e2e-tests/tests/fixtures/globals_program/globals_program.c
+++ b/e2e-tests/tests/fixtures/globals_program/globals_program.c
@@ -19,15 +19,15 @@ Inner g_slots[2] = {{10, 1.0}, {20, 2.0}}; // .data
 
 __attribute__((noinline)) static void tick_once(int i) {
     // Local aliases to globals to expose via DWARF at this PC
-    GlobalState* s = &G_STATE;
-    GlobalState* ls = &LIB_STATE;
-    volatile int* p_s_internal = &s_internal;
-    volatile int* p_s_bss = &s_bss_counter;
-    volatile int* p_lib_internal = lib_get_internal_counter_ptr();
-    const char* gm = g_message;
-    const char* lm = lib_message;
-    char* gb = g_bss_buffer;
-    char* lb = lib_bss;
+    GlobalState* volatile s = &G_STATE;
+    GlobalState* volatile ls = &LIB_STATE;
+    volatile int* volatile p_s_internal = &s_internal;
+    volatile int* volatile p_s_bss = &s_bss_counter;
+    volatile int* volatile p_lib_internal = lib_get_internal_counter_ptr();
+    const char* volatile gm = g_message;
+    const char* volatile lm = lib_message;
+    char* volatile gb = g_bss_buffer;
+    char* volatile lb = lib_bss;
     // mutate executable globals
     g_counter += 1;
     s_internal += 2; module_duplicate_counter += 11;

--- a/e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program.c
+++ b/e2e-tests/tests/fixtures/member_pointer_program/member_pointer_program.c
@@ -64,7 +64,7 @@ __attribute__((noinline)) static void trace_member_pointer(int iter) {
     body_buf[0] = (iter & 1) ? 0x00 : 0x01;
     header_key_buf[0] = 'X';
 
-    /* Keep r, h, h.key.data, and r.header_in.pos live at this PC. */
+    asm volatile("" : : "r"(request_line_buf), "r"(header_key_buf), "r"(header_value_buf), "r"(body_buf) : "memory");
     volatile uintptr_t sink =
         (uintptr_t)r->request_line.data + (uintptr_t)h->key.data +
         (uintptr_t)r->header_in.pos + (uintptr_t)h->value.data;

--- a/e2e-tests/tests/fixtures/scalar_types_program/Makefile
+++ b/e2e-tests/tests/fixtures/scalar_types_program/Makefile
@@ -4,15 +4,33 @@ CFLAGS ?= $(BASE_CFLAGS) -O0
 BINARY ?= scalar_types_program
 OBJ ?= $(BINARY).o
 
-all: $(BINARY)
-
 $(BINARY): $(OBJ)
 	$(CC) $(CFLAGS) -o $@ $^
 
 $(OBJ): scalar_types_program.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-clean:
-	rm -f *.o scalar_types_program
+scalar_types_program_o1: scalar_types_program_o1.o
+	$(CC) $(BASE_CFLAGS) -O1 -o $@ $^
 
-.PHONY: all clean
+scalar_types_program_o2: scalar_types_program_o2.o
+	$(CC) $(BASE_CFLAGS) -O2 -o $@ $^
+
+scalar_types_program_o3: scalar_types_program_o3.o
+	$(CC) $(BASE_CFLAGS) -O3 -DNDEBUG -o $@ $^
+
+scalar_types_program_o1.o: scalar_types_program.c
+	$(CC) $(BASE_CFLAGS) -O1 -c -o $@ $<
+
+scalar_types_program_o2.o: scalar_types_program.c
+	$(CC) $(BASE_CFLAGS) -O2 -c -o $@ $<
+
+scalar_types_program_o3.o: scalar_types_program.c
+	$(CC) $(BASE_CFLAGS) -O3 -DNDEBUG -c -o $@ $<
+
+all: $(BINARY) scalar_types_program_o1 scalar_types_program_o2 scalar_types_program_o3
+
+clean:
+	rm -f *.o scalar_types_program scalar_types_program_o*
+
+.PHONY: all clean scalar_types_program_o1 scalar_types_program_o2 scalar_types_program_o3

--- a/e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program.c
+++ b/e2e-tests/tests/fixtures/scalar_types_program/scalar_types_program.c
@@ -140,6 +140,18 @@ __attribute__((noinline)) static void scalar_stack_by_value(
     asm volatile("" ::: "memory");
 }
 
+__attribute__((noinline)) static void scalar_format_anchor(
+    volatile uint8_t *bufp,
+    volatile char *textp,
+    volatile int *lenp)
+{
+    uintptr_t mix = (uintptr_t)bufp;
+    mix ^= (uintptr_t)textp;
+    mix ^= (uintptr_t)lenp;
+    scalar_sink ^= mix;
+    asm volatile("" ::: "memory");
+}
+
 __attribute__((noinline)) static void scalar_probe(int iter)
 {
     volatile int8_t i8_neg = (int8_t)-5;
@@ -168,6 +180,15 @@ __attribute__((noinline)) static void scalar_probe(int iter)
     volatile float f32_neg_zero = -0.0f;
     volatile double f64_inf = __builtin_huge_val();
     volatile double f64_nan = __builtin_nan("");
+    static volatile uint8_t byte_pattern[16] = {
+        0xde, 0xad, 0xbe, 0xef, 0x00, 0x41, 0x7f, 0x80,
+        0x10, 0x20, 0x30, 0x40, 0xaa, 0xbb, 0xcc, 0xdd,
+    };
+    static volatile char text_pattern[16] = {
+        'H', 'e', 'l', 'l', 'o', 0x01, 'Z', 0,
+        'x', 'y', 'z', 0, 0, 0, 0, 0,
+    };
+    volatile int format_len = 5;
 
     scalar_anchor(
         &i8_neg,
@@ -227,6 +248,11 @@ __attribute__((noinline)) static void scalar_probe(int iter)
         u8_big,
         i32_neg,
         u64_big);
+
+    scalar_format_anchor(
+        byte_pattern,
+        text_pattern,
+        &format_len);
 }
 
 int main(void)

--- a/e2e-tests/tests/globals_execution.rs
+++ b/e2e-tests/tests/globals_execution.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{init, FIXTURES};
+use common::{init, OptimizationLevel, FIXTURES};
 use regex::Regex;
 use std::path::Path;
 use std::time::Duration;
@@ -125,6 +125,290 @@ trace globals_program.c:32 {
     assert!(
         stdout.contains("HEX_LM_INFER"),
         "Expected HEX_LM_INFER. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_globals_o3_pointer_arithmetic_memcmp_and_strncmp() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("globals_program", OptimizationLevel::O3)?;
+    let target = spawn_globals_program(&binary_path).await?;
+
+    let script = r#"
+trace globals_program.c:32 {
+    let n = 0b110;
+    print "GM_OFFSET_PTR={:p}", gm + 7;
+    print "GM_OFFSET_FMT={:s.0x6}", gm + 7;
+    print "GMSG_OFFSET_HEX={:x.0b110}", g_message + 7;
+    print "GM_OFFSET_STAR={:s.*}", n, gm + 7;
+    print "GMSG_OFFSET_CAPTURE={:x.n$}", g_message + 7;
+    let dyn_zero = G_STATE.counter - G_STATE.counter;
+    let dyn_gm_off = dyn_zero + 0x7;
+    let dyn_neg_len = dyn_zero - 0x5;
+    let dyn_long_len = dyn_gm_off + 0xff;
+    let dyn_gm = gm + dyn_gm_off;
+    let dyn_gmsg = g_message + dyn_gm_off;
+    print "GM_DYN_OFFSET_FMT={:s.0b110}", dyn_gm;
+    print "GM_DYN_OFFSET_HEX={:x.0x6}", dyn_gm;
+    print "GMSG_DYN_OFFSET_FMT={:s.0o6}", dyn_gmsg;
+    print "GMSG_DYN_OFFSET_HEX={:x.0b110}", dyn_gmsg;
+    print "GMSG_DYN_COMMUTED={:s.0x6}", dyn_gm_off + g_message;
+    print "O3_GY:{}", s.inner.y;
+    print "O3_LIBY:{}", LIB_STATE.inner.y;
+    print "O3_GX_CALC:{}:{}", s.inner.x, s.inner.x + 0x2;
+    print "O3_SLOT_CALC:{}:{}", g_slots[0x1].x, g_slots[0x1].x - 0b11;
+    print "O3_GARR1_CALC:{}:{}", G_STATE.array[0b1], G_STATE.array[0b1] + -0x1;
+    let dyn_slot_idx = g_slots[0x0].x / 0xa;
+    let dyn_garr_idx = G_STATE.counter - (G_STATE.counter / 0x4) * 0x4;
+    print "O3_DYN_SLOT:{}:{}", dyn_slot_idx, g_slots[dyn_slot_idx].x;
+    print "O3_DYN_SLOT_DIV:{}", g_slots[dyn_slot_idx].x / 0xa;
+    print "O3_DYN_GARR IDX={} VAL={}", dyn_garr_idx, G_STATE.array[dyn_garr_idx];
+    print "O3_DYN_GARR_DIV:{}", G_STATE.array[dyn_garr_idx] / 0x1;
+    print "O3_PTR_ALIAS:{}:{}:{}", *p_s_internal, *p_s_bss, *p_lib_internal;
+    print "O3_PTR_ALIAS_DIV:{}:{}:{}", *p_s_internal / 0x3, *p_s_bss / 0x3, *p_lib_internal / 0x5;
+    let slot_neg = g_slots[0x1].x + -0x40;
+    print "O3_GLOBAL_DIV:{}:{}:{}:{}", g_counter, g_counter / 0x2, G_STATE.counter, G_STATE.counter / 0b10;
+    print "O3_GLOBAL_SIGNED_DIV:{}:{}", slot_neg, slot_neg / 0x4;
+    if *p_s_internal / 0x3 >= 0x3 { print "O3_PTR_ALIAS_INTERNAL_DIV_OK"; }
+    if *p_s_bss / 0x3 >= 0x1 { print "O3_PTR_ALIAS_BSS_DIV_OK"; }
+    if *p_lib_internal / 0x5 >= 0x1 { print "O3_PTR_ALIAS_LIB_DIV_OK"; }
+    if g_counter / 0x2 >= 0x15 { print "O3_GCOUNTER_DIV_OK"; }
+    if G_STATE.array[0b1] / 0x2 >= 0x1 { print "O3_GARR1_DIV_OK"; }
+    if g_slots[dyn_slot_idx].x == 0x14 { print "O3_DYN_SLOT_OK"; }
+    if g_slots[dyn_slot_idx].x / 0xa == 0b10 { print "O3_DYN_SLOT_DIV_OK"; }
+    if G_STATE.array[dyn_garr_idx] / 0x1 >= 0x1 { print "O3_DYN_GARR_DIV_OK"; }
+    if slot_neg / 0x4 == -0xb { print "O3_SLOT_SIGNED_DIV_OK"; }
+    if memcmp(gm + 7, hex("476c6f62616c"), 0x6) { print "GM_OFFSET_HEX_OK"; }
+    if strncmp(gm + 7, "Global", 0b110) { print "GM_OFFSET_STR_OK"; }
+    if memcmp(g_message + 7, hex("476c6f62616c"), 0o6) { print "GMSG_OFFSET_HEX_OK"; }
+    if memcmp(dyn_gm, hex("476c6f62616c"), dyn_gm_off - 0x1) { print "GM_DYN_HEX_OK"; }
+    if strncmp(dyn_gmsg, "Global", dyn_gm_off - 0b1) { print "GMSG_DYN_STR_OK"; }
+    if strncmp(dyn_gm, "Mismatch", dyn_neg_len) { print "GM_DYN_NEG_LEN_OK"; }
+    if strncmp(dyn_gm, "Global", dyn_long_len) { print "GM_DYN_LONG_LEN_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(
+        stdout.contains("GM_OFFSET_PTR=0x"),
+        "Expected O3 pointer formatting for gm + 7. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_OFFSET_FMT=Global"),
+        "Expected O3 formatted string read from gm + 7. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_OFFSET_HEX=47 6c 6f 62 61 6c"),
+        "Expected O3 formatted hex read from g_message + 7. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_OFFSET_STAR=Global"),
+        "Expected O3 dynamic-length formatted string read from gm + 7. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_OFFSET_CAPTURE=47 6c 6f 62 61 6c"),
+        "Expected O3 named-length formatted hex read from g_message + 7. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_DYN_OFFSET_FMT=Global"),
+        "Expected O3 dynamic formatted string read from gm + dyn offset. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_DYN_OFFSET_HEX=47 6c 6f 62 61 6c"),
+        "Expected O3 dynamic formatted hex read from gm + dyn offset. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_DYN_OFFSET_FMT=Global"),
+        "Expected O3 dynamic formatted string read from g_message + dyn offset. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_DYN_OFFSET_HEX=47 6c 6f 62 61 6c"),
+        "Expected O3 dynamic formatted hex read from g_message + dyn offset. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_DYN_COMMUTED=Global"),
+        "Expected O3 commuted dynamic pointer arithmetic over g_message. STDOUT: {stdout}"
+    );
+    let gy_re = Regex::new(r"O3_GY:([0-9]+(?:\.[0-9]+)?)").unwrap();
+    let gy_values = gy_re
+        .captures_iter(&stdout)
+        .map(|caps| caps[1].parse::<f64>())
+        .collect::<Result<Vec<_>, _>>()?;
+    assert!(
+        gy_values.len() >= 2,
+        "Expected repeated O3 executable global double member reads. STDOUT: {stdout}"
+    );
+    assert!(
+        (gy_values[1] - gy_values[0] - 0.5).abs() < f64::EPSILON,
+        "Expected O3 executable global double member to advance by 0.5 per tick. Values: {gy_values:?}. STDOUT: {stdout}"
+    );
+    let ly_re = Regex::new(r"O3_LIBY:([0-9]+(?:\.[0-9]+)?)").unwrap();
+    let ly_values = ly_re
+        .captures_iter(&stdout)
+        .map(|caps| caps[1].parse::<f64>())
+        .collect::<Result<Vec<_>, _>>()?;
+    assert!(
+        ly_values.len() >= 2,
+        "Expected repeated O3 library global double member reads. STDOUT: {stdout}"
+    );
+    assert!(
+        (ly_values[1] - ly_values[0] - 1.25).abs() < f64::EPSILON,
+        "Expected O3 library global double member to advance by 1.25 per tick. Values: {ly_values:?}. STDOUT: {stdout}"
+    );
+    let gx_re = Regex::new(r"O3_GX_CALC:(-?[0-9]+):(-?[0-9]+)").unwrap();
+    assert!(
+        gx_re.captures_iter(&stdout).any(|caps| {
+            let base = caps[1].parse::<i64>().unwrap_or(i64::MIN);
+            let calc = caps[2].parse::<i64>().unwrap_or(i64::MAX);
+            calc == base + 2
+        }),
+        "Expected O3 global alias member arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_SLOT_CALC:20:17"),
+        "Expected O3 top-level global struct-array member arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYN_SLOT:1:20"),
+        "Expected O3 dynamic global struct-array member access. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYN_SLOT_DIV:2"),
+        "Expected O3 dynamic global struct-array member division. STDOUT: {stdout}"
+    );
+    let garr_re = Regex::new(r"O3_GARR1_CALC:(-?[0-9]+):(-?[0-9]+)").unwrap();
+    assert!(
+        garr_re.captures_iter(&stdout).any(|caps| {
+            let base = caps[1].parse::<i64>().unwrap_or(i64::MIN);
+            let calc = caps[2].parse::<i64>().unwrap_or(i64::MAX);
+            calc == base - 1
+        }),
+        "Expected O3 global array member arithmetic. STDOUT: {stdout}"
+    );
+    let dyn_garr_re = Regex::new(r"O3_DYN_GARR IDX=([0-9]+) VAL=(-?[0-9]+)").unwrap();
+    let dyn_garr_div_re = Regex::new(r"O3_DYN_GARR_DIV:(-?[0-9]+)").unwrap();
+    let dyn_garr_values: Vec<(i64, i64)> = dyn_garr_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<Result<Vec<_>, anyhow::Error>>()?;
+    let dyn_garr_div_values = dyn_garr_div_re
+        .captures_iter(&stdout)
+        .map(|caps| caps[1].parse::<i64>())
+        .collect::<Result<Vec<_>, _>>()?;
+    anyhow::ensure!(
+        dyn_garr_values
+            .iter()
+            .zip(dyn_garr_div_values.iter())
+            .any(|(&(idx, val), &div)| (0..=3).contains(&idx) && div == val),
+        "Expected O3 dynamic global array index/division samples. Values={dyn_garr_values:?} Divs={dyn_garr_div_values:?} STDOUT: {stdout}"
+    );
+    let ptr_alias_re = Regex::new(r"O3_PTR_ALIAS:(-?[0-9]+):(-?[0-9]+):(-?[0-9]+)").unwrap();
+    let ptr_alias_samples: Vec<(i64, i64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = ptr_alias_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<i64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !ptr_alias_samples.is_empty(),
+        "Missing O3 pointer-alias samples. STDOUT: {stdout}"
+    );
+    let ptr_alias_div_re =
+        Regex::new(r"O3_PTR_ALIAS_DIV:(-?[0-9]+):(-?[0-9]+):(-?[0-9]+)").unwrap();
+    let ptr_alias_div_samples: Vec<(i64, i64, i64)> = stdout
+        .lines()
+        .filter_map(|line| {
+            let caps = ptr_alias_div_re.captures(line)?;
+            Some((
+                caps.get(1)?.as_str().parse::<i64>().ok()?,
+                caps.get(2)?.as_str().parse::<i64>().ok()?,
+                caps.get(3)?.as_str().parse::<i64>().ok()?,
+            ))
+        })
+        .collect();
+    anyhow::ensure!(
+        !ptr_alias_div_samples.is_empty(),
+        "Missing O3 pointer-alias division samples. STDOUT: {stdout}"
+    );
+    assert!(
+        ptr_alias_samples
+            .iter()
+            .zip(ptr_alias_div_samples.iter())
+            .any(|(&(internal, bss, lib_internal), &(internal_div, bss_div, lib_div))| {
+                internal_div == internal / 3 && bss_div == bss / 3 && lib_div == lib_internal / 5
+            }),
+        "Expected O3 pointer-alias division to match runtime values. Alias={ptr_alias_samples:?} AliasDiv={ptr_alias_div_samples:?} STDOUT: {stdout}"
+    );
+    let global_div_re =
+        Regex::new(r"O3_GLOBAL_DIV:(-?[0-9]+):(-?[0-9]+):(-?[0-9]+):(-?[0-9]+)").unwrap();
+    assert!(
+        global_div_re.captures_iter(&stdout).any(|caps| {
+            let g_counter = caps[1].parse::<i64>().unwrap_or(i64::MIN);
+            let g_counter_div = caps[2].parse::<i64>().unwrap_or(i64::MAX);
+            let state_counter = caps[3].parse::<i64>().unwrap_or(i64::MIN);
+            let state_counter_div = caps[4].parse::<i64>().unwrap_or(i64::MAX);
+            g_counter_div == g_counter / 2 && state_counter_div == state_counter / 2
+        }),
+        "Expected O3 global division to match runtime counter values. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_GLOBAL_SIGNED_DIV:-44:-11"),
+        "Expected O3 global signed division over negative computed value. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_PTR_ALIAS_INTERNAL_DIV_OK",
+        "O3_PTR_ALIAS_BSS_DIV_OK",
+        "O3_PTR_ALIAS_LIB_DIV_OK",
+        "O3_GCOUNTER_DIV_OK",
+        "O3_GARR1_DIV_OK",
+        "O3_DYN_SLOT_OK",
+        "O3_DYN_SLOT_DIV_OK",
+        "O3_DYN_GARR_DIV_OK",
+        "O3_SLOT_SIGNED_DIV_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 global division marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("GM_OFFSET_HEX_OK"),
+        "Expected GM_OFFSET_HEX_OK. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_OFFSET_STR_OK"),
+        "Expected GM_OFFSET_STR_OK. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_OFFSET_HEX_OK"),
+        "Expected GMSG_OFFSET_HEX_OK. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_DYN_HEX_OK"),
+        "Expected GM_DYN_HEX_OK. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GMSG_DYN_STR_OK"),
+        "Expected GMSG_DYN_STR_OK. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_DYN_NEG_LEN_OK"),
+        "Expected dynamic negative strncmp length to clamp to zero. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("GM_DYN_LONG_LEN_OK"),
+        "Expected dynamic long strncmp length to clamp safely. STDOUT: {stdout}"
     );
     Ok(())
 }

--- a/e2e-tests/tests/member_pointer_execution.rs
+++ b/e2e-tests/tests/member_pointer_execution.rs
@@ -1,0 +1,220 @@
+//! Member-pointer style C runtime tests.
+//!
+//! These cover nginx-like local pointer chains under optimized code. The
+//! companion `member_pointer_compilation.rs` file exercises DWARF planning and
+//! compile-time errors; this file attaches to a real target process.
+
+mod common;
+
+use common::{init, OptimizationLevel, FIXTURES};
+use std::path::Path;
+use std::time::Duration;
+
+async fn run_ghostscope_with_script_for_target(
+    script_content: &str,
+    timeout_secs: u64,
+    target: &common::targets::TargetHandle,
+) -> anyhow::Result<(i32, String, String)> {
+    common::runner::GhostscopeRunner::new()
+        .with_script(script_content)
+        .attach_to(target)
+        .timeout_secs(timeout_secs)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await
+}
+
+async fn spawn_member_pointer_binary(
+    binary_path: &Path,
+) -> anyhow::Result<common::targets::TargetHandle> {
+    let target = common::targets::TargetLauncher::binary(binary_path)
+        .spawn()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(target)
+}
+
+#[tokio::test]
+async fn test_member_pointer_o3_runtime_member_pointer_format_and_memcmp() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("member_pointer_program", OptimizationLevel::O3)?;
+    let target = spawn_member_pointer_binary(&binary_path).await?;
+
+    let script = r#"
+trace member_pointer_program.c:68 {
+    let key = h.key.data;
+    let key_len = h.key.len;
+    let half_key_len = h.key.len / 0x2;
+    let tail_len = h.value.len - 0b1;
+    let dyn_key_idx = h.key.len - 0x4;
+    let dyn_body_idx = h.value.len - 0b10;
+    let body = r.header_in.pos + 0x1;
+    let body_tail = r.header_in.end + -0x3;
+    let key_dyn_tail = key + dyn_key_idx;
+    let body_dyn_tail = r.header_in.pos + dyn_body_idx;
+    print "MP_HDR={:s.6}", h.key.data;
+    print "MP_VAL={:s.5}", h.value.data;
+    print "MP_REQ={:s.4}", r.request_line.data;
+    print "MP_BODY={:x.0x4}", r.header_in.pos;
+    print "MP_LEN={}:{}:{}", h.key.len, h.value.len, r.request_line.len;
+    print "MP_LEN_CALC={}:{}", h.key.len + h.value.len, r.request_line.len - 0x5;
+    print "MP_LEN_DIV={}:{}:{}", h.key.len / 0x2, (r.request_line.len + -0x5) / 0b10, (h.value.len + -0x7) / -0x2;
+    print "MP_KEY_ALIAS={:s.0x6}", key;
+    print "MP_KEY_TAIL={:s.0b100}", key + 0b10;
+    print "MP_KEY_ADDR_TAIL={:s.0o4}", &key[0b10];
+    print "MP_KEY_DYNAMIC={:s.key_len$}", key;
+    print "MP_KEY_DIV_DYNAMIC={:s.half_key_len$}", key;
+    print "MP_KEY_TAIL_DYNAMIC={:s.tail_len$}", key + 0b10;
+    print "MP_KEY_DYN_TAIL={:s.0b100}", key_dyn_tail;
+    print "MP_KEY_DYN_INDEX={:s.0x4}", &key[dyn_key_idx];
+    print "MP_BODY_ALIAS={:x.0o4}", body;
+    print "MP_BODY_TAIL={:s.0b11}", body_tail;
+    print "MP_BODY_DYN_TAIL={:s.0x5}", body_dyn_tail;
+    if h.key.len == 0x6 && h.value.len == 0o5 { print "MP_LEN_OK"; }
+    if h.key.len / 0x2 == 0b11 && (h.value.len + -0x7) / -0x2 == 0x1 { print "MP_LEN_DIV_OK"; }
+    if r.request_line.len - h.key.len == 0xd { print "MP_REQ_LEN_DELTA_OK"; }
+    if memcmp(h.key.data, hex("582d"), 0x2) { print "MP_HDR_OK"; }
+    if memcmp(r.header_in.pos, r.header_in.pos, 0b100) { print "MP_BODY_SELF_OK"; }
+    if memcmp(key + 0x2, hex("44656d6f"), 0b100) { print "MP_KEY_TAIL_OK"; }
+    if memcmp(&key[0b10], hex("44656d6f"), 0x4) { print "MP_KEY_ADDR_TAIL_OK"; }
+    if memcmp(key_dyn_tail, hex("44656d6f"), 0b100) { print "MP_KEY_DYN_TAIL_OK"; }
+    if memcmp(&key[dyn_key_idx], hex("44656d6f"), 0x4) { print "MP_KEY_DYN_INDEX_OK"; }
+    if memcmp(dyn_key_idx + key, hex("44656d6f"), 0o4) { print "MP_KEY_DYN_COMMUTE_OK"; }
+    if memcmp(body, hex("01026865"), 0o4) { print "MP_BODY_ALIAS_OK"; }
+    if memcmp(r.header_in.end + -0x3, hex("6c6c6f"), 0x3) { print "MP_BODY_TAIL_OK"; }
+    if strncmp(body_dyn_tail, "hello", 0x5) { print "MP_BODY_DYN_TAIL_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("MP_HDR=X-Demo"),
+        "Expected optimized header key string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_VAL=hello"),
+        "Expected optimized header value string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_REQ=POST"),
+        "Expected optimized request line prefix. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_HDR_OK"),
+        "Expected optimized member pointer memcmp marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_BODY_SELF_OK"),
+        "Expected optimized body self memcmp marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_ALIAS=X-Demo"),
+        "Expected optimized member pointer alias string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_LEN=6:5:19"),
+        "Expected optimized member pointer length fields. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_LEN_CALC=11:14"),
+        "Expected optimized member pointer length arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_LEN_DIV=3:7:1"),
+        "Expected optimized member pointer length division. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_TAIL=Demo"),
+        "Expected optimized member pointer alias arithmetic string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_ADDR_TAIL=Demo"),
+        "Expected optimized address-of alias-index string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_DYNAMIC=X-Demo"),
+        "Expected optimized member pointer dynamic length string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_DIV_DYNAMIC=X-D"),
+        "Expected optimized member pointer division-based dynamic length string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_TAIL_DYNAMIC=Demo"),
+        "Expected optimized member pointer arithmetic dynamic length string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_DYN_TAIL=Demo"),
+        "Expected optimized dynamic member pointer alias tail string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_DYN_INDEX=Demo"),
+        "Expected optimized dynamic member pointer alias index string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_BODY_ALIAS=01 02 68 65"),
+        "Expected optimized body alias pointer arithmetic bytes. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_BODY_TAIL=llo"),
+        "Expected optimized negative member pointer arithmetic string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_BODY_DYN_TAIL=hello"),
+        "Expected optimized dynamic body pointer arithmetic string. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_LEN_OK"),
+        "Expected optimized member pointer length comparison marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_LEN_DIV_OK"),
+        "Expected optimized member pointer length division comparison marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_REQ_LEN_DELTA_OK"),
+        "Expected optimized member pointer length arithmetic comparison marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_TAIL_OK"),
+        "Expected optimized member pointer alias arithmetic memcmp marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_KEY_ADDR_TAIL_OK"),
+        "Expected optimized address-of alias-index memcmp marker. STDOUT: {stdout}"
+    );
+    for marker in [
+        "MP_KEY_DYN_TAIL_OK",
+        "MP_KEY_DYN_INDEX_OK",
+        "MP_KEY_DYN_COMMUTE_OK",
+        "MP_BODY_DYN_TAIL_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected optimized dynamic member pointer marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("MP_BODY_ALIAS_OK"),
+        "Expected optimized body alias pointer arithmetic memcmp marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("MP_BODY_TAIL_OK"),
+        "Expected optimized negative body pointer arithmetic memcmp marker. STDOUT: {stdout}"
+    );
+
+    use regex::Regex;
+    let re_body = Regex::new(r"MP_BODY=(?:00|01) 01 02 68").unwrap();
+    assert!(
+        stdout.lines().any(|line| re_body.is_match(line)),
+        "Expected optimized body bytes. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}

--- a/e2e-tests/tests/optimized_inline_call_value_execution.rs
+++ b/e2e-tests/tests/optimized_inline_call_value_execution.rs
@@ -173,7 +173,7 @@ async fn test_optimized_inline_parameters_have_exact_values_before_internal_call
 
     let target = spawn_inline_call_value_program(&binary_path).await?;
     let script = format!(
-        "trace inline_call_value_program.c:{INLINE_BEFORE_CALL_TRACE_LINE} {{\n    print \"PRECALL:{{}}:{{}}\", original_x, original_y;\n}}\n"
+        "trace inline_call_value_program.c:{INLINE_BEFORE_CALL_TRACE_LINE} {{\n    print \"PRECALL:{{}}:{{}}\", original_x, original_y;\n    print \"PRECALC:{{}}:{{}}\", original_x + original_y, original_x - original_y;\n    print \"PRECALL_DIV:{{}}:{{}}\", original_x / 0b111, (original_x + -0x40) / -0x4;\n    if original_x == (original_y - 0xb) * 0x7 {{ print \"PRECALL_REL_OK\"; }}\n}}\n"
     );
     let (exit_code, stdout, stderr) =
         run_ghostscope_with_script_for_target(&script, 4, &target).await?;
@@ -194,21 +194,53 @@ async fn test_optimized_inline_parameters_have_exact_values_before_internal_call
     );
 
     let re = Regex::new(r"PRECALL:([0-9-]+):([0-9-]+)")?;
-    let mut seen = 0;
-    for caps in re.captures_iter(&stdout) {
-        let original_x: i64 = caps[1].parse()?;
-        let original_y: i64 = caps[2].parse()?;
+    let calc_re = Regex::new(r"PRECALC:([0-9-]+):([0-9-]+)")?;
+    let calc_samples: Vec<(i64, i64)> = calc_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let div_re = Regex::new(r"PRECALL_DIV:([0-9-]+):([0-9-]+)")?;
+    let div_samples: Vec<(i64, i64)> = div_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let precall_samples: Vec<(i64, i64)> = re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    assert!(
+        precall_samples.len() == calc_samples.len() && precall_samples.len() == div_samples.len(),
+        "Expected matching pre-call value, arithmetic, and division samples. STDOUT: {stdout}"
+    );
+    for ((original_x, original_y), (sum, diff), (x_div_7, shifted_div_neg_4)) in precall_samples
+        .iter()
+        .copied()
+        .zip(calc_samples.iter().copied())
+        .zip(div_samples.iter().copied())
+        .map(|((values, calc), div)| (values, calc, div))
+    {
         assert_eq!(
             original_x,
             (original_y - 11) * 7,
             "Expected original_x/original_y to match wrapper(seed) on the pre-call line. STDOUT: {stdout}"
         );
-        seen += 1;
+        assert_eq!(sum, original_x + original_y, "STDOUT: {stdout}");
+        assert_eq!(diff, original_x - original_y, "STDOUT: {stdout}");
+        assert_eq!(x_div_7, original_x / 7, "STDOUT: {stdout}");
+        assert_eq!(
+            shifted_div_neg_4,
+            (original_x - 64) / -4,
+            "STDOUT: {stdout}"
+        );
     }
 
     assert!(
-        seen >= 2,
+        precall_samples.len() >= 2,
         "Expected multiple pre-call inline events. STDOUT: {stdout}\nSTDERR: {stderr}"
+    );
+    assert!(
+        stdout.contains("PRECALL_REL_OK"),
+        "Expected pre-call inline computed relation marker. STDOUT: {stdout}"
     );
     Ok(())
 }
@@ -356,7 +388,7 @@ async fn test_entry_value_recovers_outer_parameter_inside_optimized_inline_after
 
     let target = spawn_inline_call_value_program(&binary_path).await?;
     let script = format!(
-        "trace inline_call_value_program.c:{INLINE_AFTER_CALL_TRACE_LINE} {{\n    print \"POSTCALL:{{}}:{{}}\", seed, after_call;\n}}\n"
+        "trace inline_call_value_program.c:{INLINE_AFTER_CALL_TRACE_LINE} {{\n    print \"POSTCALL:{{}}:{{}}\", seed, after_call;\n    print \"POSTCALC:{{}}:{{}}\", seed * 0x7, after_call - 0b111;\n    print \"POSTDIV:{{}}:{{}}\", after_call / 0x5, (after_call + -0x7) / -0x3;\n    if after_call > seed {{ print \"POSTCALL_GT_SEED\"; }}\n}}\n"
     );
     let (exit_code, stdout, stderr) =
         run_ghostscope_with_script_for_target(&script, 4, &target).await?;
@@ -377,10 +409,32 @@ async fn test_entry_value_recovers_outer_parameter_inside_optimized_inline_after
     );
 
     let re = Regex::new(r"POSTCALL:([0-9-]+):([0-9-]+)")?;
-    let mut seen = 0;
-    for caps in re.captures_iter(&stdout) {
-        let seed: i64 = caps[1].parse()?;
-        let after_call: i64 = caps[2].parse()?;
+    let calc_re = Regex::new(r"POSTCALC:([0-9-]+):([0-9-]+)")?;
+    let calc_samples: Vec<(i64, i64)> = calc_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let div_re = Regex::new(r"POSTDIV:([0-9-]+):([0-9-]+)")?;
+    let div_samples: Vec<(i64, i64)> = div_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let postcall_samples: Vec<(i64, i64)> = re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    assert!(
+        postcall_samples.len() == calc_samples.len() && postcall_samples.len() == div_samples.len(),
+        "Expected matching post-call value, arithmetic, and division samples. STDOUT: {stdout}"
+    );
+    for ((seed, after_call), (seed_times_7, after_minus_7), (after_div_5, combined_div_neg_3)) in
+        postcall_samples
+            .iter()
+            .copied()
+            .zip(calc_samples.iter().copied())
+            .zip(div_samples.iter().copied())
+            .map(|((values, calc), div)| (values, calc, div))
+    {
         let original_x = seed * 7;
         let original_y = seed + 11;
         let combined = (original_x + original_y) * (original_x - original_y);
@@ -389,12 +443,19 @@ async fn test_entry_value_recovers_outer_parameter_inside_optimized_inline_after
             combined + 7,
             "Expected seed/after_call to match wrapper(seed) on the first post-call line. STDOUT: {stdout}"
         );
-        seen += 1;
+        assert_eq!(seed_times_7, original_x, "STDOUT: {stdout}");
+        assert_eq!(after_minus_7, combined, "STDOUT: {stdout}");
+        assert_eq!(after_div_5, after_call / 5, "STDOUT: {stdout}");
+        assert_eq!(combined_div_neg_3, combined / -3, "STDOUT: {stdout}");
     }
 
     assert!(
-        seen >= 2,
+        postcall_samples.len() >= 2,
         "Expected multiple post-call entry_value events. STDOUT: {stdout}\nSTDERR: {stderr}"
+    );
+    assert!(
+        stdout.contains("POSTCALL_GT_SEED"),
+        "Expected post-call entry_value computed comparison marker. STDOUT: {stdout}"
     );
     Ok(())
 }

--- a/e2e-tests/tests/optimized_inline_execution.rs
+++ b/e2e-tests/tests/optimized_inline_execution.rs
@@ -86,7 +86,7 @@ async fn test_optimized_inline_parameters_preserve_callsite_relationships() -> a
     //     lexical_block
     let target = spawn_inline_callsite_program(&binary_path).await?;
     let script = format!(
-        "trace inline_callsite_program.c:{INLINE_TRACE_LINE} {{\n    print \"ARGS:{{}}:{{}}:{{}}\", a, b, c;\n}}\n"
+        "trace inline_callsite_program.c:{INLINE_TRACE_LINE} {{\n    print \"ARGS:{{}}:{{}}:{{}}\", a, b, c;\n    print \"ARGDIV:{{}}:{{}}:{{}}\", a / 0x2, (b + -0b11) / -0x2, c / 0o3;\n}}\n"
     );
     let (exit_code, stdout, stderr) =
         run_ghostscope_with_script_for_target(&script, 4, &target).await?;
@@ -99,18 +99,43 @@ async fn test_optimized_inline_parameters_preserve_callsite_relationships() -> a
     assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
 
     let re = Regex::new(r"ARGS:([0-9-]+):([0-9-]+):([0-9-]+)")?;
-    let mut seen = 0;
-    for caps in re.captures_iter(&stdout) {
-        let a: i64 = caps[1].parse()?;
-        let b: i64 = caps[2].parse()?;
-        let c: i64 = caps[3].parse()?;
+    let div_re = Regex::new(r"ARGDIV:([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let arg_samples: Vec<(i64, i64, i64)> = re
+        .captures_iter(&stdout)
+        .map(|caps| {
+            Ok((
+                caps[1].parse::<i64>()?,
+                caps[2].parse::<i64>()?,
+                caps[3].parse::<i64>()?,
+            ))
+        })
+        .collect::<anyhow::Result<_>>()?;
+    let div_samples: Vec<(i64, i64, i64)> = div_re
+        .captures_iter(&stdout)
+        .map(|caps| {
+            Ok((
+                caps[1].parse::<i64>()?,
+                caps[2].parse::<i64>()?,
+                caps[3].parse::<i64>()?,
+            ))
+        })
+        .collect::<anyhow::Result<_>>()?;
+    assert!(
+        arg_samples.len() == div_samples.len(),
+        "Expected matching inline arg and division samples. STDOUT: {stdout}"
+    );
+    for ((a, b, c), (a_div_2, b_shift_div_neg_2, c_div_3)) in
+        arg_samples.iter().copied().zip(div_samples.iter().copied())
+    {
         assert_eq!(b, a + 1, "Expected b == a + 1. STDOUT: {stdout}");
         assert_eq!(c, a + 2, "Expected c == a + 2. STDOUT: {stdout}");
-        seen += 1;
+        assert_eq!(a_div_2, a / 2, "STDOUT: {stdout}");
+        assert_eq!(b_shift_div_neg_2, (b - 3) / -2, "STDOUT: {stdout}");
+        assert_eq!(c_div_3, c / 3, "STDOUT: {stdout}");
     }
 
     assert!(
-        seen >= 2,
+        arg_samples.len() >= 2,
         "Expected multiple inline arg events. STDOUT: {stdout}"
     );
     Ok(())
@@ -218,7 +243,7 @@ async fn test_optimized_inline_struct_member_access_resolves_inline_parameter_na
         );
     }
     let script = format!(
-        "trace inline_callsite_program.c:{INLINE_STATE_TRACE_LINE} {{\n    print \"STATE:{{}}:{{}}\", state.total_bytes, state.stream_id;\n}}\n"
+        "trace inline_callsite_program.c:{INLINE_STATE_TRACE_LINE} {{\n    let dyn_zero = delta - delta;\n    let state_dyn = state + dyn_zero;\n    print \"STATE:{{}}:{{}}\", state.total_bytes, state.stream_id;\n    print \"STATE_DIV:{{}}:{{}}\", state.total_bytes / 0xa, (state.stream_id + -0x10) / -0x7;\n    print \"STATE_DYN:{{}}:{{}}\", state_dyn.total_bytes, state[dyn_zero].stream_id;\n    print \"STATE_DYN_DIV:{{}}:{{}}\", state_dyn.total_bytes / 0xa, state_dyn[dyn_zero].stream_id / 0x1;\n}}\n"
     );
     let (exit_code, stdout, stderr) =
         run_ghostscope_with_script_for_target(&script, 4, &target).await?;
@@ -239,21 +264,99 @@ async fn test_optimized_inline_struct_member_access_resolves_inline_parameter_na
     );
 
     let re = Regex::new(r"STATE:([0-9-]+):([0-9-]+)")?;
-    let mut seen = 0;
-    for caps in re.captures_iter(&stdout) {
-        let total_bytes: i64 = caps[1].parse()?;
-        let stream_id: i64 = caps[2].parse()?;
+    let div_re = Regex::new(r"STATE_DIV:([0-9-]+):([0-9-]+)")?;
+    let dyn_re = Regex::new(r"STATE_DYN:([0-9-]+):([0-9-]+)")?;
+    let dyn_div_re = Regex::new(r"STATE_DYN_DIV:([0-9-]+):([0-9-]+)")?;
+    let state_samples: Vec<(i64, i64)> = re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let div_samples: Vec<(i64, i64)> = div_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let dyn_samples: Vec<(i64, i64)> = dyn_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    let dyn_div_samples: Vec<(i64, i64)> = dyn_div_re
+        .captures_iter(&stdout)
+        .map(|caps| Ok((caps[1].parse::<i64>()?, caps[2].parse::<i64>()?)))
+        .collect::<anyhow::Result<_>>()?;
+    assert!(
+        state_samples.len() == div_samples.len()
+            && state_samples.len() == dyn_samples.len()
+            && state_samples.len() == dyn_div_samples.len(),
+        "Expected matching inline state, dynamic state, and division samples. STDOUT: {stdout}"
+    );
+    for (
+        ((total_bytes, stream_id), (total_div_10, stream_shift_div_neg_7)),
+        ((dyn_total, dyn_stream), (dyn_total_div_10, dyn_stream_div_1)),
+    ) in state_samples
+        .iter()
+        .copied()
+        .zip(div_samples.iter().copied())
+        .zip(
+            dyn_samples
+                .iter()
+                .copied()
+                .zip(dyn_div_samples.iter().copied()),
+        )
+    {
         assert_eq!(
             total_bytes,
             (stream_id - 7) * 10,
             "Expected state.total_bytes == (state.stream_id - 7) * 10. STDOUT: {stdout}"
         );
-        seen += 1;
+        assert_eq!(dyn_total, total_bytes, "STDOUT: {stdout}");
+        assert_eq!(dyn_stream, stream_id, "STDOUT: {stdout}");
+        assert_eq!(total_div_10, total_bytes / 10, "STDOUT: {stdout}");
+        assert_eq!(
+            stream_shift_div_neg_7,
+            (stream_id - 16) / -7,
+            "STDOUT: {stdout}"
+        );
+        assert_eq!(dyn_total_div_10, total_bytes / 10, "STDOUT: {stdout}");
+        assert_eq!(dyn_stream_div_1, stream_id, "STDOUT: {stdout}");
     }
 
     assert!(
-        seen >= 2,
+        state_samples.len() >= 2,
         "Expected multiple inline struct member events. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_optimized_inline_struct_pointer_memory_formats() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("inline_callsite_program")?;
+    let target = spawn_inline_callsite_program(&binary_path).await?;
+    let script = format!(
+        "trace inline_callsite_program.c:{INLINE_STATE_TRACE_LINE} {{\n    print \"INLINE_STATE_PTR={{:p}}\", state + 0;\n    print \"INLINE_STATE_HEX={{:x.0x8}}\", state + 0;\n    if memcmp(state + 0, hex(\"1400000009000000\"), 0b1000) {{ print \"INLINE_STATE_MEM_OK\"; }}\n}}\n"
+    );
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(&script, 4, &target).await?;
+    target.terminate().await?;
+
+    if should_skip_for_ebpf_env(exit_code, &stderr) {
+        return Ok(());
+    }
+
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(
+        stdout.contains("INLINE_STATE_PTR=0x"),
+        "Expected inline state pointer formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("INLINE_STATE_HEX=14 00 00 00 09 00 00 00"),
+        "Expected inline state raw memory bytes. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("INLINE_STATE_MEM_OK"),
+        "Expected inline state memcmp marker. STDOUT: {stdout}"
     );
 
     Ok(())

--- a/e2e-tests/tests/partitioned_ranges_execution.rs
+++ b/e2e-tests/tests/partitioned_ranges_execution.rs
@@ -1,0 +1,148 @@
+mod common;
+
+use common::{fixture_compiler_available, init, FixtureCompiler, FIXTURES};
+use regex::Regex;
+use std::path::Path;
+use std::time::Duration;
+
+async fn run_ghostscope_with_script_for_target(
+    script_content: &str,
+    timeout_secs: u64,
+    target: &common::targets::TargetHandle,
+) -> anyhow::Result<(i32, String, String)> {
+    common::runner::GhostscopeRunner::new()
+        .with_script(script_content)
+        .attach_to(target)
+        .timeout_secs(timeout_secs)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await
+}
+
+async fn spawn_partitioned_ranges_program(
+    binary_path: &Path,
+) -> anyhow::Result<common::targets::TargetHandle> {
+    let bin_dir = binary_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("partitioned_ranges_program has no parent directory"))?;
+    let target = common::targets::TargetLauncher::binary(binary_path)
+        .current_dir(bin_dir)
+        .spawn()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(target)
+}
+
+#[tokio::test]
+async fn test_partitioned_ranges_o3_hot_line_runtime_tracing() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("partitioned_ranges_program")?;
+    assert_partitioned_ranges_hot_line_runtime_tracing(&binary_path).await
+}
+
+#[tokio::test]
+async fn test_partitioned_ranges_clang_dwarf5_rnglistx_hot_line_runtime_tracing(
+) -> anyhow::Result<()> {
+    init();
+
+    if !fixture_compiler_available(FixtureCompiler::ClangDwarf5Rnglistx) {
+        eprintln!(
+            "Skipping clang rnglistx partitioned-ranges runtime regression: clang is unavailable"
+        );
+        return Ok(());
+    }
+
+    let binary_path = FIXTURES.get_test_binary_with_compiler(
+        "partitioned_ranges_program",
+        FixtureCompiler::ClangDwarf5Rnglistx,
+    )?;
+    assert_partitioned_ranges_hot_line_runtime_tracing(&binary_path).await
+}
+
+async fn assert_partitioned_ranges_hot_line_runtime_tracing(
+    binary_path: &Path,
+) -> anyhow::Result<()> {
+    let target = spawn_partitioned_ranges_program(binary_path).await?;
+    let script = r#"
+trace partitioned_ranges_program.c:42 {
+    let next = x + 0x2;
+    print "PARTITIONED_X:{}", x;
+    print "PARTITIONED_CALC:{}:{}:{}", next, x * 0b11, x + -0o1;
+    print "PARTITIONED_DIV:{}:{}:{}", x / 0x2, (x + -0x400) / -0b10, next / 0o3;
+    if x > 0 { print "PARTITIONED_OK"; }
+    if x + -0x1 >= 0 { print "PARTITIONED_NONNEG"; }
+    if next - x == 0b10 { print "PARTITIONED_DELTA_OK"; }
+}
+"#;
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(
+        stdout.contains("PARTITIONED_X:"),
+        "Expected partitioned ranges parameter output. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("PARTITIONED_OK"),
+        "Expected partitioned ranges hot-line marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("PARTITIONED_NONNEG"),
+        "Expected partitioned ranges non-negative arithmetic marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("PARTITIONED_DELTA_OK"),
+        "Expected partitioned ranges let/arithmetic marker. STDOUT: {stdout}"
+    );
+    let value_re = Regex::new(r"PARTITIONED_X:([0-9-]+)")?;
+    let calc_re = Regex::new(r"PARTITIONED_CALC:([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let values: Vec<i64> = value_re
+        .captures_iter(&stdout)
+        .map(|caps| caps[1].parse::<i64>())
+        .collect::<Result<_, _>>()?;
+    let calcs: Vec<(i64, i64, i64)> = calc_re
+        .captures_iter(&stdout)
+        .map(|caps| {
+            Ok((
+                caps[1].parse::<i64>()?,
+                caps[2].parse::<i64>()?,
+                caps[3].parse::<i64>()?,
+            ))
+        })
+        .collect::<anyhow::Result<_>>()?;
+    let div_re = Regex::new(r"PARTITIONED_DIV:([0-9-]+):([0-9-]+):([0-9-]+)")?;
+    let divs: Vec<(i64, i64, i64)> = div_re
+        .captures_iter(&stdout)
+        .map(|caps| {
+            Ok((
+                caps[1].parse::<i64>()?,
+                caps[2].parse::<i64>()?,
+                caps[3].parse::<i64>()?,
+            ))
+        })
+        .collect::<anyhow::Result<_>>()?;
+    assert!(
+        !values.is_empty() && values.len() == calcs.len() && values.len() == divs.len(),
+        "Expected matching partitioned value, arithmetic, and division samples. STDOUT: {stdout}"
+    );
+    for ((x, (next, triple, prev)), (half, offset_div_neg_2, next_div_3)) in values
+        .iter()
+        .copied()
+        .zip(calcs.iter().copied())
+        .zip(divs.iter().copied())
+    {
+        assert_eq!(next, x + 2, "STDOUT: {stdout}");
+        assert_eq!(triple, x * 3, "STDOUT: {stdout}");
+        assert_eq!(prev, x - 1, "STDOUT: {stdout}");
+        assert_eq!(half, x / 2, "STDOUT: {stdout}");
+        assert_eq!(offset_div_neg_2, (x - 1024) / -2, "STDOUT: {stdout}");
+        assert_eq!(next_div_3, next / 3, "STDOUT: {stdout}");
+    }
+    assert!(
+        !stdout.contains("ExprError"),
+        "Partitioned ranges tracing should not emit ExprError. STDOUT: {stdout}"
+    );
+    Ok(())
+}

--- a/e2e-tests/tests/scalar_types_execution.rs
+++ b/e2e-tests/tests/scalar_types_execution.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{init, FIXTURES};
+use common::{init, OptimizationLevel, FIXTURES};
 use std::path::Path;
 use std::time::Duration;
 
@@ -29,6 +29,59 @@ async fn spawn_scalar_types_binary(
         .await?;
     tokio::time::sleep(Duration::from_millis(500)).await;
     Ok(target)
+}
+
+async fn assert_scalar_format_lengths(binary_path: &Path) -> anyhow::Result<()> {
+    let target = spawn_scalar_types_binary(binary_path).await?;
+
+    let script = r#"
+trace scalar_format_anchor {
+    let dyn_idx = *lenp - 0x2;
+    let dyn_text_idx = *lenp - 0x4;
+    let dyn_byte = bufp + dyn_idx;
+    let dyn_text = textp + dyn_text_idx;
+    print "HEX_DEC={:x.4}", bufp;
+    print "HEX_HEX={:x.0x4}", bufp;
+    print "HEX_OCT={:x.0o4}", bufp;
+    print "HEX_BIN={:X.0b100}", bufp;
+    print "HEX_STAR={:x.*}", *lenp, bufp;
+    print "HEX_DYN_BYTE={:x.0x4}", dyn_byte;
+    let n = 5;
+    print "ASCII_CAPTURE={:s.n$}", textp;
+    print "ASCII_DYN={:s.0x4}", dyn_text;
+    print "PTR_FMT={:p}", bufp;
+    if memcmp(dyn_byte, hex("ef00417f"), 0b100) { print "DYN_BYTE_MEM_OK"; }
+    if strncmp(dyn_text, "ello", 0o4) { print "DYN_TEXT_STR_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    for expected in [
+        "HEX_DEC=de ad be ef",
+        "HEX_HEX=de ad be ef",
+        "HEX_OCT=de ad be ef",
+        "HEX_BIN=DE AD BE EF",
+        "HEX_STAR=de ad be ef 00",
+        "HEX_DYN_BYTE=ef 00 41 7f",
+        "ASCII_CAPTURE=Hello",
+        "ASCII_DYN=ello",
+        "DYN_BYTE_MEM_OK",
+        "DYN_TEXT_STR_OK",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "Expected formatted output {expected}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("PTR_FMT=0x"),
+        "Expected pointer formatter output. STDOUT: {stdout}"
+    );
+    Ok(())
 }
 
 #[tokio::test]
@@ -223,6 +276,116 @@ trace scalar_by_value {
 }
 
 #[tokio::test]
+async fn test_c_scalar_o3_by_value_parameters_preserve_semantics() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_by_value {
+    print "O3_BYVAL_SIGNED:{}:{}:{}", i8v, i16v, alias_i8v;
+    print "O3_BYVAL_UNSIGNED:{}:{}:{}:{}", u8v, u16v, u32v, u64v;
+    if i8v < 0 { print "O3_BYVAL_I8_NEG"; }
+    if i16v < -1000 { print "O3_BYVAL_I16_NEG"; }
+    if alias_i8v < 0 { print "O3_BYVAL_ALIAS_NEG"; }
+    if i8v == -5 { print "O3_BYVAL_I8_EQ_NEG"; }
+    if i16v == -1234 { print "O3_BYVAL_I16_EQ_NEG"; }
+    if alias_i8v == -9 { print "O3_BYVAL_ALIAS_EQ_NEG"; }
+    if u64v > 9223372036854775807 { print "O3_BYVAL_U64_HIGH"; }
+    if i8v < u8v { print "O3_BYVAL_MIXED_I8_LT_U8"; }
+    if i8v > u8v { print "O3_BYVAL_MIXED_I8_GT_U8"; }
+    if u32v > -10000000000 { print "O3_BYVAL_U32_GT_SCRIPT_NEG"; }
+    print "O3_BYVAL_ENUMS:{}:{}", enum_negv, enum_bigv;
+    print "O3_BYVAL_ARITH:{}:{}:{}:{}", i8v + u8v, u16v - 0xea60, alias_i8v + -0x1, enum_bigv - 0xee6b2800;
+    print "O3_BYVAL_DIV:{}:{}:{}", u16v / 0x3, u32v / 0x2, u64v / 0x2;
+    print "O3_BYVAL_SIGNED_DIV:{}:{}", i8v / 0x2, i16v / -0x2;
+    print "O3_BYVAL_DYNAMIC_DIV:{}:{}:{}", u8v / (i8v + 0xf), u32v / (u8v + 0x6), i16v / (i8v + 0x3);
+    if u64v / 0x2 == 9223372036854775805 { print "O3_BYVAL_U64_DIV_OK"; }
+    if i8v / 0x2 == -0x2 { print "O3_BYVAL_I8_DIV_OK"; }
+    if i16v / -0x2 == 0x269 { print "O3_BYVAL_I16_DIV_OK"; }
+    if u8v / (i8v + 0xf) == 0x19 { print "O3_BYVAL_DYNAMIC_U8_DIV_OK"; }
+    if u32v / (u8v + 0x6) == 0xee6b28 { print "O3_BYVAL_DYNAMIC_U32_DIV_OK"; }
+    if i16v / (i8v + 0x3) == 0x269 { print "O3_BYVAL_DYNAMIC_I16_DIV_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_BYVAL_SIGNED:-5:-1234:-9"),
+        "Expected O3 signed by-value parameters to preserve negatives. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_UNSIGNED:250:60000:4000000000:18446744073709551610"),
+        "Expected O3 unsigned by-value parameters to preserve full-width values. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_BYVAL_I8_NEG",
+        "O3_BYVAL_I16_NEG",
+        "O3_BYVAL_ALIAS_NEG",
+        "O3_BYVAL_I8_EQ_NEG",
+        "O3_BYVAL_I16_EQ_NEG",
+        "O3_BYVAL_ALIAS_EQ_NEG",
+        "O3_BYVAL_U64_HIGH",
+        "O3_BYVAL_MIXED_I8_LT_U8",
+        "O3_BYVAL_U32_GT_SCRIPT_NEG",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 by-value marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("O3_BYVAL_MIXED_I8_GT_U8"),
+        "Unexpected O3 by-value mixed comparison marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_ENUMS:scalar_signed_enum::SCALAR_ENUM_NEG(-3):scalar_big_enum::SCALAR_ENUM_BIG(4000000000)"),
+        "Expected O3 signed and large enum by-value formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_ARITH:245:0:-10:0"),
+        "Expected O3 by-value arithmetic across narrow signed/unsigned and enum values. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_DIV:20000:2000000000:9223372036854775805"),
+        "Expected O3 by-value division to preserve unsigned C semantics. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_SIGNED_DIV:-2:617"),
+        "Expected O3 by-value signed division to truncate toward zero. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_DYNAMIC_DIV:25:15625000:617"),
+        "Expected O3 by-value dynamic division across signed and unsigned narrow values. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_U64_DIV_OK"),
+        "Expected O3 by-value uint64 division comparison marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYVAL_I8_DIV_OK") && stdout.contains("O3_BYVAL_I16_DIV_OK"),
+        "Expected O3 by-value signed division comparison markers. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_BYVAL_DYNAMIC_U8_DIV_OK",
+        "O3_BYVAL_DYNAMIC_U32_DIV_OK",
+        "O3_BYVAL_DYNAMIC_I16_DIV_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 by-value dynamic division marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_c_scalar_float_bool_by_value_parameters() -> anyhow::Result<()> {
     init();
 
@@ -253,6 +416,87 @@ trace scalar_float_bool_by_value {
     assert!(
         stdout.contains("BYVAL_BOOL_DIFF"),
         "Expected _Bool by-value comparison marker. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_o3_bool_by_value_parameters() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_float_bool_by_value {
+    print "O3_BYVAL_BOOL:{}:{}", bool_truev, bool_falsev;
+    if bool_truev != bool_falsev { print "O3_BYVAL_BOOL_DIFF"; }
+    if bool_truev == true { print "O3_BYVAL_BOOL_TRUE"; }
+    if bool_falsev == false { print "O3_BYVAL_BOOL_FALSE"; }
+    if bool_truev == 1 { print "O3_BYVAL_BOOL_EQ_ONE"; }
+    if bool_falsev == 0 { print "O3_BYVAL_BOOL_EQ_ZERO"; }
+    if bool_truev && bool_truev { print "O3_BYVAL_BOOL_AND_TRUE"; }
+    if bool_falsev || bool_truev { print "O3_BYVAL_BOOL_OR_TRUE"; }
+    if bool_truev && bool_falsev { print "O3_BYVAL_BOOL_AND_FALSE_BAD"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_BYVAL_BOOL:true:false"),
+        "Expected O3 _Bool by-value parameter formatting. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_BYVAL_BOOL_DIFF",
+        "O3_BYVAL_BOOL_TRUE",
+        "O3_BYVAL_BOOL_FALSE",
+        "O3_BYVAL_BOOL_EQ_ONE",
+        "O3_BYVAL_BOOL_EQ_ZERO",
+        "O3_BYVAL_BOOL_AND_TRUE",
+        "O3_BYVAL_BOOL_OR_TRUE",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 float/bool by-value marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("O3_BYVAL_BOOL_AND_FALSE_BAD"),
+        "Unexpected O3 _Bool && marker for false RHS. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_o3_float_by_value_parameters_report_xmm_unavailable() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_float_bool_by_value {
+    print "O3_BYVAL_FLOAT:{}", f32v;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_ne!(
+        exit_code, 0,
+        "Expected optimized XMM-backed float parameter to be reported unavailable. STDOUT: {stdout}"
+    );
+    assert!(
+        stderr.contains("Unsupported DWARF register: 17 (XMM0)")
+            && stderr.contains("uprobe pt_regs does not expose XMM register values"),
+        "Expected a clear XMM/pt_regs diagnostic. STDERR: {stderr}"
     );
     Ok(())
 }
@@ -303,6 +547,179 @@ trace scalar_stack_by_value {
 }
 
 #[tokio::test]
+async fn test_c_scalar_o3_stack_by_value_parameters_preserve_semantics() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_stack_by_value {
+    print "O3_STACK_REGS:{}:{}", reg1, reg6;
+    print "O3_STACK_VALUES:{}:{}:{}:{}", stack_i8v, stack_u8v, stack_i32v, stack_u64v;
+    if stack_i8v < 0 { print "O3_STACK_I8_NEG"; }
+    if stack_u8v > 200 { print "O3_STACK_U8_BIG"; }
+    if stack_i32v < -10000000 { print "O3_STACK_I32_NEG"; }
+    if stack_i8v == -5 { print "O3_STACK_I8_EQ_NEG"; }
+    if stack_i32v == -12345678 { print "O3_STACK_I32_EQ_NEG"; }
+    if stack_u64v > 9223372036854775807 { print "O3_STACK_U64_HIGH"; }
+    if stack_i8v < stack_u8v { print "O3_STACK_MIXED_I8_LT_U8"; }
+    if stack_i8v > stack_u8v { print "O3_STACK_MIXED_I8_GT_U8"; }
+    print "O3_STACK_DIV:{}:{}:{}", stack_u8v / 0x5, stack_u64v / 0x2, stack_i32v / -0x3;
+    print "O3_STACK_SIGNED_DIV:{}", stack_i8v / 0x2;
+    if stack_u64v / 0x2 == 9223372036854775805 { print "O3_STACK_U64_DIV_OK"; }
+    if stack_i8v / 0x2 == -0x2 { print "O3_STACK_I8_DIV_OK"; }
+    if stack_i32v / -0x3 == 4115226 { print "O3_STACK_I32_DIV_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_STACK_REGS:11:66"),
+        "Expected O3 register by-value parameters before stack slots. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STACK_VALUES:-5:250:-12345678:18446744073709551610"),
+        "Expected O3 stack-passed by-value parameters to preserve values. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_STACK_I8_NEG",
+        "O3_STACK_U8_BIG",
+        "O3_STACK_I32_NEG",
+        "O3_STACK_I8_EQ_NEG",
+        "O3_STACK_I32_EQ_NEG",
+        "O3_STACK_U64_HIGH",
+        "O3_STACK_MIXED_I8_LT_U8",
+        "O3_STACK_U64_DIV_OK",
+        "O3_STACK_I8_DIV_OK",
+        "O3_STACK_I32_DIV_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 stack by-value marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        !stdout.contains("O3_STACK_MIXED_I8_GT_U8"),
+        "Unexpected O3 stack mixed comparison marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STACK_DIV:50:9223372036854775805:4115226"),
+        "Expected O3 stack by-value division to preserve unsigned and signed semantics. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STACK_SIGNED_DIV:-2"),
+        "Expected O3 stack signed division to truncate toward zero. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_base_prefixed_format_lengths_on_pointer_memory() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("scalar_types_program")?;
+    assert_scalar_format_lengths(&binary_path).await
+}
+
+#[tokio::test]
+async fn test_c_scalar_o3_pointer_memory_format_lengths() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    assert_scalar_format_lengths(&binary_path).await
+}
+
+#[tokio::test]
+async fn test_c_scalar_o3_pointer_parameters_preserve_values() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_anchor {
+    print "O3_SIGNED:{}:{}:{}", *i8p, *i32p, *i64p;
+    print "O3_UNSIGNED:{}:{}:{}", *u8p, *u32p, *u64p;
+    if *i32p > *u32p { print "O3_MIXED_I32_GT_U32"; }
+    if *u32p < *i32p { print "O3_MIXED_U32_LT_I32"; }
+    if *i32p < *u32p { print "O3_MIXED_I32_LT_U32"; }
+    if *i32minp < *u32p { print "O3_MIXED_I32_MIN_LT_U32"; }
+    if *i32minp > *u32p { print "O3_MIXED_I32_MIN_GT_U32"; }
+    if *u32p > -10000000000 { print "O3_U32_GT_SCRIPT_NEG"; }
+    if *u32p < -10000000000 { print "O3_U32_LT_SCRIPT_NEG"; }
+    if *i8p < *u8p { print "O3_MIXED_I8_LT_U8"; }
+    if *i8p > *u8p { print "O3_MIXED_I8_GT_U8"; }
+    if *i64p < *u64p { print "O3_MIXED_I64_LT_U64"; }
+    print "O3_PTR_DIV:{}:{}:{}", *u32p / 0x2, *u64p / 0x2, *i64p / -0x3;
+    print "O3_PTR_SIGNED_DIV:{}:{}", *i8p / 0x2, *i32p / -0x3;
+    if *u64p / 0x2 == 9223372036854775805 { print "O3_PTR_U64_DIV_OK"; }
+    if *i8p / 0x2 == -0x2 { print "O3_PTR_I8_DIV_OK"; }
+    if *i32p / -0x3 == 4115226 { print "O3_PTR_I32_DIV_OK"; }
+    if *i64p / -0x3 == 3000000000000000000 { print "O3_PTR_I64_DIV_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_SIGNED:-5:-12345678:-9000000000000000000"),
+        "Expected O3 signed pointer parameter values. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_UNSIGNED:250:4000000000:18446744073709551610"),
+        "Expected O3 unsigned pointer parameter values. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_MIXED_I32_GT_U32",
+        "O3_MIXED_U32_LT_I32",
+        "O3_MIXED_I32_MIN_LT_U32",
+        "O3_U32_GT_SCRIPT_NEG",
+        "O3_MIXED_I8_LT_U8",
+        "O3_MIXED_I64_LT_U64",
+        "O3_PTR_U64_DIV_OK",
+        "O3_PTR_I8_DIV_OK",
+        "O3_PTR_I32_DIV_OK",
+        "O3_PTR_I64_DIV_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 comparison marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    for marker in [
+        "O3_MIXED_I32_LT_U32",
+        "O3_MIXED_I32_MIN_GT_U32",
+        "O3_U32_LT_SCRIPT_NEG",
+        "O3_MIXED_I8_GT_U8",
+    ] {
+        assert!(
+            !stdout.contains(marker),
+            "Unexpected O3 comparison marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("O3_PTR_DIV:2000000000:9223372036854775805:3000000000000000000"),
+        "Expected O3 pointer-memory division to preserve unsigned and signed values. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_PTR_SIGNED_DIV:-2:4115226"),
+        "Expected O3 pointer-memory signed division to truncate toward zero. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_c_scalar_typedef_char_enum_and_float_edges() -> anyhow::Result<()> {
     init();
 
@@ -347,6 +764,77 @@ trace scalar_extra_anchor {
         assert!(
             stdout.contains(marker),
             "Expected marker {marker}. STDOUT: {stdout}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_c_scalar_o3_typedef_char_enum_and_float_edges() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("scalar_types_program", OptimizationLevel::O3)?;
+    let target = spawn_scalar_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace scalar_extra_anchor {
+    print "O3_CHARS:{}:{}:{}", *charp, *scharp, *ucharp;
+    print "O3_ALIASES:{}:{}", *alias_i8p, *qualified_u16p;
+    print "O3_ENUMS:{}:{}", *enum_negp, *enum_bigp;
+    print "O3_EDGE_DIV:{}:{}:{}:{}", *scharp / 0x2, *ucharp / 0x10, *qualified_u16p / 0xa, *enum_negp / 0x2;
+    print "O3_FLOAT_EDGE:{}:{}:{}", *neg_zerop, *infp, *nanp;
+    if *charp == 0x41 { print "O3_CHAR_HEX_A"; }
+    if *scharp == -0x7 { print "O3_SCHAR_NEG_HEX"; }
+    if *ucharp == 0xf0 { print "O3_UCHAR_HEX_F0"; }
+    if *alias_i8p < 0 { print "O3_ALIAS_NEG"; }
+    if *qualified_u16p == 0b1111110111101000 { print "O3_QUAL_U16_BIN_EQ"; }
+    if *enum_negp == -0x3 { print "O3_ENUM_NEG_HEX_EQ"; }
+    if *enum_bigp == 0xee6b2800 { print "O3_ENUM_BIG_HEX_EQ"; }
+    if *scharp / 0x2 == -0x3 { print "O3_SCHAR_DIV_OK"; }
+    if *enum_negp / 0x2 == -0x1 { print "O3_ENUM_NEG_DIV_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_CHARS:65:-7:240"),
+        "Expected O3 char/signed char/unsigned char numeric formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIASES:-9:65000"),
+        "Expected O3 typedef and qualified scalar formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ENUMS:scalar_signed_enum(scalar_signed_enum::SCALAR_ENUM_NEG(-3)):scalar_big_enum(scalar_big_enum::SCALAR_ENUM_BIG(4000000000))"),
+        "Expected O3 enum variant formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_EDGE_DIV:-3:15:6500:-1"),
+        "Expected O3 narrow char, qualified integer, and signed enum division. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_FLOAT_EDGE:-0:inf:NaN"),
+        "Expected O3 float edge formatting for -0.0, infinity, and NaN. STDOUT: {stdout}"
+    );
+    for marker in [
+        "O3_CHAR_HEX_A",
+        "O3_SCHAR_NEG_HEX",
+        "O3_UCHAR_HEX_F0",
+        "O3_ALIAS_NEG",
+        "O3_QUAL_U16_BIN_EQ",
+        "O3_ENUM_NEG_HEX_EQ",
+        "O3_ENUM_BIG_HEX_EQ",
+        "O3_SCHAR_DIV_OK",
+        "O3_ENUM_NEG_DIV_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected O3 marker {marker}. STDOUT: {stdout}"
         );
     }
     Ok(())

--- a/e2e-tests/tests/script_execution.rs
+++ b/e2e-tests/tests/script_execution.rs
@@ -210,6 +210,7 @@ async fn test_struct_pointer_addition_scales_by_type_size() -> anyhow::Result<()
 trace print_record {
     print record + 1;
     print record + 2;
+    print (record + 0x1) + 0b1;
 }
 "#;
 
@@ -228,6 +229,7 @@ trace print_record {
     // Gather addresses from failure lines for (record+1) and (record+2)
     let mut addr1: Option<u64> = None;
     let mut addr2: Option<u64> = None;
+    let mut addr_chain: Option<u64> = None;
     for line in stdout.lines() {
         let t = line.trim();
         if t.starts_with("(record+1) = ") || t.starts_with("(record + 1) = ") {
@@ -258,6 +260,24 @@ trace print_record {
                 }
             }
         }
+        if t.starts_with("((record+1)+1) = ")
+            || t.starts_with("((record + 1) + 1) = ")
+            || t.starts_with("((record+0x1)+0b1) = ")
+            || t.starts_with("((record + 0x1) + 0b1) = ")
+        {
+            if let Some(ix) = t.rfind("0x") {
+                let mut j = ix + 2;
+                let bytes = t.as_bytes();
+                while j < t.len() && bytes[j].is_ascii_hexdigit() {
+                    j += 1;
+                }
+                if j > ix + 2 {
+                    if let Ok(v) = u64::from_str_radix(&t[ix + 2..j], 16) {
+                        addr_chain = Some(v);
+                    }
+                }
+            }
+        }
     }
 
     if let (Some(a1), Some(a2)) = (addr1, addr2) {
@@ -266,6 +286,13 @@ trace print_record {
         assert_eq!(
             delta, 48,
             "expected address delta sizeof(DataRecord)=48 bytes (got {delta}).\nSTDOUT: {stdout}\nSTDERR: {stderr}"
+        );
+        let chain = addr_chain.ok_or_else(|| {
+            anyhow::anyhow!("missing nested record pointer address. STDOUT: {stdout}")
+        })?;
+        assert_eq!(
+            chain, a2,
+            "expected nested record pointer addition to equal record+2.\nSTDOUT: {stdout}\nSTDERR: {stderr}"
         );
     } else {
         // If we didn't observe failure lines with addresses, we cannot assert safely here.
@@ -927,6 +954,579 @@ trace nonexistent_function_12345 {
     } else {
         println!("⚠️  Expected 'No uprobe configurations' error, got: {stderr}");
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_o3_cross_object_register_args_and_string_pointer_formatting() -> anyhow::Result<()> {
+    init();
+    ensure_global_cleanup_registered();
+
+    let opt_level = OptimizationLevel::O3;
+    let _ = get_global_test_pid_with_opt(opt_level).await?;
+
+    let script_content = r#"
+trace add_numbers {
+    print "O3_ADD:{}:{}:{}", a, b, a + b;
+    print "O3_DIV_DYNAMIC:{}:{}:{}", a, b, b / a;
+    if b == a * 2 { print "O3_ADD_OK"; }
+    if b / (b - a) >= 0x1 { print "O3_DIV_DYNAMIC_OK"; }
+}
+
+trace get_string_length {
+    let dyn_offset = 0xb + ($pid - $pid);
+    let dyn_prefix = ($pid - $pid) + str;
+    let dyn_tail = str + dyn_offset;
+    print "O3_STR={:s.0x9}", str;
+    print "O3_STR_DYN_PREFIX={:s.0x9}", dyn_prefix;
+    print "O3_STR_DYN_TAIL={:s.0x5}", dyn_tail;
+    if strncmp(str, "Iteration", 0x9) { print "O3_STR_OK"; }
+    if strncmp(str + 11, "value", 5) { print "O3_STR_OFFSET_OK"; }
+    if strncmp(dyn_prefix, "Iteration", 0b1001) { print "O3_STR_DYN_PREFIX_OK"; }
+    if strncmp(dyn_tail, "value", 0x5) { print "O3_STR_DYN_TAIL_OK"; }
+    if strncmp(dyn_offset + str, "value", 0o5) { print "O3_STR_DYN_COMMUTE_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_opt(script_content, 4, opt_level).await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_ADD_OK"),
+        "Expected O3 cross-object register argument comparison. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DIV_DYNAMIC_OK"),
+        "Expected O3 dynamic division marker. STDOUT: {stdout}"
+    );
+    let mut div_samples = 0;
+    for line in stdout.lines() {
+        let Some(sample) = line.trim().strip_prefix("O3_DIV_DYNAMIC:") else {
+            continue;
+        };
+        let fields: Vec<_> = sample.split(':').collect();
+        if fields.len() != 3 {
+            continue;
+        }
+        let a: i64 = fields[0].parse()?;
+        let b: i64 = fields[1].parse()?;
+        let quotient: i64 = fields[2].parse()?;
+        assert_ne!(a, 0, "STDOUT: {stdout}");
+        assert_eq!(quotient, b / a, "STDOUT: {stdout}");
+        div_samples += 1;
+    }
+    assert!(
+        div_samples >= 1,
+        "Expected O3 dynamic division samples. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STR=Iteration"),
+        "Expected O3 string pointer formatting with hex static length. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STR_DYN_PREFIX=Iteration"),
+        "Expected O3 dynamic string pointer alias formatting at prefix. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STR_DYN_TAIL=value"),
+        "Expected O3 dynamic string pointer alias formatting at tail. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STR_OK"),
+        "Expected O3 strncmp with hex static length. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STR_OFFSET_OK"),
+        "Expected O3 strncmp on typed string pointer arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_STR_DYN_PREFIX_OK")
+            && stdout.contains("O3_STR_DYN_TAIL_OK")
+            && stdout.contains("O3_STR_DYN_COMMUTE_OK"),
+        "Expected O3 dynamic string pointer alias strncmp markers. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_o3_guarded_dynamic_division_short_circuits_zero_denominator() -> anyhow::Result<()> {
+    init();
+    ensure_global_cleanup_registered();
+
+    let opt_level = OptimizationLevel::O3;
+    let _ = get_global_test_pid_with_opt(opt_level).await?;
+
+    let script_content = r#"
+trace calculate_something {
+    let denom = b - a - 0x5;
+    if denom == 0 || a / denom > 0 { print "O3_DIV_GUARD_OR_OK"; }
+    if denom != 0 && a / denom > 0 { print "O3_DIV_GUARD_AND_BAD"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_opt(script_content, 4, opt_level).await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_DIV_GUARD_OR_OK"),
+        "Expected short-circuit OR guard marker. STDOUT: {stdout}"
+    );
+    assert!(
+        !stdout.contains("O3_DIV_GUARD_AND_BAD"),
+        "AND guard should not execute division branch while denom is zero. STDOUT: {stdout}"
+    );
+    assert!(
+        !stdout.contains("ExprError"),
+        "Guarded dynamic division should not emit ExprError. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_o3_local_int_array_decay_pointer_addition_and_memcmp() -> anyhow::Result<()> {
+    init();
+    ensure_global_cleanup_registered();
+
+    let opt_level = OptimizationLevel::O3;
+    let _ = get_global_test_pid_with_opt(opt_level).await?;
+
+    let script_content = r#"
+trace sample_program.c:73 {
+    let p = numbers + 0x1;
+    let q = p;
+    let r = p - 0b1;
+    let s = p + -0x1;
+    let t = -0x1 + p;
+    let u = p - -0x1;
+    let byte_back = &numbers[0b10] + -0x4;
+    let byte_forward = &numbers[0x1] - -0x4;
+    let dyn_arr_idx = numbers[0x0] / 0xa;
+    let dyn_ptr_idx = (numbers[0b10] / numbers[0x0]) - 0b10;
+    let dyn_ptr = numbers + dyn_arr_idx;
+    let dyn_alias = p + dyn_ptr_idx;
+    let dyn_byte_off = dyn_arr_idx * 0x4;
+    let dyn_raw_addr = &numbers[0x0] + dyn_byte_off;
+    let dyn_raw_back = &numbers[0b10] - dyn_byte_off;
+    print "O3_NUM1:{}", numbers + 1;
+    print "O3_NUM2:{}", (numbers + 0x1) + 0b1;
+    print "O3_ALIAS_NUM2:{}", p + 0b1;
+    print "O3_MIXED_NUM2:{}", (numbers + 0x3) - 0b1;
+    print "O3_ALIAS_CHAIN_NUM2:{}", q + 0b1;
+    print "O3_INDEX_NUM2:{}", numbers[0b10];
+    print "O3_ALIAS_INDEX_NUM2:{}", p[0b1];
+    print "O3_ALIAS_CHAIN_INDEX_NUM2:{}", q[0b1];
+    print "O3_NEG_INDEX0:{}", p[-0x1];
+    print "O3_CONST_EXPR_INDEX_NUM2:{}", p[0x2 - 0b1];
+    print "O3_CONST_EXPR_CHAIN_INDEX_NUM2:{}", q[-0x1 + 0b10];
+    print "O3_DYNAMIC_INDEX:{}:{}:{}", dyn_arr_idx, numbers[dyn_arr_idx], p[dyn_ptr_idx];
+    print "O3_DYNAMIC_INDEX_CHAIN:{}:{}", q[dyn_ptr_idx], p[dyn_ptr_idx - 0x1];
+    print "O3_DYNAMIC_ALIAS_VALUE:{}:{}", dyn_ptr[0x1], dyn_ptr[dyn_arr_idx];
+    print "O3_DEREF_ALIAS1:{}", *p;
+    print "O3_DEREF_ALIAS_CHAIN2:{}", *(q + 0b1);
+    print "O3_NUM_DIV:{}:{}:{}", numbers[0b10] / numbers[0x0], p[0b1] / *p, *(q + 0b1) / (p[-0x1] + 0x5);
+    print "O3_DYNAMIC_INDEX_DIV:{}:{}", numbers[dyn_arr_idx + 0x1] / numbers[dyn_arr_idx], q[dyn_ptr_idx] / p[dyn_ptr_idx - 0x1];
+    print "O3_REBASED_NUM2:{}", r + 0x2;
+    print "O3_REBASED_INDEX2:{}", r[0x2];
+    print "O3_REBASED_DEREF2:{}", *(r + 0x2);
+    print "O3_NEGADD_NUM2:{}", s + 0b10;
+    print "O3_NEGADD_INDEX2:{}", s[0b10];
+    print "O3_LEFT_NEGADD_NUM2:{}", t + 0b10;
+    print "O3_SUB_NEG_NUM2:{}", u + 0x0;
+    print "O3_NUM_HEX={:x.0x8}", numbers;
+    print "O3_NUM_CHAIN_HEX={:x.0x4}", (numbers + 0x1) + 0b1;
+    print "O3_ALIAS_CHAIN_HEX={:x.0x4}", p + 0b1;
+    print "O3_MIXED_CHAIN_HEX={:x.0o4}", (numbers + 0x3) - 0b1;
+    print "O3_ALIAS_ALIAS_CHAIN_HEX={:x.0b100}", q + 0b1;
+    print "O3_DYNAMIC_INDEX_HEX={:x.0x4}", &numbers[dyn_arr_idx];
+    print "O3_DYNAMIC_ALIAS_INDEX_HEX={:x.0b100}", &p[dyn_ptr_idx];
+    print "O3_DYNAMIC_PTRADD_HEX={:x.0x4}", numbers + dyn_arr_idx;
+    print "O3_DYNAMIC_ALIAS_PTRADD_HEX={:x.0b100}", p + dyn_ptr_idx;
+    print "O3_DYNAMIC_ALIAS_DIRECT_HEX={:x.0x4}", dyn_ptr;
+    print "O3_DYNAMIC_ALIAS_INDEX_HEX={:x.0x4}", &dyn_ptr[0x1];
+    print "O3_DYNAMIC_ALIAS_DYN_INDEX_HEX={:x.0b100}", &dyn_ptr[dyn_arr_idx];
+    print "O3_DYNAMIC_ALIAS_PLUS_HEX={:x.0x4}", dyn_ptr + 0x1;
+    print "O3_DYNAMIC_ALIAS_SUB_HEX={:x.0x4}", dyn_alias - dyn_ptr_idx;
+    print "O3_DYNAMIC_ALIAS_COMMUTE_HEX={:x.0x4}", dyn_arr_idx + dyn_ptr;
+    print "O3_DYNAMIC_RAW_ADDR_HEX={:x.0x4}", dyn_raw_addr;
+    print "O3_DYNAMIC_RAW_BACK_HEX={:x.0b100}", dyn_raw_back;
+    print "O3_ADDR_ALIAS_INDEX_HEX={:x.0x4}", &p[0b1];
+    print "O3_ADDR_DEREF_HEX={:x.0b100}", &*(q + 0b1);
+    print "O3_NEGADD_HEX={:x.0x4}", s + 0b10;
+    print "O3_LEFT_NEGADD_HEX={:x.0x4}", t + 0b10;
+    print "O3_SUB_NEG_HEX={:x.0x4}", u + 0x0;
+    print "O3_BYTE_BACK_HEX={:x.0x4}", byte_back;
+    print "O3_BYTE_FORWARD_HEX={:x.0b100}", byte_forward;
+    print "O3_NEG_INDEX_HEX={:x.0x4}", &p[-0x1];
+    print "O3_CONST_EXPR_INDEX_HEX={:x.0o4}", &p[0x2 - 0b1];
+    print "O3_CONST_EXPR_CHAIN_INDEX_HEX={:x.0b100}", &q[-0x1 + 0b10];
+    if memcmp(numbers, hex("0a00000014000000"), 0x8) { print "O3_NUM_MEM_OK"; }
+    if memcmp(numbers + 1, hex("14000000"), 0b100) { print "O3_NUM_PTRADD_OK"; }
+    if memcmp((numbers + 0x1) + 0b1, hex("1e000000"), 0b100) { print "O3_NUM_CHAIN_PTRADD_OK"; }
+    if memcmp(p + 0b1, hex("1e000000"), 0b100) { print "O3_NUM_ALIAS_PTRADD_OK"; }
+    if memcmp((numbers + 0x3) - 0b1, hex("1e000000"), 0o4) { print "O3_NUM_MIXED_PTRADD_OK"; }
+    if memcmp(q + 0b1, hex("1e000000"), 0b100) { print "O3_NUM_ALIAS_CHAIN_PTRADD_OK"; }
+    if memcmp(r + 0x2, hex("1e000000"), 0x4) { print "O3_NUM_REBASED_PTRADD_OK"; }
+    if memcmp(&numbers[dyn_arr_idx], hex("14000000"), 0x4) { print "O3_DYNAMIC_INDEX_ADDR_OK"; }
+    if memcmp(&p[dyn_ptr_idx], hex("1e000000"), 0b100) { print "O3_DYNAMIC_ALIAS_INDEX_ADDR_OK"; }
+    if memcmp(numbers + dyn_arr_idx, hex("14000000"), 0x4) { print "O3_DYNAMIC_PTRADD_OK"; }
+    if memcmp(p + dyn_ptr_idx, hex("1e000000"), 0b100) { print "O3_DYNAMIC_ALIAS_PTRADD_OK"; }
+    if memcmp(dyn_ptr, hex("14000000"), 0x4) { print "O3_DYNAMIC_ALIAS_DIRECT_OK"; }
+    if memcmp(&dyn_ptr[0x1], hex("1e000000"), 0x4) { print "O3_DYNAMIC_ALIAS_INDEX_OK"; }
+    if memcmp(&dyn_ptr[dyn_arr_idx], hex("1e000000"), 0b100) { print "O3_DYNAMIC_ALIAS_DYN_INDEX_OK"; }
+    if memcmp(dyn_ptr + 0x1, hex("1e000000"), 0x4) { print "O3_DYNAMIC_ALIAS_PLUS_OK"; }
+    if memcmp(dyn_alias - dyn_ptr_idx, hex("14000000"), 0x4) { print "O3_DYNAMIC_ALIAS_SUB_OK"; }
+    if memcmp(dyn_arr_idx + dyn_ptr, hex("1e000000"), 0x4) { print "O3_DYNAMIC_ALIAS_COMMUTE_OK"; }
+    if memcmp(dyn_raw_addr, hex("14000000"), 0x4) { print "O3_DYNAMIC_RAW_ADDR_OK"; }
+    if memcmp(dyn_raw_back, hex("14000000"), 0b100) { print "O3_DYNAMIC_RAW_BACK_OK"; }
+    if memcmp(&p[0b1], hex("1e000000"), 0x4) { print "O3_ADDR_ALIAS_INDEX_OK"; }
+    if memcmp(&*(q + 0b1), hex("1e000000"), 0b100) { print "O3_ADDR_DEREF_OK"; }
+    if memcmp(s + 0b10, hex("1e000000"), 0x4) { print "O3_NEGADD_PTRADD_OK"; }
+    if memcmp(t + 0b10, hex("1e000000"), 0x4) { print "O3_LEFT_NEGADD_PTRADD_OK"; }
+    if memcmp(u + 0x0, hex("1e000000"), 0b100) { print "O3_SUB_NEG_PTRADD_OK"; }
+    if memcmp(byte_back, hex("14000000"), 0x4) { print "O3_BYTE_BACK_OK"; }
+    if memcmp(byte_forward, hex("1e000000"), 0b100) { print "O3_BYTE_FORWARD_OK"; }
+    if memcmp(&p[-0x1], hex("0a000000"), 0x4) { print "O3_NEG_INDEX_OK"; }
+    if memcmp(&p[0x2 - 0b1], hex("1e000000"), 0o4) { print "O3_CONST_EXPR_INDEX_OK"; }
+    if memcmp(&q[-0x1 + 0b10], hex("1e000000"), 0b100) { print "O3_CONST_EXPR_CHAIN_INDEX_OK"; }
+    if numbers[0b10] / numbers[0x0] == 0x3 { print "O3_NUM_DIV_INDEX_OK"; }
+    if p[0b1] / *p == 0b1 { print "O3_NUM_DIV_ALIAS_OK"; }
+    if *(q + 0b1) / (p[-0x1] + 0x5) == 0x2 { print "O3_NUM_DIV_MIXED_OK"; }
+    if numbers[dyn_arr_idx] == 0x14 { print "O3_DYNAMIC_INDEX_ARRAY_OK"; }
+    if p[dyn_ptr_idx] == 0x1e { print "O3_DYNAMIC_INDEX_PTR_OK"; }
+    if q[dyn_ptr_idx] / p[dyn_ptr_idx - 0x1] == 0x1 { print "O3_DYNAMIC_INDEX_DIV_OK"; }
+    if dyn_ptr[0x1] == 0x1e && dyn_ptr[dyn_arr_idx] == 0x1e { print "O3_DYNAMIC_ALIAS_VALUE_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_opt(script_content, 4, opt_level).await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("O3_NUM1:20") || stdout.contains("O3_NUM1:(numbers+1) = 20"),
+        "Expected O3 pointer addition on int array to read the second element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM2:30") || stdout.contains("O3_NUM2:((numbers+1)+1) = 30"),
+        "Expected nested O3 pointer addition on int array to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIAS_NUM2:30") || stdout.contains("O3_ALIAS_NUM2:(p+1) = 30"),
+        "Expected alias-based nested O3 pointer addition on int array to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_MIXED_NUM2:30")
+            || stdout.contains("O3_MIXED_NUM2:((numbers+3)-1) = 30"),
+        "Expected mixed +/- O3 pointer arithmetic on int array to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIAS_CHAIN_NUM2:30")
+            || stdout.contains("O3_ALIAS_CHAIN_NUM2:(q+1) = 30"),
+        "Expected alias-of-alias O3 pointer arithmetic on int array to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_INDEX_NUM2:30"),
+        "Expected O3 binary array index on int array to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIAS_INDEX_NUM2:30"),
+        "Expected O3 alias pointer array index to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIAS_CHAIN_INDEX_NUM2:30"),
+        "Expected O3 alias-of-alias pointer array index to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEG_INDEX0:10"),
+        "Expected O3 negative alias pointer array index to read the first element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_CONST_EXPR_INDEX_NUM2:30"),
+        "Expected O3 constant-expression alias pointer index to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_CONST_EXPR_CHAIN_INDEX_NUM2:30"),
+        "Expected O3 constant-expression alias-of-alias index to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_INDEX:1:20:30"),
+        "Expected dynamic array and alias pointer indexes to read second and third elements. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_INDEX_CHAIN:30:20"),
+        "Expected dynamic alias-of-alias pointer index and rebased dynamic index reads. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_VALUE:30:30"),
+        "Expected dynamic pointer alias literal and dynamic indexes to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DEREF_ALIAS1:20"),
+        "Expected O3 alias pointer dereference to read the second element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DEREF_ALIAS_CHAIN2:30"),
+        "Expected O3 alias-of-alias pointer arithmetic dereference to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_DIV:3:1:2"),
+        "Expected O3 local array indexed division results. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_INDEX_DIV:1:1"),
+        "Expected dynamic local array and alias pointer division results. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_REBASED_NUM2:30") || stdout.contains("O3_REBASED_NUM2:(r+2) = 30"),
+        "Expected O3 rebased subtraction alias pointer addition to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_REBASED_INDEX2:30"),
+        "Expected O3 rebased subtraction alias array index to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_REBASED_DEREF2:30"),
+        "Expected O3 rebased subtraction alias dereference to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEGADD_NUM2:30") || stdout.contains("O3_NEGADD_NUM2:(s+2) = 30"),
+        "Expected O3 alias plus negative literal pointer addition to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEGADD_INDEX2:30"),
+        "Expected O3 alias plus negative literal array index to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_LEFT_NEGADD_NUM2:30")
+            || stdout.contains("O3_LEFT_NEGADD_NUM2:(t+2) = 30"),
+        "Expected O3 negative-left alias pointer addition to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_SUB_NEG_NUM2:30") || stdout.contains("O3_SUB_NEG_NUM2:(u+0) = 30"),
+        "Expected O3 subtract-negative alias pointer arithmetic to read the third element. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_HEX=0a 00 00 00 14 00 00 00"),
+        "Expected O3 local int array hex memdump. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_CHAIN_HEX=1e 00 00 00"),
+        "Expected nested O3 pointer addition memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIAS_CHAIN_HEX=1e 00 00 00"),
+        "Expected alias-based nested O3 pointer addition memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_MIXED_CHAIN_HEX=1e 00 00 00"),
+        "Expected mixed +/- O3 pointer addition memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ALIAS_ALIAS_CHAIN_HEX=1e 00 00 00"),
+        "Expected alias-of-alias O3 pointer addition memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_INDEX_HEX=14 00 00 00"),
+        "Expected dynamic address-of local array index memdump to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_INDEX_HEX=1e 00 00 00"),
+        "Expected dynamic address-of alias pointer index memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_PTRADD_HEX=14 00 00 00"),
+        "Expected dynamic local array pointer addition memdump to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_PTRADD_HEX=1e 00 00 00"),
+        "Expected dynamic alias pointer addition memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_DIRECT_HEX=14 00 00 00"),
+        "Expected dynamic pointer alias memdump to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_INDEX_HEX=1e 00 00 00"),
+        "Expected dynamic pointer alias literal index memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_DYN_INDEX_HEX=1e 00 00 00"),
+        "Expected dynamic pointer alias dynamic index memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_PLUS_HEX=1e 00 00 00"),
+        "Expected dynamic pointer alias plus literal memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_SUB_HEX=14 00 00 00"),
+        "Expected dynamic pointer alias subtraction memdump to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_COMMUTE_HEX=1e 00 00 00"),
+        "Expected dynamic pointer alias commuted addition memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_RAW_ADDR_HEX=14 00 00 00"),
+        "Expected dynamic raw address byte-offset memdump to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_RAW_BACK_HEX=14 00 00 00"),
+        "Expected dynamic raw address byte-offset subtraction memdump to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ADDR_ALIAS_INDEX_HEX=1e 00 00 00"),
+        "Expected address-of alias pointer indexing memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ADDR_DEREF_HEX=1e 00 00 00"),
+        "Expected address-of pointer dereference memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEGADD_HEX=1e 00 00 00"),
+        "Expected alias plus negative literal memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_LEFT_NEGADD_HEX=1e 00 00 00"),
+        "Expected negative-left alias pointer memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_SUB_NEG_HEX=1e 00 00 00"),
+        "Expected subtract-negative alias pointer memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYTE_BACK_HEX=14 00 00 00"),
+        "Expected raw address plus negative byte offset to start at the second int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYTE_FORWARD_HEX=1e 00 00 00"),
+        "Expected raw address subtract-negative byte offset to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEG_INDEX_HEX=0a 00 00 00"),
+        "Expected address-of negative alias pointer index to start at the first int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_CONST_EXPR_INDEX_HEX=1e 00 00 00"),
+        "Expected constant-expression alias pointer index memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_CONST_EXPR_CHAIN_INDEX_HEX=1e 00 00 00"),
+        "Expected constant-expression alias-of-alias index memdump to start at the third int. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_MEM_OK"),
+        "Expected O3 memcmp on local int array decay. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_PTRADD_OK"),
+        "Expected O3 memcmp on scaled int pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_CHAIN_PTRADD_OK"),
+        "Expected O3 memcmp on nested scaled int pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_ALIAS_PTRADD_OK"),
+        "Expected O3 memcmp on alias-based nested scaled int pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_MIXED_PTRADD_OK"),
+        "Expected O3 memcmp on mixed +/- scaled int pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_ALIAS_CHAIN_PTRADD_OK"),
+        "Expected O3 memcmp on alias-of-alias scaled int pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_REBASED_PTRADD_OK"),
+        "Expected O3 memcmp on rebased subtraction alias pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_INDEX_ADDR_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_INDEX_ADDR_OK"),
+        "Expected O3 memcmp on dynamic address-of array and alias pointer indexes. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_PTRADD_OK") && stdout.contains("O3_DYNAMIC_ALIAS_PTRADD_OK"),
+        "Expected O3 memcmp on dynamic array and alias pointer addition. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_ALIAS_DIRECT_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_INDEX_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_DYN_INDEX_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_PLUS_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_SUB_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_COMMUTE_OK"),
+        "Expected O3 memcmp on dynamic pointer aliases and follow-up arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_RAW_ADDR_OK") && stdout.contains("O3_DYNAMIC_RAW_BACK_OK"),
+        "Expected O3 memcmp on dynamic raw address byte offsets. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ADDR_ALIAS_INDEX_OK"),
+        "Expected O3 memcmp on address-of alias pointer indexing. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_ADDR_DEREF_OK"),
+        "Expected O3 memcmp on address-of pointer dereference. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEGADD_PTRADD_OK"),
+        "Expected O3 memcmp on alias plus negative literal pointer arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_LEFT_NEGADD_PTRADD_OK"),
+        "Expected O3 memcmp on negative-left alias pointer arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_SUB_NEG_PTRADD_OK"),
+        "Expected O3 memcmp on subtract-negative alias pointer arithmetic. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYTE_BACK_OK"),
+        "Expected O3 memcmp on raw address plus negative byte offset. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_BYTE_FORWARD_OK"),
+        "Expected O3 memcmp on raw address subtract-negative byte offset. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NEG_INDEX_OK"),
+        "Expected O3 memcmp on address-of negative alias pointer index. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_CONST_EXPR_INDEX_OK"),
+        "Expected O3 memcmp on constant-expression alias pointer index. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_CONST_EXPR_CHAIN_INDEX_OK"),
+        "Expected O3 memcmp on constant-expression alias-of-alias index. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_DIV_INDEX_OK"),
+        "Expected O3 indexed local array division marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_DIV_ALIAS_OK"),
+        "Expected O3 alias local array division marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_NUM_DIV_MIXED_OK"),
+        "Expected O3 mixed local array division marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("O3_DYNAMIC_INDEX_ARRAY_OK")
+            && stdout.contains("O3_DYNAMIC_INDEX_PTR_OK")
+            && stdout.contains("O3_DYNAMIC_INDEX_DIV_OK")
+            && stdout.contains("O3_DYNAMIC_ALIAS_VALUE_OK"),
+        "Expected O3 dynamic array and pointer index markers. STDOUT: {stdout}"
+    );
 
     Ok(())
 }

--- a/e2e-tests/tests/static_scope_execution.rs
+++ b/e2e-tests/tests/static_scope_execution.rs
@@ -1,0 +1,101 @@
+mod common;
+
+use common::{fixture_compiler_available, init, FixtureCompiler, FIXTURES};
+use std::path::Path;
+use std::time::Duration;
+
+async fn run_ghostscope_with_script_for_target(
+    script_content: &str,
+    timeout_secs: u64,
+    target: &common::targets::TargetHandle,
+) -> anyhow::Result<(i32, String, String)> {
+    common::runner::GhostscopeRunner::new()
+        .with_script(script_content)
+        .attach_to(target)
+        .timeout_secs(timeout_secs)
+        .enable_sysmon_shared_lib(false)
+        .run()
+        .await
+}
+
+async fn spawn_static_scope_program(
+    binary_path: &Path,
+) -> anyhow::Result<common::targets::TargetHandle> {
+    let bin_dir = binary_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("static_scope_program has no parent directory"))?;
+    let target = common::targets::TargetLauncher::binary(binary_path)
+        .current_dir(bin_dir)
+        .spawn()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(target)
+}
+
+#[tokio::test]
+async fn test_static_scope_clang_dwarf5_runtime_static_addresses() -> anyhow::Result<()> {
+    init();
+
+    if !fixture_compiler_available(FixtureCompiler::ClangDwarf5) {
+        eprintln!("Skipping clang DWARF5 static-scope runtime test because clang is unavailable");
+        return Ok(());
+    }
+
+    let binary_path = FIXTURES
+        .get_test_binary_with_compiler("static_scope_program", FixtureCompiler::ClangDwarf5)?;
+    let target = spawn_static_scope_program(&binary_path).await?;
+    let script = r#"
+trace static_scope_program.c:18 {
+    print "STATIC_SCOPE:{}:{}:{}", file_scope_static_counter, function_scope_static_counter, regular_local;
+    print "STATIC_SCOPE_DIV:{}:{}", file_scope_static_counter / regular_local, function_scope_static_counter / regular_local;
+    print "STATIC_FUNC_PTR={:p}", &function_scope_static_counter;
+    print "STATIC_FUNC_HEX={:x.0x4}", &function_scope_static_counter;
+    if regular_local / 0x2 == 0x2 { print "STATIC_LOCAL_DIV_OK"; }
+    if function_scope_static_counter / regular_local >= 0x8 { print "STATIC_FUNC_DIV_OK"; }
+}
+"#;
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    let saw_regular_local = stdout.lines().any(|line| {
+        let Some(payload) = line.trim().strip_prefix("STATIC_SCOPE:") else {
+            return false;
+        };
+        let mut fields = payload.split(':');
+        matches!(
+            (fields.next(), fields.next(), fields.next(), fields.next()),
+            (Some(_file_static), Some(_function_static), Some("5"), None)
+        )
+    });
+    assert!(
+        saw_regular_local,
+        "Expected static-scope values and regular_local=5. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("STATIC_FUNC_PTR=0x"),
+        "Expected function-scope static pointer formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("STATIC_FUNC_HEX="),
+        "Expected function-scope static raw memory formatting. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("STATIC_SCOPE_DIV:"),
+        "Expected static-scope division output. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("STATIC_LOCAL_DIV_OK"),
+        "Expected regular local division marker. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("STATIC_FUNC_DIV_OK"),
+        "Expected function-scope static division marker. STDOUT: {stdout}"
+    );
+    assert!(
+        !stdout.contains("ExprError"),
+        "Static-scope runtime tracing should not emit ExprError. STDOUT: {stdout}"
+    );
+    Ok(())
+}

--- a/ghostscope-compiler/src/ebpf/codegen.rs
+++ b/ghostscope-compiler/src/ebpf/codegen.rs
@@ -464,6 +464,61 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             | E::ArrayAccess(_, _)
             | E::PointerDeref(_)
             | E::ChainAccess(_)) => {
+                if let E::ArrayAccess(array_expr, index_expr) = expr {
+                    if let Some((BasicValueEnum::IntValue(value), _element_type)) =
+                        self.compile_dynamic_array_access_value(array_expr, index_expr)?
+                    {
+                        let bitw = value.get_type().get_bit_width();
+                        let (kind, byte_len) = if bitw == 1 {
+                            (TypeKind::Bool, 1)
+                        } else if bitw <= 8 {
+                            (TypeKind::I8, 1)
+                        } else if bitw <= 16 {
+                            (TypeKind::I16, 2)
+                        } else if bitw <= 32 {
+                            (TypeKind::I32, 4)
+                        } else {
+                            (TypeKind::I64, 8)
+                        };
+                        return Ok(ComplexArg {
+                            var_name_index: self
+                                .trace_context
+                                .add_variable_name(self.expr_to_name(expr)),
+                            type_index: self.add_synthesized_type_index_for_kind(kind),
+                            access_path: Vec::new(),
+                            data_len: byte_len,
+                            source: ComplexArgSource::ComputedInt { value, byte_len },
+                        });
+                    }
+                }
+                if let E::MemberAccess(obj_expr, field) = expr {
+                    if let Some((BasicValueEnum::IntValue(value), _member_type)) =
+                        self.compile_dynamic_member_access_value(obj_expr, field)?
+                    {
+                        let bitw = value.get_type().get_bit_width();
+                        let (kind, byte_len) = if bitw == 1 {
+                            (TypeKind::Bool, 1)
+                        } else if bitw <= 8 {
+                            (TypeKind::I8, 1)
+                        } else if bitw <= 16 {
+                            (TypeKind::I16, 2)
+                        } else if bitw <= 32 {
+                            (TypeKind::I32, 4)
+                        } else {
+                            (TypeKind::I64, 8)
+                        };
+                        return Ok(ComplexArg {
+                            var_name_index: self
+                                .trace_context
+                                .add_variable_name(self.expr_to_name(expr)),
+                            type_index: self.add_synthesized_type_index_for_kind(kind),
+                            access_path: Vec::new(),
+                            data_len: byte_len,
+                            source: ComplexArgSource::ComputedInt { value, byte_len },
+                        });
+                    }
+                }
+
                 let plan = self
                     .query_dwarf_for_complex_expr_plan(expr)?
                     .ok_or_else(|| CodeGenError::VariableNotFound(format!("{expr:?}")))?;
@@ -485,120 +540,85 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
 
             // 7) Pointer arithmetic (ptr +/- K) → typed runtime read at computed address
-            E::BinaryOp { left, op, right } => {
-                use crate::script::ast::BinaryOp as BO;
+            E::BinaryOp { .. } => {
                 // Support: ptr + int, int + ptr, ptr - int (int may be negative)
                 // Only allow when ptr side resolves to DWARF pointer/array; the offset must be an integer literal for now.
                 // We emit a RuntimeRead with computed location, preserving the pointed-to DWARF type.
-                let (ptr_side, int_side, sign) = match (&**left, op, &**right) {
-                    (l, BO::Add, E::Int(k)) => (l, *k, 1),
-                    (E::Int(k), BO::Add, r) => (r, *k, 1),
-                    (l, BO::Subtract, E::Int(k)) => (l, *k, -1),
-                    _ => {
-                        // Fallback to generic expression handling below
-                        let compiled = self.compile_expr(expr)?;
-                        if let BasicValueEnum::IntValue(iv) = compiled {
-                            let bitw = iv.get_type().get_bit_width();
-                            let (kind, byte_len) = if bitw == 1 {
-                                (TypeKind::Bool, 1)
-                            } else if bitw <= 8 {
-                                (TypeKind::I8, 1)
-                            } else if bitw <= 16 {
-                                (TypeKind::I16, 2)
-                            } else if bitw <= 32 {
-                                (TypeKind::I32, 4)
-                            } else {
-                                (TypeKind::I64, 8)
-                            };
-                            return Ok(ComplexArg {
-                                var_name_index: self
-                                    .trace_context
-                                    .add_variable_name(self.expr_to_name(expr)),
-                                type_index: self.add_synthesized_type_index_for_kind(kind),
-                                access_path: Vec::new(),
-                                data_len: byte_len,
-                                source: ComplexArgSource::ComputedInt {
-                                    value: iv,
-                                    byte_len,
-                                },
-                            });
-                        } else {
-                            return Err(CodeGenError::TypeError(
-                                "Non-integer expression not supported in print".to_string(),
-                            ));
-                        }
-                    }
-                };
+                let pointer_arithmetic = self.pointer_arithmetic_parts_expanding_aliases(expr)?;
 
                 // Try DWARF resolution for the pointer side
-                if let Some(var) = self.query_dwarf_for_complex_expr(ptr_side)? {
-                    if var.dwarf_type.is_some() {
-                        let index = sign * int_side;
-                        let pointed_plan = var
-                            .plan_pointer_element_index(index)
-                            .map_err(|err| CodeGenError::DwarfError(err.to_string()))?;
-                        let pc_address = self.get_compile_time_context()?.pc_address;
-                        let materialized =
-                            self.variable_read_plan_to_materialization(pointed_plan, pc_address)?;
-                        let elem_ty = materialized.dwarf_type.clone().ok_or_else(|| {
-                            CodeGenError::DwarfError(
-                                "Expression has no DWARF type information".to_string(),
-                            )
-                        })?;
-                        let address = match materialized.materialization {
-                            ghostscope_dwarf::VariableMaterialization::UserMemoryRead {
-                                address,
-                            } => address,
-                            ghostscope_dwarf::VariableMaterialization::Unavailable {
-                                availability,
-                            } => {
-                                return Err(Self::dwarf_expression_unavailable_error(
-                                    &materialized.name,
-                                    &availability,
-                                    pc_address,
-                                ))
+                if let Some((ptr_side, index)) = pointer_arithmetic {
+                    if let Some(var) = self.query_dwarf_for_complex_expr(&ptr_side)? {
+                        if var
+                            .dwarf_type
+                            .as_ref()
+                            .is_some_and(ghostscope_dwarf::is_c_pointer_or_array_type)
+                        {
+                            let pointed_plan = var
+                                .plan_pointer_element_index(index)
+                                .map_err(|err| CodeGenError::DwarfError(err.to_string()))?;
+                            let pc_address = self.get_compile_time_context()?.pc_address;
+                            let materialized = self
+                                .variable_read_plan_to_materialization(pointed_plan, pc_address)?;
+                            let elem_ty = materialized.dwarf_type.clone().ok_or_else(|| {
+                                CodeGenError::DwarfError(
+                                    "Expression has no DWARF type information".to_string(),
+                                )
+                            })?;
+                            let address =
+                                match materialized.materialization {
+                                    ghostscope_dwarf::VariableMaterialization::UserMemoryRead {
+                                        address,
+                                    } => address,
+                                    ghostscope_dwarf::VariableMaterialization::Unavailable {
+                                        availability,
+                                    } => {
+                                        return Err(Self::dwarf_expression_unavailable_error(
+                                            &materialized.name,
+                                            &availability,
+                                            pc_address,
+                                        ))
+                                    }
+                                    _ => return Err(CodeGenError::DwarfError(
+                                        "pointer arithmetic did not produce an address-backed plan"
+                                            .to_string(),
+                                    )),
+                                };
+                            let data_len = Self::compute_read_size_for_type(&elem_ty);
+                            let module_hint = self.take_module_hint();
+                            if data_len == 0 {
+                                // Fallback for unsized/void targets: print computed address as pointer
+                                let ptr_ti = ghostscope_dwarf::TypeInfo::PointerType {
+                                    target_type: Box::new(elem_ty.clone()),
+                                    size: 8,
+                                };
+                                return Ok(ComplexArg {
+                                    var_name_index: self
+                                        .trace_context
+                                        .add_variable_name(self.expr_to_name(expr)),
+                                    type_index: self.trace_context.add_type(ptr_ti),
+                                    access_path: Vec::new(),
+                                    data_len: 8,
+                                    source: ComplexArgSource::AddressValue {
+                                        address,
+                                        module_for_offsets: module_hint,
+                                    },
+                                });
                             }
-                            _ => {
-                                return Err(CodeGenError::DwarfError(
-                                    "pointer arithmetic did not produce an address-backed plan"
-                                        .to_string(),
-                                ))
-                            }
-                        };
-                        let data_len = Self::compute_read_size_for_type(&elem_ty);
-                        let module_hint = self.take_module_hint();
-                        if data_len == 0 {
-                            // Fallback for unsized/void targets: print computed address as pointer
-                            let ptr_ti = ghostscope_dwarf::TypeInfo::PointerType {
-                                target_type: Box::new(elem_ty.clone()),
-                                size: 8,
-                            };
                             return Ok(ComplexArg {
                                 var_name_index: self
                                     .trace_context
                                     .add_variable_name(self.expr_to_name(expr)),
-                                type_index: self.trace_context.add_type(ptr_ti),
+                                type_index: self.trace_context.add_type(elem_ty.clone()),
                                 access_path: Vec::new(),
-                                data_len: 8,
-                                source: ComplexArgSource::AddressValue {
+                                data_len,
+                                source: ComplexArgSource::RuntimeRead {
                                     address,
+                                    dwarf_type: elem_ty,
                                     module_for_offsets: module_hint,
                                 },
                             });
                         }
-                        return Ok(ComplexArg {
-                            var_name_index: self
-                                .trace_context
-                                .add_variable_name(self.expr_to_name(expr)),
-                            type_index: self.trace_context.add_type(elem_ty.clone()),
-                            access_path: Vec::new(),
-                            data_len,
-                            source: ComplexArgSource::RuntimeRead {
-                                address,
-                                dwarf_type: elem_ty,
-                                module_for_offsets: module_hint,
-                            },
-                        });
                     }
                 }
 
@@ -1341,7 +1361,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     /// - AddressOf(...)
     /// - Member/Array/PointerDeref/Chain access
     /// - Variable that is a DWARF-backed symbol (not a script var)
-    /// - Simple constant-offset on top of an aliasy expression: alias + K (K >= 0)
+    /// - Offset arithmetic on top of an aliasy expression: alias +/- integer expression
     fn is_alias_candidate_expr(&mut self, expr: &crate::script::ast::Expr) -> bool {
         use crate::script::ast::BinaryOp as BO;
         use crate::script::ast::Expr as E;
@@ -1356,10 +1376,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 op: BO::Add,
                 right,
             } => {
-                let is_const_nonneg = |e: &E| matches!(e, E::Int(v) if *v >= 0);
-                (self.is_alias_candidate_expr(left) && is_const_nonneg(right))
-                    || (self.is_alias_candidate_expr(right) && is_const_nonneg(left))
+                let left_is_alias = self.is_alias_candidate_expr(left);
+                let right_is_alias = self.is_alias_candidate_expr(right);
+                (left_is_alias && !right_is_alias) || (right_is_alias && !left_is_alias)
             }
+            E::BinaryOp {
+                left,
+                op: BO::Subtract,
+                right,
+            } => self.is_alias_candidate_expr(left) && !self.is_alias_candidate_expr(right),
             // Otherwise, only keep address-like or aggregate DWARF expressions as aliases.
             // Scalar DWARF expressions should stay concrete so `let n = foo.len;` behaves
             // like an integer script variable and remains usable in capture-length formatting.
@@ -1710,6 +1735,47 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     }
 
     /// Compile formatted print statement: collect all variable data and send as PrintComplexFormat instruction
+    fn resolve_memory_format_address(
+        &mut self,
+        expr: &crate::script::ast::Expr,
+    ) -> Result<IntValue<'ctx>> {
+        let val = self.compile_expr(expr).ok();
+        if let Some(BasicValueEnum::PointerValue(pv)) = val {
+            return self
+                .builder
+                .build_ptr_to_int(pv, self.context.i64_type(), "ptr_to_i64")
+                .map_err(|e| CodeGenError::Builder(e.to_string()));
+        }
+
+        if let Some(BasicValueEnum::IntValue(iv)) = val {
+            if let Some(var) = self.query_dwarf_for_complex_expr(expr)? {
+                if let Some(ref ty) = var.dwarf_type {
+                    if matches!(ty, ghostscope_dwarf::TypeInfo::PointerType { .. }) {
+                        let _ = self.take_module_hint();
+                        return Ok(iv);
+                    }
+                }
+            }
+        }
+
+        if let Ok(addr) = self.resolve_ptr_i64_from_expr(expr) {
+            let _ = self.take_module_hint();
+            return Ok(addr);
+        }
+
+        let var = self
+            .query_dwarf_for_complex_expr(expr)?
+            .ok_or_else(|| CodeGenError::VariableNotFound(format!("{expr:?}")))?;
+        let module_hint = self.take_module_hint();
+        let pc_address = self.get_compile_time_context()?.pc_address;
+        self.variable_read_plan_to_lvalue_address_with_hint(
+            &var,
+            pc_address,
+            None,
+            module_hint.as_deref(),
+        )
+    }
+
     fn compile_formatted_print(
         &mut self,
         format: &str,
@@ -1738,6 +1804,28 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             Static(usize),
             Star,
             Capture(String),
+        }
+
+        fn parse_static_len(spec: &str) -> Option<usize> {
+            if spec.chars().all(|c| c.is_ascii_digit()) {
+                return spec.parse::<usize>().ok();
+            }
+            if let Some(hex) = spec.strip_prefix("0x") {
+                if !hex.is_empty() && hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return usize::from_str_radix(hex, 16).ok();
+                }
+            }
+            if let Some(oct) = spec.strip_prefix("0o") {
+                if !oct.is_empty() && oct.chars().all(|c| matches!(c, '0'..='7')) {
+                    return usize::from_str_radix(oct, 8).ok();
+                }
+            }
+            if let Some(bin) = spec.strip_prefix("0b") {
+                if !bin.is_empty() && bin.chars().all(|c| matches!(c, '0' | '1')) {
+                    return usize::from_str_radix(bin, 2).ok();
+                }
+            }
+            None
         }
 
         fn parse_slots(fmt: &str) -> Vec<(Conv, LenSpec)> {
@@ -1775,8 +1863,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 LenSpec::Star
                             } else if let Some(s) = r.strip_suffix('$') {
                                 LenSpec::Capture(s.to_string())
-                            } else if r.chars().all(|c| c.is_ascii_digit()) {
-                                LenSpec::Static(r.parse::<usize>().unwrap_or(0))
+                            } else if let Some(n) = parse_static_len(r) {
+                                LenSpec::Static(n)
                             } else {
                                 LenSpec::None
                             }
@@ -1854,48 +1942,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         LenSpec::Static(n) if ai < args.len() => {
                             // Resolve value expr address
                             let expr = &args[ai];
-                            // Try get pointer address directly from expr value
-                            let val = self.compile_expr(expr).ok();
-                            let mut addr_iv: Option<IntValue> = match val {
-                                Some(BasicValueEnum::PointerValue(pv)) => Some(
-                                    self.builder
-                                        .build_ptr_to_int(pv, self.context.i64_type(), "ptr_to_i64")
-                                        .map_err(|e| CodeGenError::Builder(e.to_string()))?,
-                                ),
-                                _ => None,
-                            };
-                            // If compiled value is IntValue but DWARF type is a pointer, treat the IntValue as an address (pointer value)
-                            if addr_iv.is_none() {
-                                if let Some(BasicValueEnum::IntValue(iv)) = val {
-                                    if let Some(var) = self.query_dwarf_for_complex_expr(expr)? {
-                                        if let Some(ref t) = var.dwarf_type {
-                                            if matches!(
-                                                t,
-                                                ghostscope_dwarf::TypeInfo::PointerType { .. }
-                                            ) {
-                                                addr_iv = Some(iv);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            let addr_iv = if let Some(iv) = addr_iv {
-                                iv
-                            } else {
-                                // Fallback: DWARF address (for arrays/char[N])
-                                let var =
-                                    self.query_dwarf_for_complex_expr(expr)?.ok_or_else(|| {
-                                        CodeGenError::VariableNotFound(format!("{expr:?}"))
-                                    })?;
-                                let mod_hint = self.take_module_hint();
-                                let pc_address = self.get_compile_time_context()?.pc_address;
-                                self.variable_read_plan_to_lvalue_address_with_hint(
-                                    &var,
-                                    pc_address,
-                                    None,
-                                    mod_hint.as_deref(),
-                                )?
-                            };
+                            let addr_iv = self.resolve_memory_format_address(expr)?;
                             complex_args.push(ComplexArg {
                                 var_name_index: self
                                     .trace_context
@@ -1953,47 +2000,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                             // value expression -> dynamic memdump with cap
                             let val_expr = &args[ai + 1];
-                            // Resolve base address either from pointer-typed value or DWARF evaluation
-                            let val = self.compile_expr(val_expr).ok();
-                            let mut addr_iv: Option<IntValue> = match val {
-                                Some(BasicValueEnum::PointerValue(pv)) => Some(
-                                    self.builder
-                                        .build_ptr_to_int(pv, self.context.i64_type(), "ptr_to_i64")
-                                        .map_err(|e| CodeGenError::Builder(e.to_string()))?,
-                                ),
-                                _ => None,
-                            };
-                            if addr_iv.is_none() {
-                                if let Some(BasicValueEnum::IntValue(iv)) = val {
-                                    if let Some(var) =
-                                        self.query_dwarf_for_complex_expr(val_expr)?
-                                    {
-                                        if let Some(ref t) = var.dwarf_type {
-                                            if matches!(
-                                                t,
-                                                ghostscope_dwarf::TypeInfo::PointerType { .. }
-                                            ) {
-                                                addr_iv = Some(iv);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            let addr_iv = if let Some(iv) = addr_iv {
-                                iv
-                            } else {
-                                let var = self.query_dwarf_for_complex_expr(val_expr)?.ok_or_else(
-                                    || CodeGenError::VariableNotFound(format!("{val_expr:?}")),
-                                )?;
-                                let mod_hint = self.take_module_hint();
-                                let pc_address = self.get_compile_time_context()?.pc_address;
-                                self.variable_read_plan_to_lvalue_address_with_hint(
-                                    &var,
-                                    pc_address,
-                                    None,
-                                    mod_hint.as_deref(),
-                                )?
-                            };
+                            let addr_iv = self.resolve_memory_format_address(val_expr)?;
                             // Reserve up to configured per-arg cap for dynamic slices
                             let cap = self.compile_options.mem_dump_cap as usize;
                             complex_args.push(ComplexArg {
@@ -2066,46 +2073,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                             // value
                             let val_expr = &args[ai];
-                            let val = self.compile_expr(val_expr).ok();
-                            let mut addr_iv: Option<IntValue> = match val {
-                                Some(BasicValueEnum::PointerValue(pv)) => Some(
-                                    self.builder
-                                        .build_ptr_to_int(pv, self.context.i64_type(), "ptr_to_i64")
-                                        .map_err(|e| CodeGenError::Builder(e.to_string()))?,
-                                ),
-                                _ => None,
-                            };
-                            if addr_iv.is_none() {
-                                if let Some(BasicValueEnum::IntValue(iv)) = val {
-                                    if let Some(var) =
-                                        self.query_dwarf_for_complex_expr(val_expr)?
-                                    {
-                                        if let Some(ref t) = var.dwarf_type {
-                                            if matches!(
-                                                t,
-                                                ghostscope_dwarf::TypeInfo::PointerType { .. }
-                                            ) {
-                                                addr_iv = Some(iv);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            let addr_iv = if let Some(iv) = addr_iv {
-                                iv
-                            } else {
-                                let var = self.query_dwarf_for_complex_expr(val_expr)?.ok_or_else(
-                                    || CodeGenError::VariableNotFound(format!("{val_expr:?}")),
-                                )?;
-                                let mod_hint = self.take_module_hint();
-                                let pc_address = self.get_compile_time_context()?.pc_address;
-                                self.variable_read_plan_to_lvalue_address_with_hint(
-                                    &var,
-                                    pc_address,
-                                    None,
-                                    mod_hint.as_deref(),
-                                )?
-                            };
+                            let addr_iv = self.resolve_memory_format_address(val_expr)?;
                             let cap = self.compile_options.mem_dump_cap as usize;
                             complex_args.push(ComplexArg {
                                 var_name_index: self
@@ -5115,6 +5083,62 @@ mod tests {
         // Should treat tail as alias (not as value), thus compile_program succeeds
         let res = ctx.compile_program(&program, "alias_stage", &[s1, s2], None, None, None);
         assert!(res.is_ok(), "expected alias-to-alias staging to compile");
+    }
+
+    #[test]
+    fn alias_to_alias_with_negative_const_offset_is_alias_variable() {
+        let context = inkwell::context::Context::create();
+        let opts = CompileOptions::default();
+        let mut ctx = EbpfContext::new(&context, "test_mod", Some(0), &opts).expect("ctx");
+        // let base = &buf[1]; let head = base + -1;
+        let base = crate::script::Statement::AliasDeclaration {
+            name: "base".to_string(),
+            target: crate::script::Expr::AddressOf(Box::new(crate::script::Expr::ArrayAccess(
+                Box::new(crate::script::Expr::Variable("buf".to_string())),
+                Box::new(crate::script::Expr::Int(1)),
+            ))),
+        };
+        let negative_one = crate::script::Expr::BinaryOp {
+            left: Box::new(crate::script::Expr::Int(0)),
+            op: crate::script::BinaryOp::Subtract,
+            right: Box::new(crate::script::Expr::Int(1)),
+        };
+        let head = crate::script::Statement::VarDeclaration {
+            name: "head".to_string(),
+            value: crate::script::Expr::BinaryOp {
+                left: Box::new(crate::script::Expr::Variable("base".to_string())),
+                op: crate::script::BinaryOp::Add,
+                right: Box::new(negative_one),
+            },
+        };
+        let program = crate::script::Program::new();
+        let res = ctx.compile_program(&program, "alias_neg_stage", &[base, head], None, None, None);
+        assert!(
+            res.is_ok(),
+            "expected alias plus negative literal staging to compile"
+        );
+    }
+
+    #[test]
+    fn pointer_arithmetic_parts_fold_negative_literal_offsets() {
+        let negative_one = crate::script::Expr::BinaryOp {
+            left: Box::new(crate::script::Expr::Int(0)),
+            op: crate::script::BinaryOp::Subtract,
+            right: Box::new(crate::script::Expr::Int(1)),
+        };
+        let expr = crate::script::Expr::BinaryOp {
+            left: Box::new(crate::script::Expr::BinaryOp {
+                left: Box::new(crate::script::Expr::Variable("p".to_string())),
+                op: crate::script::BinaryOp::Add,
+                right: Box::new(negative_one),
+            }),
+            op: crate::script::BinaryOp::Add,
+            right: Box::new(crate::script::Expr::Int(3)),
+        };
+        let (base, index) = EbpfContext::<'static, 'static>::pointer_arithmetic_parts(&expr)
+            .expect("pointer arithmetic parts");
+        assert!(matches!(base, crate::script::Expr::Variable(name) if name == "p"));
+        assert_eq!(index, 2);
     }
 
     #[test]

--- a/ghostscope-compiler/src/ebpf/context.rs
+++ b/ghostscope-compiler/src/ebpf/context.rs
@@ -73,9 +73,6 @@ pub struct EbpfContext<'ctx, 'dw> {
     pub di_builder: DebugInfoBuilder<'ctx>,
     pub compile_unit: inkwell::debug_info::DICompileUnit<'ctx>,
 
-    // Register cache for pt_regs access
-    pub register_cache: HashMap<u16, IntValue<'ctx>>,
-
     // === Complete Variable Management System ===
     pub variables: HashMap<String, PointerValue<'ctx>>, // Variable name -> LLVM pointer
     pub var_types: HashMap<String, VarType>,            // Variable name -> type
@@ -194,7 +191,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             map_manager,
             di_builder,
             compile_unit,
-            register_cache: HashMap::new(),
 
             // Initialize variable management system
             variables: HashMap::new(),

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -278,11 +278,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     }
 
     /// Convert DWARF type size to MemoryAccessSize
-    fn dwarf_type_to_memory_access_size(&self, dwarf_type: &TypeInfo) -> MemoryAccessSize {
+    pub(super) fn dwarf_type_to_memory_access_size(
+        &self,
+        dwarf_type: &TypeInfo,
+    ) -> MemoryAccessSize {
         MemoryAccessSize::from_size(dwarf_type.size())
     }
 
-    fn sign_extend_memory_read_if_needed(
+    pub(super) fn sign_extend_memory_read_if_needed(
         &self,
         value: BasicValueEnum<'ctx>,
         dwarf_type: &TypeInfo,
@@ -310,6 +313,55 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .build_int_s_extend(narrowed, self.context.i64_type(), "signed_mem_sext")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         Ok(extended.into())
+    }
+
+    fn normalize_direct_integer_value_if_needed(
+        &mut self,
+        value: BasicValueEnum<'ctx>,
+        dwarf_type: Option<&TypeInfo>,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        let Some(c_type) = dwarf_type.and_then(ghostscope_dwarf::c_integer_comparison_type) else {
+            return Ok(value);
+        };
+        let BasicValueEnum::IntValue(int_value) = value else {
+            return Ok(value);
+        };
+
+        let bit_width = c_type.size.saturating_mul(8).clamp(1, 64) as u32;
+        let current_width = int_value.get_type().get_bit_width();
+        let narrow_type = self.context.custom_width_int_type(bit_width);
+        let narrowed = if current_width > bit_width {
+            self.builder
+                .build_int_truncate(int_value, narrow_type, "direct_int_trunc")
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        } else if current_width < bit_width {
+            if c_type.is_unsigned {
+                self.builder
+                    .build_int_z_extend(int_value, narrow_type, "direct_int_zext_to_type")
+                    .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            } else {
+                self.builder
+                    .build_int_s_extend(int_value, narrow_type, "direct_int_sext_to_type")
+                    .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            }
+        } else {
+            int_value
+        };
+
+        if bit_width == 64 {
+            return Ok(narrowed.into());
+        }
+
+        let normalized = if c_type.is_unsigned {
+            self.builder
+                .build_int_z_extend(narrowed, self.context.i64_type(), "direct_int_zext")
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        } else {
+            self.builder
+                .build_int_s_extend(narrowed, self.context.i64_type(), "direct_int_sext")
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        };
+        Ok(normalized.into())
     }
 
     pub(super) fn variable_read_plan_to_materialization(
@@ -350,7 +402,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     ) -> Result<BasicValueEnum<'ctx>> {
         match &materialization.materialization {
             ghostscope_dwarf::VariableMaterialization::DirectValue { value } => {
-                self.planned_value_to_llvm_value(value, &materialization.name, status_ptr)
+                let value =
+                    self.planned_value_to_llvm_value(value, &materialization.name, status_ptr)?;
+                self.normalize_direct_integer_value_if_needed(
+                    value,
+                    materialization.dwarf_type.as_ref(),
+                )
             }
             ghostscope_dwarf::VariableMaterialization::UserMemoryRead { address } => {
                 let dwarf_type = materialization.dwarf_type.as_ref().ok_or_else(|| {
@@ -437,7 +494,108 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.generate_memory_read(addr, access_size, status_ptr)
         }?;
 
+        if let Some(bitfield_value) =
+            self.extract_bitfield_memory_read_if_needed(read_value, dwarf_type)?
+        {
+            return Ok(bitfield_value);
+        }
+
         self.sign_extend_memory_read_if_needed(read_value, dwarf_type, access_size)
+    }
+
+    fn extract_bitfield_memory_read_if_needed(
+        &self,
+        value: BasicValueEnum<'ctx>,
+        dwarf_type: &TypeInfo,
+    ) -> Result<Option<BasicValueEnum<'ctx>>> {
+        let TypeInfo::BitfieldType {
+            underlying_type,
+            bit_offset,
+            bit_size,
+        } = ghostscope_dwarf::strip_type_aliases(dwarf_type)
+        else {
+            return Ok(None);
+        };
+
+        let bit_size = u32::from(*bit_size).min(64);
+        if bit_size == 0 {
+            return Ok(Some(self.context.i64_type().const_zero().into()));
+        }
+
+        let int_value = value.into_int_value();
+        let current_width = int_value.get_type().get_bit_width();
+        let int64 = if current_width < 64 {
+            self.builder
+                .build_int_z_extend(int_value, self.context.i64_type(), "bitfield_raw_zext")
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        } else if current_width > 64 {
+            self.builder
+                .build_int_truncate(int_value, self.context.i64_type(), "bitfield_raw_trunc")
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        } else {
+            int_value
+        };
+
+        let bit_offset = u32::from(*bit_offset);
+        if bit_offset >= 64 {
+            return Ok(Some(self.context.i64_type().const_zero().into()));
+        }
+
+        let shifted = if bit_offset == 0 {
+            int64
+        } else {
+            self.builder
+                .build_right_shift(
+                    int64,
+                    self.context
+                        .i64_type()
+                        .const_int(u64::from(bit_offset), false),
+                    false,
+                    "bitfield_shift",
+                )
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        };
+
+        let masked = if bit_size == 64 {
+            shifted
+        } else {
+            let mask = (1u64 << bit_size) - 1;
+            self.builder
+                .build_and(
+                    shifted,
+                    self.context.i64_type().const_int(mask, false),
+                    "bitfield_mask",
+                )
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+        };
+
+        if bit_size < 64 && ghostscope_dwarf::is_c_signed_integer_type(underlying_type) {
+            let sign_shift = 64 - bit_size;
+            let shifted_left = self
+                .builder
+                .build_left_shift(
+                    masked,
+                    self.context
+                        .i64_type()
+                        .const_int(u64::from(sign_shift), false),
+                    "bitfield_sign_shift_left",
+                )
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+            let extended = self
+                .builder
+                .build_right_shift(
+                    shifted_left,
+                    self.context
+                        .i64_type()
+                        .const_int(u64::from(sign_shift), false),
+                    true,
+                    "bitfield_sign_extend",
+                )
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+            return Ok(Some(extended.into()));
+        }
+
+        Ok(Some(masked.into()))
     }
 
     /// Execute a semantic runtime expression selected by DWARF read planning.
@@ -533,14 +691,22 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                 PlanExprOp::Div => {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
-                        let result = self
-                            .builder
-                            .build_int_signed_div(a, b, "div")
-                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        let result = self.build_signed_int_div_via_udiv(a, b, "div")?;
                         stack.push(result);
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Div".to_string(),
+                        ));
+                    }
+                }
+
+                PlanExprOp::Mod => {
+                    if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
+                        let result = self.build_signed_int_rem_via_urem(a, b, "mod")?;
+                        stack.push(result);
+                    } else {
+                        return Err(CodeGenError::LLVMError(
+                            "Stack underflow in Mod".to_string(),
                         ));
                     }
                 }
@@ -611,6 +777,109 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in ShiftRight".to_string(),
+                        ));
+                    }
+                }
+
+                PlanExprOp::Shra => {
+                    if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
+                        let result = self
+                            .builder
+                            .build_right_shift(a, b, true, "shra")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(result);
+                    } else {
+                        return Err(CodeGenError::LLVMError(
+                            "Stack underflow in ShiftRightArithmetic".to_string(),
+                        ));
+                    }
+                }
+
+                PlanExprOp::Not => {
+                    if let Some(a) = stack.pop() {
+                        let result = self
+                            .builder
+                            .build_not(a, "not")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(result);
+                    } else {
+                        return Err(CodeGenError::LLVMError(
+                            "Stack underflow in Not".to_string(),
+                        ));
+                    }
+                }
+
+                PlanExprOp::Neg => {
+                    if let Some(a) = stack.pop() {
+                        let result = self
+                            .builder
+                            .build_int_sub(self.context.i64_type().const_zero(), a, "neg")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(result);
+                    } else {
+                        return Err(CodeGenError::LLVMError(
+                            "Stack underflow in Neg".to_string(),
+                        ));
+                    }
+                }
+
+                PlanExprOp::Abs => {
+                    if let Some(a) = stack.pop() {
+                        let zero = self.context.i64_type().const_zero();
+                        let is_neg = self
+                            .builder
+                            .build_int_compare(inkwell::IntPredicate::SLT, a, zero, "abs_neg")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        let negated = self
+                            .builder
+                            .build_int_sub(zero, a, "abs_negated")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        let result = self
+                            .builder
+                            .build_select::<BasicValueEnum<'ctx>, _>(
+                                is_neg,
+                                negated.into(),
+                                a.into(),
+                                "abs",
+                            )
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+                            .into_int_value();
+                        stack.push(result);
+                    } else {
+                        return Err(CodeGenError::LLVMError(
+                            "Stack underflow in Abs".to_string(),
+                        ));
+                    }
+                }
+
+                PlanExprOp::Eq
+                | PlanExprOp::Ne
+                | PlanExprOp::Lt
+                | PlanExprOp::Le
+                | PlanExprOp::Gt
+                | PlanExprOp::Ge => {
+                    if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
+                        let predicate = match op {
+                            PlanExprOp::Eq => inkwell::IntPredicate::EQ,
+                            PlanExprOp::Ne => inkwell::IntPredicate::NE,
+                            PlanExprOp::Lt => inkwell::IntPredicate::SLT,
+                            PlanExprOp::Le => inkwell::IntPredicate::SLE,
+                            PlanExprOp::Gt => inkwell::IntPredicate::SGT,
+                            PlanExprOp::Ge => inkwell::IntPredicate::SGE,
+                            _ => unreachable!(),
+                        };
+                        let cmp = self
+                            .builder
+                            .build_int_compare(predicate, a, b, "cmp")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        let result = self
+                            .builder
+                            .build_int_z_extend(cmp, self.context.i64_type(), "cmp_i64")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(result);
+                    } else {
+                        return Err(CodeGenError::LLVMError(
+                            "Stack underflow in comparison".to_string(),
                         ));
                     }
                 }
@@ -1272,18 +1541,44 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     Ok(Some(base))
                 }
                 crate::script::Expr::ArrayAccess(array, index) => {
-                    let Some(base) = append_segments(array, segments)? else {
-                        return Ok(None);
-                    };
                     let crate::script::Expr::Int(index) = index.as_ref() else {
                         return Err(CodeGenError::NotImplemented(
                             "Only literal integer array indices are supported (TODO)".to_string(),
                         ));
                     };
+
+                    if let Some((array_base, base_index)) =
+                        EbpfContext::<'static, 'static>::pointer_arithmetic_parts(array)
+                    {
+                        let Some(base) = append_segments(array_base, segments)? else {
+                            return Ok(None);
+                        };
+                        let index = base_index.checked_add(*index).ok_or_else(|| {
+                            CodeGenError::TypeError(
+                                "array index offset overflow after pointer arithmetic".to_string(),
+                            )
+                        })?;
+                        segments.push(VariableAccessSegment::ArrayIndex(index));
+                        return Ok(Some(base));
+                    }
+
+                    let Some(base) = append_segments(array, segments)? else {
+                        return Ok(None);
+                    };
                     segments.push(VariableAccessSegment::ArrayIndex(*index));
                     Ok(Some(base))
                 }
                 crate::script::Expr::PointerDeref(inner) => {
+                    if let Some((pointer_base, index)) =
+                        EbpfContext::<'static, 'static>::pointer_arithmetic_parts(inner)
+                    {
+                        let Some(base) = append_segments(pointer_base, segments)? else {
+                            return Ok(None);
+                        };
+                        segments.push(VariableAccessSegment::ArrayIndex(index));
+                        return Ok(Some(base));
+                    }
+
                     let Some(base) = append_segments(inner, segments)? else {
                         return Ok(None);
                     };
@@ -1305,6 +1600,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::script::BinaryOp;
     use crate::script::Expr;
     use ghostscope_dwarf::AddressExpr;
     use ghostscope_dwarf::PlanExprOp;
@@ -1381,6 +1677,57 @@ mod tests {
 
         assert!(matches!(err, CodeGenError::NotImplemented(_)));
         assert!(err.to_string().contains("literal integer array indices"));
+    }
+
+    #[test]
+    fn access_path_from_expr_folds_pointer_arithmetic_array_base() {
+        let expr = Expr::ArrayAccess(
+            Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Variable("numbers".to_string())),
+                    op: BinaryOp::Add,
+                    right: Box::new(Expr::Int(3)),
+                }),
+                op: BinaryOp::Subtract,
+                right: Box::new(Expr::Int(1)),
+            }),
+            Box::new(Expr::Int(2)),
+        );
+
+        let (base, path) = EbpfContext::<'static, 'static>::access_path_from_expr(&expr)
+            .expect("access path should parse")
+            .expect("expression should be flattenable");
+
+        assert_eq!(base, "numbers");
+        assert_eq!(path.segments, vec![VariableAccessSegment::ArrayIndex(4)]);
+        assert_eq!(
+            EbpfContext::<'static, 'static>::access_path_to_string(&base, &path),
+            "numbers[4]"
+        );
+    }
+
+    #[test]
+    fn access_path_from_expr_folds_pointer_arithmetic_deref() {
+        let expr = Expr::PointerDeref(Box::new(Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Variable("numbers".to_string())),
+                op: BinaryOp::Add,
+                right: Box::new(Expr::Int(3)),
+            }),
+            op: BinaryOp::Subtract,
+            right: Box::new(Expr::Int(1)),
+        }));
+
+        let (base, path) = EbpfContext::<'static, 'static>::access_path_from_expr(&expr)
+            .expect("access path should parse")
+            .expect("expression should be flattenable");
+
+        assert_eq!(base, "numbers");
+        assert_eq!(path.segments, vec![VariableAccessSegment::ArrayIndex(2)]);
+        assert_eq!(
+            EbpfContext::<'static, 'static>::access_path_to_string(&base, &path),
+            "numbers[2]"
+        );
     }
 
     #[test]
@@ -1533,6 +1880,177 @@ mod tests {
             .variable_read_plan_to_llvm_value(&plan, 0, None)
             .expect("absolute address value should lower");
         assert!(matches!(value, BasicValueEnum::IntValue(_)));
+    }
+
+    #[test]
+    fn runtime_computed_div_and_mod_lower_without_signed_ir_ops() {
+        let llctx = LlvmContext::create();
+        let opts = crate::CompileOptions::default();
+        let mut ctx = EbpfContext::new(&llctx, "runtime_div_mod", Some(0), &opts).expect("ctx");
+        ctx.create_basic_ebpf_function("f").expect("fn");
+
+        let ty = ghostscope_protocol::TypeInfo::BaseType {
+            name: "long".to_string(),
+            size: 8,
+            encoding: ghostscope_dwarf::constants::DW_ATE_signed.0 as u16,
+        };
+        let div_plan = read_plan(
+            "div_value",
+            "long",
+            Some(ty.clone()),
+            VariableLocation::ComputedValue(vec![
+                PlanExprOp::LoadRegister(0),
+                PlanExprOp::PushConstant(-3),
+                PlanExprOp::Div,
+            ]),
+            Availability::Available,
+        );
+        let mod_plan = read_plan(
+            "mod_value",
+            "long",
+            Some(ty),
+            VariableLocation::ComputedValue(vec![
+                PlanExprOp::LoadRegister(0),
+                PlanExprOp::PushConstant(-3),
+                PlanExprOp::Mod,
+            ]),
+            Availability::Available,
+        );
+
+        let div_value = ctx
+            .variable_read_plan_to_llvm_value(&div_plan, 0, None)
+            .expect("DW_OP_div-style plan should lower");
+        let mod_value = ctx
+            .variable_read_plan_to_llvm_value(&mod_plan, 0, None)
+            .expect("DW_OP_mod-style plan should lower");
+        assert!(matches!(div_value, BasicValueEnum::IntValue(_)));
+        assert!(matches!(mod_value, BasicValueEnum::IntValue(_)));
+
+        let ir = ctx.module.print_to_string().to_string();
+        assert!(
+            !ir.contains(" sdiv "),
+            "runtime DWARF div should not emit LLVM signed division:\n{ir}"
+        );
+        assert!(
+            !ir.contains(" srem "),
+            "runtime DWARF mod should not emit LLVM signed remainder:\n{ir}"
+        );
+        assert!(
+            ir.contains(" udiv "),
+            "runtime DWARF div should lower through unsigned division:\n{ir}"
+        );
+        assert!(
+            ir.contains(" urem "),
+            "runtime DWARF mod should lower through unsigned remainder:\n{ir}"
+        );
+    }
+
+    #[test]
+    fn runtime_computed_common_dwarf_ops_lower() {
+        let llctx = LlvmContext::create();
+        let opts = crate::CompileOptions::default();
+        let mut ctx = EbpfContext::new(&llctx, "runtime_common_ops", Some(0), &opts).expect("ctx");
+        ctx.create_basic_ebpf_function("f").expect("fn");
+
+        let ty = ghostscope_protocol::TypeInfo::BaseType {
+            name: "long".to_string(),
+            size: 8,
+            encoding: ghostscope_dwarf::constants::DW_ATE_signed.0 as u16,
+        };
+        let cases = [
+            (
+                "shra_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(1),
+                    PlanExprOp::Shra,
+                ],
+            ),
+            (
+                "not_value",
+                vec![PlanExprOp::LoadRegister(0), PlanExprOp::Not],
+            ),
+            (
+                "neg_value",
+                vec![PlanExprOp::LoadRegister(0), PlanExprOp::Neg],
+            ),
+            (
+                "abs_value",
+                vec![PlanExprOp::LoadRegister(0), PlanExprOp::Abs],
+            ),
+            (
+                "eq_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(0),
+                    PlanExprOp::Eq,
+                ],
+            ),
+            (
+                "ne_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(0),
+                    PlanExprOp::Ne,
+                ],
+            ),
+            (
+                "lt_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(0),
+                    PlanExprOp::Lt,
+                ],
+            ),
+            (
+                "le_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(0),
+                    PlanExprOp::Le,
+                ],
+            ),
+            (
+                "gt_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(0),
+                    PlanExprOp::Gt,
+                ],
+            ),
+            (
+                "ge_value",
+                vec![
+                    PlanExprOp::LoadRegister(0),
+                    PlanExprOp::PushConstant(0),
+                    PlanExprOp::Ge,
+                ],
+            ),
+        ];
+
+        for (name, ops) in cases {
+            let plan = read_plan(
+                name,
+                "long",
+                Some(ty.clone()),
+                VariableLocation::ComputedValue(ops),
+                Availability::Available,
+            );
+            let value = ctx
+                .variable_read_plan_to_llvm_value(&plan, 0, None)
+                .unwrap_or_else(|err| panic!("{name} should lower: {err:?}"));
+            assert!(matches!(value, BasicValueEnum::IntValue(_)));
+        }
+
+        let ir = ctx.module.print_to_string().to_string();
+        assert!(
+            ir.contains(" ashr "),
+            "DW_OP_shra-style plan should emit arithmetic shift right:\n{ir}"
+        );
+        assert!(
+            ir.contains(" icmp "),
+            "comparison-style DWARF plans should emit integer compares:\n{ir}"
+        );
     }
 
     #[test]

--- a/ghostscope-compiler/src/ebpf/expression.rs
+++ b/ghostscope-compiler/src/ebpf/expression.rs
@@ -222,6 +222,145 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         false
     }
 
+    pub(crate) fn integer_literal_value(expr: &Expr) -> Option<i64> {
+        use crate::script::ast::BinaryOp as BO;
+        use crate::script::ast::Expr as E;
+
+        match expr {
+            E::Int(value) => Some(*value),
+            E::BinaryOp {
+                left,
+                op: BO::Add,
+                right,
+            } => {
+                Self::integer_literal_value(left)?.checked_add(Self::integer_literal_value(right)?)
+            }
+            E::BinaryOp {
+                left,
+                op: BO::Subtract,
+                right,
+            } => {
+                Self::integer_literal_value(left)?.checked_sub(Self::integer_literal_value(right)?)
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn pointer_arithmetic_parts(expr: &Expr) -> Option<(&Expr, i64)> {
+        use crate::script::ast::Expr as E;
+
+        fn collect_offset(expr: &Expr, acc: i64) -> Option<(&Expr, i64)> {
+            use crate::script::ast::BinaryOp as BO;
+            use crate::script::ast::Expr as E;
+
+            match expr {
+                E::BinaryOp {
+                    left,
+                    op: BO::Add,
+                    right,
+                } => match (&**left, &**right) {
+                    (ptr_side, int_expr)
+                        if EbpfContext::<'static, 'static>::integer_literal_value(int_expr)
+                            .is_some() =>
+                    {
+                        let index =
+                            EbpfContext::<'static, 'static>::integer_literal_value(int_expr)?;
+                        collect_offset(ptr_side, acc.checked_add(index)?)
+                    }
+                    (int_expr, ptr_side)
+                        if EbpfContext::<'static, 'static>::integer_literal_value(int_expr)
+                            .is_some() =>
+                    {
+                        let index =
+                            EbpfContext::<'static, 'static>::integer_literal_value(int_expr)?;
+                        collect_offset(ptr_side, acc.checked_add(index)?)
+                    }
+                    _ => Some((expr, acc)),
+                },
+                E::BinaryOp {
+                    left,
+                    op: BO::Subtract,
+                    right,
+                } => match &**right {
+                    int_expr
+                        if EbpfContext::<'static, 'static>::integer_literal_value(int_expr)
+                            .is_some() =>
+                    {
+                        let index =
+                            EbpfContext::<'static, 'static>::integer_literal_value(int_expr)?;
+                        collect_offset(left, acc.checked_sub(index)?)
+                    }
+                    _ => Some((expr, acc)),
+                },
+                _ => Some((expr, acc)),
+            }
+        }
+
+        let E::BinaryOp { .. } = expr else {
+            return None;
+        };
+
+        let (base, index) = collect_offset(expr, 0)?;
+        match base {
+            E::BinaryOp { .. } => None,
+            _ => Some((base, index)),
+        }
+    }
+
+    pub(crate) fn pointer_arithmetic_parts_expanding_aliases(
+        &self,
+        expr: &Expr,
+    ) -> Result<Option<(Expr, i64)>> {
+        let Some((base, index)) = Self::pointer_arithmetic_parts(expr) else {
+            return Ok(None);
+        };
+
+        let mut base = base.clone();
+        let mut index = index;
+        let mut visited = std::collections::HashSet::new();
+
+        loop {
+            let Expr::Variable(name) = &base else {
+                break;
+            };
+            if !self.alias_variable_exists(name) {
+                break;
+            }
+            if !visited.insert(name.clone()) {
+                return Err(CodeGenError::TypeError(format!(
+                    "alias cycle detected for '{name}'"
+                )));
+            }
+            let Some(target) = self.get_alias_variable(name) else {
+                break;
+            };
+            if let Some((alias_base, alias_index)) = Self::pointer_arithmetic_parts(&target) {
+                index = alias_index.checked_add(index).ok_or_else(|| {
+                    CodeGenError::TypeError("pointer arithmetic offset overflow".to_string())
+                })?;
+                base = alias_base.clone();
+            } else {
+                base = target;
+            }
+        }
+
+        Ok(Some((base, index)))
+    }
+
+    fn is_dwarf_pointer_or_array_arg(&mut self, expr: &Expr) -> Result<bool> {
+        let Some(var) = self.query_dwarf_for_complex_expr(expr)? else {
+            return Ok(false);
+        };
+        let Some(ty) = var.dwarf_type.as_ref() else {
+            return Ok(false);
+        };
+        let ty = ghostscope_dwarf::strip_type_aliases(ty);
+        Ok(matches!(
+            ty,
+            DwarfType::PointerType { .. } | DwarfType::ArrayType { .. }
+        ))
+    }
+
     fn dwarf_integer_comparison_expr(&mut self, expr: &Expr) -> Option<CIntegerComparisonType> {
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
@@ -264,6 +403,20 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         if matches!(e, Expr::AddressOf(_)) {
             return Ok(());
         }
+        if let Some((ptr_side, _)) = self.pointer_arithmetic_parts_expanding_aliases(e)? {
+            if matches!(&ptr_side, Expr::AddressOf(_))
+                || self
+                    .is_dwarf_pointer_or_array_arg(&ptr_side)
+                    .unwrap_or(false)
+            {
+                return Ok(());
+            }
+        }
+        if self.is_dynamic_pointer_arithmetic_expr(e)?
+            || self.expands_to_nonliteral_pointer_arithmetic(e)?
+        {
+            return Ok(());
+        }
         match self.query_dwarf_for_complex_expr(e) {
             Ok(Some(var)) => {
                 let Some(ty) = var.dwarf_type.as_ref() else {
@@ -289,6 +442,98 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     "{where_ctx}: expression is not a pointer"
                 ))),
             },
+        }
+    }
+
+    fn is_dynamic_pointer_arithmetic_expr(&mut self, expr: &Expr) -> Result<bool> {
+        use crate::script::ast::BinaryOp as BO;
+        use crate::script::ast::Expr as E;
+
+        let E::BinaryOp { left, op, right } = expr else {
+            return Ok(false);
+        };
+
+        match op {
+            BO::Add => Ok(self.is_dynamic_indexable_pointer_base(left)?
+                || self.is_dynamic_indexable_pointer_base(right)?),
+            BO::Subtract => self.is_dynamic_indexable_pointer_base(left),
+            _ => Ok(false),
+        }
+    }
+
+    fn is_dynamic_indexable_pointer_base(&mut self, expr: &Expr) -> Result<bool> {
+        if matches!(expr, Expr::AddressOf(_)) {
+            return Ok(true);
+        }
+
+        if self
+            .query_dwarf_for_complex_expr(expr)
+            .ok()
+            .flatten()
+            .and_then(|var| var.dwarf_type)
+            .is_some_and(|ty| ghostscope_dwarf::is_c_pointer_or_array_type(&ty))
+        {
+            return Ok(true);
+        }
+
+        let expanded = self.expand_alias_variable_expr(expr)?;
+        if matches!(expanded, Expr::AddressOf(_)) {
+            return Ok(true);
+        }
+        let Some((base_expr, _static_index)) =
+            self.pointer_arithmetic_parts_expanding_aliases(&expanded)?
+        else {
+            return Ok(false);
+        };
+
+        Ok(self
+            .query_dwarf_for_complex_expr(&base_expr)
+            .ok()
+            .flatten()
+            .and_then(|var| var.dwarf_type)
+            .is_some_and(|ty| ghostscope_dwarf::is_c_pointer_or_array_type(&ty)))
+    }
+
+    fn expands_to_nonliteral_pointer_arithmetic(&mut self, expr: &Expr) -> Result<bool> {
+        let expanded = self.expand_alias_variable_expr(expr)?;
+        self.is_nonliteral_pointer_arithmetic_expr(&expanded)
+    }
+
+    fn is_nonliteral_pointer_arithmetic_expr(&mut self, expr: &Expr) -> Result<bool> {
+        use crate::script::ast::BinaryOp as BO;
+        use crate::script::ast::Expr as E;
+
+        let E::BinaryOp { left, op, right } = expr else {
+            return Ok(false);
+        };
+
+        match op {
+            BO::Add => {
+                let left_is_ptr = self.is_dynamic_indexable_pointer_base(left)?;
+                let right_is_ptr = self.is_dynamic_indexable_pointer_base(right)?;
+                let left_is_literal = Self::integer_literal_value(left).is_some();
+                let right_is_literal = Self::integer_literal_value(right).is_some();
+
+                if (left_is_ptr && !right_is_ptr && !right_is_literal)
+                    || (right_is_ptr && !left_is_ptr && !left_is_literal)
+                {
+                    return Ok(true);
+                }
+
+                Ok(self.expands_to_nonliteral_pointer_arithmetic(left)?
+                    || self.expands_to_nonliteral_pointer_arithmetic(right)?)
+            }
+            BO::Subtract => {
+                let left_is_ptr = self.is_dynamic_indexable_pointer_base(left)?;
+                let right_is_literal = Self::integer_literal_value(right).is_some();
+
+                if left_is_ptr && !right_is_literal {
+                    return Ok(true);
+                }
+
+                self.expands_to_nonliteral_pointer_arithmetic(left)
+            }
+            _ => Ok(false),
         }
     }
 
@@ -370,6 +615,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 inner.as_ref()
             };
 
+            if let E::ArrayAccess(array_expr, index_expr) = resolved_inner {
+                if let Some((element_address, _element_type)) =
+                    self.compile_dynamic_array_element_address(array_expr, index_expr)?
+                {
+                    return Ok(element_address);
+                }
+            }
+
             if let Some(var) = self.query_dwarf_for_complex_expr(resolved_inner)? {
                 let module_hint = self.current_resolved_var_module_path.clone();
                 let status_ptr = if self.condition_context_active {
@@ -391,36 +644,81 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
         }
 
+        if let Some(address) = self.dynamic_pointer_arithmetic_address(e)? {
+            return Ok(address);
+        }
+
+        if let Some((ptr_side, index)) = self.pointer_arithmetic_parts_expanding_aliases(e)? {
+            if matches!(&ptr_side, E::AddressOf(_)) {
+                let base =
+                    self.resolve_ptr_i64_from_expr_internal(&ptr_side, visited, depth + 1)?;
+                let off = self.context.i64_type().const_int(index as u64, false);
+                return self
+                    .builder
+                    .build_int_add(base, off, "ptr_add")
+                    .map_err(|err| CodeGenError::Builder(err.to_string()));
+            } else if let Some(var) = self.query_dwarf_for_complex_expr(&ptr_side)? {
+                if var.dwarf_type.is_some() {
+                    let pointed_plan = var
+                        .plan_pointer_element_index(index)
+                        .map_err(|err| CodeGenError::DwarfError(err.to_string()))?;
+                    let module_hint = self.current_resolved_var_module_path.clone();
+                    let status_ptr = if self.condition_context_active {
+                        Some(self.get_or_create_cond_error_global())
+                    } else {
+                        None
+                    };
+                    let pc_address = self.get_compile_time_context()?.pc_address;
+                    return self.variable_read_plan_to_lvalue_address_with_hint(
+                        &pointed_plan,
+                        pc_address,
+                        status_ptr,
+                        module_hint.as_deref(),
+                    );
+                }
+            }
+        }
+
         // Support constant-offset addressing: (alias_expr + K) or (K + alias_expr)
         if let E::BinaryOp { left, op, right } = e {
             if matches!(op, BO::Add) {
-                let is_nonneg_lit = |x: &E| matches!(x, E::Int(v) if *v >= 0);
                 // alias + K
-                if is_nonneg_lit(right) {
+                if let Some(k) = Self::integer_literal_value(right) {
                     if let Ok(base) =
                         self.resolve_ptr_i64_from_expr_internal(left, visited, depth + 1)
                     {
-                        if let E::Int(k) = &**right {
-                            let off = self.context.i64_type().const_int(*k as u64, false);
-                            return self
-                                .builder
-                                .build_int_add(base, off, "ptr_add")
-                                .map_err(|e| CodeGenError::Builder(e.to_string()));
-                        }
+                        let off = self.context.i64_type().const_int(k as u64, false);
+                        return self
+                            .builder
+                            .build_int_add(base, off, "ptr_add")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()));
                     }
                 }
                 // K + alias
-                if is_nonneg_lit(left) {
+                if let Some(k) = Self::integer_literal_value(left) {
                     if let Ok(base) =
                         self.resolve_ptr_i64_from_expr_internal(right, visited, depth + 1)
                     {
-                        if let E::Int(k) = &**left {
-                            let off = self.context.i64_type().const_int(*k as u64, false);
-                            return self
-                                .builder
-                                .build_int_add(base, off, "ptr_add")
-                                .map_err(|e| CodeGenError::Builder(e.to_string()));
-                        }
+                        let off = self.context.i64_type().const_int(k as u64, false);
+                        return self
+                            .builder
+                            .build_int_add(base, off, "ptr_add")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()));
+                    }
+                }
+            } else if matches!(op, BO::Subtract) {
+                if let Some(k) = Self::integer_literal_value(right) {
+                    if let Ok(base) =
+                        self.resolve_ptr_i64_from_expr_internal(left, visited, depth + 1)
+                    {
+                        let off = self
+                            .context
+                            .i64_type()
+                            .const_int(k.wrapping_neg() as u64, false);
+                        return self
+                            .builder
+                            .build_int_add(base, off, "ptr_sub")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()));
                     }
                 }
             }
@@ -488,6 +786,101 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             ))
         }
     }
+
+    fn dynamic_pointer_arithmetic_address(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<Option<IntValue<'ctx>>> {
+        use crate::script::ast::BinaryOp as BO;
+        use crate::script::ast::Expr as E;
+
+        let E::BinaryOp { left, op, right } = expr else {
+            return Ok(None);
+        };
+
+        match op {
+            BO::Add => {
+                if let Some(address) = self.dynamic_raw_address_candidate(left, right, false)? {
+                    return Ok(Some(address));
+                }
+                if let Some(address) = self.dynamic_raw_address_candidate(right, left, false)? {
+                    return Ok(Some(address));
+                }
+                if let Some(address) = self.dynamic_index_address_candidate(left, right)? {
+                    return Ok(Some(address));
+                }
+                self.dynamic_index_address_candidate(right, left)
+            }
+            BO::Subtract => {
+                if let Some(address) = self.dynamic_raw_address_candidate(left, right, true)? {
+                    return Ok(Some(address));
+                }
+                let negative_right = E::BinaryOp {
+                    left: Box::new(E::Int(0)),
+                    op: BO::Subtract,
+                    right: right.clone(),
+                };
+                self.dynamic_index_address_candidate(left, &negative_right)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn dynamic_raw_address_candidate(
+        &mut self,
+        base_expr: &Expr,
+        offset_expr: &Expr,
+        subtract: bool,
+    ) -> Result<Option<IntValue<'ctx>>> {
+        if Self::integer_literal_value(offset_expr).is_some() {
+            return Ok(None);
+        }
+
+        let expanded_base = self.expand_alias_variable_expr(base_expr)?;
+        if !matches!(expanded_base, Expr::AddressOf(_)) {
+            return Ok(None);
+        }
+
+        let base_address = self.resolve_ptr_i64_from_expr(&expanded_base)?;
+        let offset = match self.compile_expr(offset_expr)? {
+            BasicValueEnum::IntValue(value) => {
+                self.normalize_int_to_i64(value, "dynamic_raw_offset_i64")?
+            }
+            _ => {
+                return Err(CodeGenError::TypeError(
+                    "raw address offset expression must compile to an integer".to_string(),
+                ))
+            }
+        };
+        let offset = if subtract {
+            self.builder
+                .build_int_neg(offset, "dynamic_raw_offset_neg")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))?
+        } else {
+            offset
+        };
+        let address = self
+            .builder
+            .build_int_add(base_address, offset, "dynamic_raw_address")
+            .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+        Ok(Some(address))
+    }
+
+    fn dynamic_index_address_candidate(
+        &mut self,
+        base_expr: &Expr,
+        index_expr: &Expr,
+    ) -> Result<Option<IntValue<'ctx>>> {
+        match self.compile_dynamic_array_element_address(base_expr, index_expr) {
+            Ok(Some((address, _element_type))) => Ok(Some(address)),
+            Ok(None) => Ok(None),
+            Err(CodeGenError::VariableNotFound(_))
+            | Err(CodeGenError::VariableNotInScope(_))
+            | Err(CodeGenError::TypeError(_)) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Builtin memcmp (boolean variant): returns true iff first `len` bytes equal.
     /// Supports dynamic `len` (expr), clamped to [0, compare_cap].
     fn compile_memcmp_builtin(
@@ -497,10 +890,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         len_expr: &Expr,
     ) -> Result<BasicValueEnum<'ctx>> {
         // Note: constant hex/len validation happens at parse-time; dynamic cases are handled at runtime by masking bytes.
-        // Important: Clear register cache to avoid reusing register values
-        // loaded in a previous basic block, which can violate SSA dominance
-        // when multiple memcmp calls appear in one function.
-        self.register_cache.clear();
 
         // Note: do not resolve pointers yet; if either side is hex("...") we will synthesize bytes
 
@@ -1006,11 +1395,80 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         Ok(phi.as_basic_value())
     }
     /// Builtin strncmp/starts_with implementation: bounded byte-compare without NUL requirement.
+    fn compile_bounded_compare_len_i32(
+        &mut self,
+        len_expr: &Expr,
+        max_len: u32,
+        name_prefix: &str,
+    ) -> Result<(IntValue<'ctx>, IntValue<'ctx>)> {
+        let len_val = self.compile_expr(len_expr)?;
+        let len_iv = match len_val {
+            BasicValueEnum::IntValue(iv) => iv,
+            _ => {
+                return Err(CodeGenError::TypeError(format!(
+                    "{name_prefix} length must be an integer expression"
+                )))
+            }
+        };
+        let i32_ty = self.context.i32_type();
+        let len_i32 = if len_iv.get_type().get_bit_width() > 32 {
+            self.builder
+                .build_int_truncate(len_iv, i32_ty, &format!("{name_prefix}_len_trunc"))
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?
+        } else if len_iv.get_type().get_bit_width() < 32 {
+            self.builder
+                .build_int_z_extend(len_iv, i32_ty, &format!("{name_prefix}_len_zext"))
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?
+        } else {
+            len_iv
+        };
+        let zero_i32 = i32_ty.const_zero();
+        let is_neg = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::SLT,
+                len_i32,
+                zero_i32,
+                &format!("{name_prefix}_len_neg"),
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let len_nn = self
+            .builder
+            .build_select(is_neg, zero_i32, len_i32, &format!("{name_prefix}_len_nn"))
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
+        let max_const = i32_ty.const_int(max_len as u64, false);
+        let gt = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::UGT,
+                len_nn,
+                max_const,
+                &format!("{name_prefix}_len_gt"),
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let bounded_len = self
+            .builder
+            .build_select(gt, max_const, len_nn, &format!("{name_prefix}_len_sel"))
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
+        let is_zero = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::EQ,
+                bounded_len,
+                zero_i32,
+                &format!("{name_prefix}_len_is_zero"),
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        Ok((bounded_len, is_zero))
+    }
+
     fn compile_strncmp_builtin(
         &mut self,
         dwarf_expr: &Expr,
         lit: &str,
-        n: u32,
+        n_expr: &Expr,
     ) -> Result<BasicValueEnum<'ctx>> {
         // Fast path: if the first argument is a script string variable or a string literal,
         // perform a compile-time bounded comparison and return a constant boolean.
@@ -1034,20 +1492,71 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         };
 
         if let Some(bytes) = immediate_bytes_opt {
+            if let Expr::Int(n) = n_expr {
+                let n_usize = std::cmp::min(
+                    (*n).max(0) as usize,
+                    self.compile_options.compare_cap as usize,
+                );
+                let content_len = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+                let cmp_len = std::cmp::min(n_usize, std::cmp::min(content_len, lit.len()));
+                let equal = bytes.get(0..cmp_len).unwrap_or(&[])
+                    == lit.as_bytes().get(0..cmp_len).unwrap_or(&[]);
+                let bool_val = self
+                    .context
+                    .bool_type()
+                    .const_int(if equal { 1 } else { 0 }, false);
+                return Ok(bool_val.into());
+            }
+
             // Treat as bounded byte compare between two immediate strings
-            let lit_bytes = lit.as_bytes();
             let cap = self.compile_options.compare_cap as usize;
-            let n_usize = std::cmp::min(n as usize, cap);
-            // compute source content length up to NUL
             let content_len = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
-            let cmp_len = std::cmp::min(n_usize, std::cmp::min(content_len, lit_bytes.len()));
-            let equal =
-                bytes.get(0..cmp_len).unwrap_or(&[]) == lit_bytes.get(0..cmp_len).unwrap_or(&[]);
-            let bool_val = self
-                .context
-                .bool_type()
-                .const_int(if equal { 1 } else { 0 }, false);
-            return Ok(bool_val.into());
+            let cmp_bound = std::cmp::min(cap, std::cmp::min(content_len, lit.len())) as u32;
+            if cmp_bound == 0 {
+                return Ok(self.context.bool_type().const_int(1, false).into());
+            }
+            let (bounded_len, _len_is_zero) =
+                self.compile_bounded_compare_len_i32(n_expr, cmp_bound, "strncmp")?;
+            let i32_ty = self.context.i32_type();
+            let i8_ty = self.context.i8_type();
+            let mut acc = i8_ty.const_zero();
+            for (i, (byte, lit_byte)) in bytes
+                .iter()
+                .copied()
+                .zip(lit.as_bytes().iter().copied())
+                .take(cmp_bound as usize)
+                .enumerate()
+            {
+                let active = self
+                    .builder
+                    .build_int_compare(
+                        inkwell::IntPredicate::UGT,
+                        bounded_len,
+                        i32_ty.const_int(i as u64, false),
+                        "strncmp_imm_active",
+                    )
+                    .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+                let diff = i8_ty.const_int((byte ^ lit_byte) as u64, false);
+                let active_diff = self
+                    .builder
+                    .build_select(active, diff, i8_ty.const_zero(), "strncmp_imm_diff")
+                    .map_err(|e| CodeGenError::Builder(e.to_string()))?
+                    .into_int_value();
+                acc = self
+                    .builder
+                    .build_or(acc, active_diff, "strncmp_imm_acc")
+                    .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+            }
+            let equal = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::EQ,
+                    acc,
+                    i8_ty.const_zero(),
+                    "strncmp_imm_eq",
+                )
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+            return Ok(equal.into());
         }
 
         // Determine pointer value (i64) of the target memory (DWARF or alias)
@@ -1112,20 +1621,55 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
         };
 
-        // Cap read length for safety
         let cap = self.compile_options.compare_cap;
-        let max_n = std::cmp::min(n, cap);
-        let lit_len = std::cmp::min(lit.len() as u32, cap);
-        let cmp_len = std::cmp::min(max_n, lit_len);
+        let cmp_bound = std::cmp::min(lit.len() as u32, cap);
+        if cmp_bound == 0 {
+            return Ok(self.context.bool_type().const_int(1, false).into());
+        }
+        let (bounded_len, len_is_zero) =
+            self.compile_bounded_compare_len_i32(n_expr, cmp_bound, "strncmp")?;
 
-        // Read bytes into buffer
-        let (buf_global, status, arr_ty) =
-            self.read_user_bytes_into_buffer(ptr_i64, cmp_len, "_gs_bi_strncmp")?;
+        let curr_block = self.builder.get_insert_block().unwrap();
+        let func = curr_block.get_parent().unwrap();
+        let zero_b = self.context.append_basic_block(func, "strncmp_len_zero");
+        let nz_b = self.context.append_basic_block(func, "strncmp_len_nz");
+        let final_b = self.context.append_basic_block(func, "strncmp_len_cont");
+        self.builder
+            .build_conditional_branch(len_is_zero, zero_b, nz_b)
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+
+        self.builder.position_at_end(zero_b);
+        let bool_true = self.context.bool_type().const_int(1, false);
+        self.builder
+            .build_unconditional_branch(final_b)
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let zero_block = self.builder.get_insert_block().unwrap();
+
+        self.builder.position_at_end(nz_b);
+
+        let (arr_ty, buf_global) = self.get_or_create_i8_buffer(cmp_bound, "_gs_bi_strncmp");
+        let ptr_ty = self.context.ptr_type(AddressSpace::default());
+        let dst_ptr = self
+            .builder
+            .build_bit_cast(buf_global, ptr_ty, "strncmp_dst_ptr")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let src_ptr = self
+            .builder
+            .build_int_to_ptr(ptr_i64, ptr_ty, "strncmp_src_ptr")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let ret = self
+            .create_bpf_helper_call(
+                BPF_FUNC_probe_read_user as u64,
+                &[dst_ptr, bounded_len.into(), src_ptr.into()],
+                self.context.i64_type().into(),
+                "probe_read_user_strncmp",
+            )?
+            .into_int_value();
         let status_ok = self
             .builder
             .build_int_compare(
                 inkwell::IntPredicate::EQ,
-                status,
+                ret,
                 self.context.i64_type().const_zero(),
                 "rd_ok",
             )
@@ -1157,11 +1701,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.builder.position_at_end(cont_b);
         }
 
-        // XOR/OR accumulation over cmp_len bytes
+        // XOR/OR accumulation over the bounded maximum; inactive bytes do not contribute.
         let i32_ty = self.context.i32_type();
         let idx0 = i32_ty.const_zero();
         let mut acc = self.context.i8_type().const_zero();
-        for (i, b) in lit.as_bytes().iter().take(cmp_len as usize).enumerate() {
+        for (i, b) in lit.as_bytes().iter().take(cmp_bound as usize).enumerate() {
             let idx_i = i32_ty.const_int(i as u64, false);
             let ptr_i = unsafe {
                 self.builder
@@ -1181,6 +1725,25 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 .builder
                 .build_xor(ch, expect, "diff")
                 .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+            let active = self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::UGT,
+                    bounded_len,
+                    idx_i,
+                    "strncmp_byte_active",
+                )
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+            let diff = self
+                .builder
+                .build_select(
+                    active,
+                    diff,
+                    self.context.i8_type().const_zero(),
+                    "strncmp_active_diff",
+                )
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?
+                .into_int_value();
             acc = self
                 .builder
                 .build_or(acc, diff, "acc_or")
@@ -1200,7 +1763,18 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .builder
             .build_and(status_ok, eq_bytes, "strncmp_and")
             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
-        Ok(result.into())
+        self.builder
+            .build_unconditional_branch(final_b)
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let nz_block = self.builder.get_insert_block().unwrap();
+
+        self.builder.position_at_end(final_b);
+        let result_phi = self
+            .builder
+            .build_phi(self.context.bool_type(), "strncmp_result")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        result_phi.add_incoming(&[(&bool_true, zero_block), (&result, nz_block)]);
+        Ok(result_phi.as_basic_value())
     }
     /// Compile an expression
     pub fn compile_expr(&mut self, expr: &Expr) -> Result<BasicValueEnum<'ctx>> {
@@ -1337,14 +1911,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             "strncmp expects 3 arguments".into(),
                         ));
                     }
-                    let n = match &args[2] {
-                        Expr::Int(v) if *v >= 0 => *v as u32,
-                        _ => {
-                            return Err(CodeGenError::TypeError(
-                                "strncmp length must be a non-negative integer literal".into(),
-                            ))
-                        }
-                    };
                     // Accept string on either side: string literal or script string variable
                     fn extract_script_string(
                         this: &mut EbpfContext<'_, '_>,
@@ -1369,14 +1935,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     let right_str = extract_script_string(self, &args[1]);
                     match (left_str, right_str) {
                         (Some(ls), Some(rs)) => {
-                            // Both sides strings -> compile-time fold
-                            let ln = n as usize;
-                            let eq = ls.as_bytes().iter().take(ln).eq(rs.as_bytes().iter().take(ln));
-                            let bv = self.context.bool_type().const_int(eq as u64, false);
-                            Ok(bv.into())
+                            let left_expr = Expr::String(ls);
+                            self.compile_strncmp_builtin(&left_expr, &rs, &args[2])
                         }
-                        (Some(ls), None) => self.compile_strncmp_builtin(&args[1], &ls, n),
-                        (None, Some(rs)) => self.compile_strncmp_builtin(&args[0], &rs, n),
+                        (Some(ls), None) => self.compile_strncmp_builtin(&args[1], &ls, &args[2]),
+                        (None, Some(rs)) => self.compile_strncmp_builtin(&args[0], &rs, &args[2]),
                         (None, None) => Err(CodeGenError::TypeError(
                             "strncmp requires at least one string argument (string literal or script string variable) as the first or second parameter".into(),
                         )),
@@ -1417,8 +1980,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             let bv = self.context.bool_type().const_int(ok as u64, false);
                             Ok(bv.into())
                         }
-                        (Some(a), None) => self.compile_strncmp_builtin(&args[1], &a, a.len() as u32),
-                        (None, Some(b)) => self.compile_strncmp_builtin(&args[0], &b, b.len() as u32),
+                        (Some(a), None) => {
+                            let n_expr = Expr::Int(a.len() as i64);
+                            self.compile_strncmp_builtin(&args[1], &a, &n_expr)
+                        }
+                        (None, Some(b)) => {
+                            let n_expr = Expr::Int(b.len() as i64);
+                            self.compile_strncmp_builtin(&args[0], &b, &n_expr)
+                        }
                         (None, None) => Err(CodeGenError::TypeError(
                             "starts_with requires at least one string argument (string literal or script string variable) as the first or second parameter".into(),
                         )),
@@ -1445,7 +2014,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     && (self.is_dwarf_aggregate_expr(left) || self.is_dwarf_aggregate_expr(right))
                 {
                     return Err(CodeGenError::TypeError(
-                        "Unsupported arithmetic/ordered comparison involving struct/union/array. Select a scalar field (e.g., 'obj.field'), or use '&expr + <non-negative literal>' in an alias/address context if you need a raw address."
+                        "Unsupported arithmetic/ordered comparison involving struct/union/array. Select a scalar field (e.g., 'obj.field'), or use '&expr +/- <integer literal>' in an alias/address context if you need a raw address."
                             .to_string(),
                     ));
                 }
@@ -1455,7 +2024,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     && (self.is_pointer_like_expr(left) || self.is_pointer_like_expr(right))
                 {
                     return Err(CodeGenError::TypeError(
-                        "Pointer ordered comparison ('<', '<=', '>', '>=') is not supported. Use '==' or '!=' to compare addresses. If you need to adjust an address, use '&expr + <non-negative literal>' in an alias/address context; to compare values, select a scalar field (e.g., 'obj.field')."
+                        "Pointer ordered comparison ('<', '<=', '>', '>=') is not supported. Use '==' or '!=' to compare addresses. If you need to adjust an address, use '&expr +/- <integer literal>' in an alias/address context; to compare values, select a scalar field (e.g., 'obj.field')."
                             .to_string(),
                     ));
                 }
@@ -1650,6 +2219,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 } else {
                     None
                 };
+                let unsigned_division_width = if matches!(op, BinaryOp::Divide) {
+                    self.unsigned_ordering_width_for_exprs(left, right)
+                } else {
+                    None
+                };
 
                 // Default eager evaluation for other binary ops
                 let left_val = self.compile_expr(left)?;
@@ -1659,6 +2233,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     op.clone(),
                     right_val,
                     unsigned_ordering_width,
+                    unsigned_division_width,
                 )
             }
             Expr::MemberAccess(_, _) => {
@@ -1809,7 +2384,137 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         op: BinaryOp,
         right: BasicValueEnum<'ctx>,
     ) -> Result<BasicValueEnum<'ctx>> {
-        self.compile_binary_op_with_ordering(left, op, right, None)
+        self.compile_binary_op_with_ordering(left, op, right, None, None)
+    }
+
+    pub(crate) fn build_signed_int_div_via_udiv(
+        &mut self,
+        left: IntValue<'ctx>,
+        right: IntValue<'ctx>,
+        name: &str,
+    ) -> Result<IntValue<'ctx>> {
+        let int_type = left.get_type();
+        let zero = int_type.const_zero();
+        let left_is_neg = self
+            .builder
+            .build_int_compare(inkwell::IntPredicate::SLT, left, zero, "sdiv_lhs_neg")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let right_is_neg = self
+            .builder
+            .build_int_compare(inkwell::IntPredicate::SLT, right, zero, "sdiv_rhs_neg")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let neg_left = self
+            .builder
+            .build_int_sub(zero, left, "sdiv_lhs_negated")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let neg_right = self
+            .builder
+            .build_int_sub(zero, right, "sdiv_rhs_negated")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let abs_left = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                left_is_neg,
+                neg_left.into(),
+                left.into(),
+                "sdiv_lhs_abs",
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
+        let abs_right = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                right_is_neg,
+                neg_right.into(),
+                right.into(),
+                "sdiv_rhs_abs",
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
+        let abs_quotient = self
+            .builder
+            .build_int_unsigned_div(abs_left, abs_right, "sdiv_abs_udiv")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let negative_result = self
+            .builder
+            .build_xor(left_is_neg, right_is_neg, "sdiv_result_neg")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let neg_quotient = self
+            .builder
+            .build_int_sub(zero, abs_quotient, "sdiv_negated")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        self.builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                negative_result,
+                neg_quotient.into(),
+                abs_quotient.into(),
+                name,
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))
+            .map(|value| value.into_int_value())
+    }
+
+    pub(crate) fn build_signed_int_rem_via_urem(
+        &mut self,
+        left: IntValue<'ctx>,
+        right: IntValue<'ctx>,
+        name: &str,
+    ) -> Result<IntValue<'ctx>> {
+        let int_type = left.get_type();
+        let zero = int_type.const_zero();
+        let left_is_neg = self
+            .builder
+            .build_int_compare(inkwell::IntPredicate::SLT, left, zero, "srem_lhs_neg")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let right_is_neg = self
+            .builder
+            .build_int_compare(inkwell::IntPredicate::SLT, right, zero, "srem_rhs_neg")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let neg_left = self
+            .builder
+            .build_int_sub(zero, left, "srem_lhs_negated")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let neg_right = self
+            .builder
+            .build_int_sub(zero, right, "srem_rhs_negated")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let abs_left = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                left_is_neg,
+                neg_left.into(),
+                left.into(),
+                "srem_lhs_abs",
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
+        let abs_right = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                right_is_neg,
+                neg_right.into(),
+                right.into(),
+                "srem_rhs_abs",
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
+        let abs_remainder = self
+            .builder
+            .build_int_unsigned_rem(abs_left, abs_right, "srem_abs_urem")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let neg_remainder = self
+            .builder
+            .build_int_sub(zero, abs_remainder, "srem_negated")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        self.builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                left_is_neg,
+                neg_remainder.into(),
+                abs_remainder.into(),
+                name,
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))
+            .map(|value| value.into_int_value())
     }
 
     fn normalize_int_for_unsigned_compare(
@@ -1835,12 +2540,43 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
     }
 
+    fn align_int_widths_for_binary_op(
+        &mut self,
+        left: IntValue<'ctx>,
+        right: IntValue<'ctx>,
+    ) -> Result<(IntValue<'ctx>, IntValue<'ctx>)> {
+        let left_width = left.get_type().get_bit_width();
+        let right_width = right.get_type().get_bit_width();
+        if left_width == right_width {
+            return Ok((left, right));
+        }
+
+        let target_width = left_width.max(right_width);
+        let target_type = self.context.custom_width_int_type(target_width);
+        let left = if left_width < target_width {
+            self.builder
+                .build_int_z_extend(left, target_type, "lhs_width_align")
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?
+        } else {
+            left
+        };
+        let right = if right_width < target_width {
+            self.builder
+                .build_int_z_extend(right, target_type, "rhs_width_align")
+                .map_err(|e| CodeGenError::Builder(e.to_string()))?
+        } else {
+            right
+        };
+        Ok((left, right))
+    }
+
     fn compile_binary_op_with_ordering(
         &mut self,
         left: BasicValueEnum<'ctx>,
         op: BinaryOp,
         right: BasicValueEnum<'ctx>,
         unsigned_ordering_width: Option<u32>,
+        unsigned_division_width: Option<u32>,
     ) -> Result<BasicValueEnum<'ctx>> {
         use inkwell::values::BasicValueEnum::*;
 
@@ -1869,6 +2605,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
         match (left, right) {
             (IntValue(left_int), IntValue(right_int)) => {
+                let (left_int, right_int) =
+                    self.align_int_widths_for_binary_op(left_int, right_int)?;
                 let unsigned_cmp_values = if let Some(bit_width) = unsigned_ordering_width {
                     Some((
                         self.normalize_int_for_unsigned_compare(
@@ -1898,10 +2636,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         .builder
                         .build_int_mul(left_int, right_int, "mul")
                         .map_err(|e| CodeGenError::Builder(e.to_string()))?,
-                    BinaryOp::Divide => self
-                        .builder
-                        .build_int_signed_div(left_int, right_int, "div")
-                        .map_err(|e| CodeGenError::Builder(e.to_string()))?,
+                    BinaryOp::Divide => {
+                        if unsigned_division_width.is_some() {
+                            self.builder
+                                .build_int_unsigned_div(left_int, right_int, "div")
+                                .map_err(|e| CodeGenError::Builder(e.to_string()))?
+                        } else {
+                            self.build_signed_int_div_via_udiv(left_int, right_int, "div")?
+                        }
+                    }
                     // Comparison operators
                     BinaryOp::Equal => {
                         let result = self
@@ -2044,7 +2787,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         Ok(cmp.into())
                     }
                     _ => Err(CodeGenError::TypeError(
-                        "Unsupported operation between aggregate address/pointer and integer: only '==' and '!=' are allowed. If you meant to offset an address, use '&expr + <non-negative literal>' in an alias/address context, or access a scalar field.".to_string(),
+                        "Unsupported operation between aggregate address/pointer and integer: only '==' and '!=' are allowed. If you meant to offset an address, use '&expr +/- <integer literal>' in an alias/address context, or access a scalar field.".to_string(),
                     )),
                 }
             }
@@ -2070,7 +2813,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     Ok(cmp.into())
                 }
                 _ => Err(CodeGenError::TypeError(
-                    "Pointer ordered comparison ('<', '<=', '>', '>=') is not supported. Use '==' or '!=' to compare addresses. If you need to adjust an address, use '&expr + <non-negative literal>' in an alias/address context; to compare values, select a scalar field (e.g., 'obj.field')."
+                    "Pointer ordered comparison ('<', '<=', '>', '>=') is not supported. Use '==' or '!=' to compare addresses. If you need to adjust an address, use '&expr +/- <integer literal>' in an alias/address context; to compare values, select a scalar field (e.g., 'obj.field')."
                         .to_string(),
                 )),
             },
@@ -2210,6 +2953,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         array_expr: &Expr,
         index_expr: &Expr,
     ) -> Result<BasicValueEnum<'ctx>> {
+        if let Some((value, _element_type)) =
+            self.compile_dynamic_array_access_value(array_expr, index_expr)?
+        {
+            return Ok(value);
+        }
+
         // Create an ArrayAccess expression and use the unified DWARF compilation
         let array_access_expr =
             Expr::ArrayAccess(Box::new(array_expr.clone()), Box::new(index_expr.clone()));
@@ -2233,6 +2982,21 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             expr
         );
 
+        if let crate::script::Expr::ArrayAccess(array_expr, index_expr) = expr {
+            if let Some((value, _element_type)) =
+                self.compile_dynamic_array_access_value(array_expr, index_expr)?
+            {
+                return Ok(value);
+            }
+        }
+        if let crate::script::Expr::MemberAccess(obj_expr, field) = expr {
+            if let Some((value, _member_type)) =
+                self.compile_dynamic_member_access_value(obj_expr, field)?
+            {
+                return Ok(value);
+            }
+        }
+
         // Query DWARF for the complex expression
         let compile_context = self.get_compile_time_context()?.clone();
         let variable_plan = match self.query_dwarf_for_complex_expr(expr)? {
@@ -2255,6 +3019,617 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         );
 
         self.variable_materialization_to_llvm_value(&materialized, compile_context.pc_address, None)
+    }
+
+    pub(super) fn compile_dynamic_array_access_value(
+        &mut self,
+        array_expr: &Expr,
+        index_expr: &Expr,
+    ) -> Result<Option<(BasicValueEnum<'ctx>, DwarfType)>> {
+        let Some((element_address, element_type)) =
+            self.compile_dynamic_array_element_address(array_expr, index_expr)?
+        else {
+            return Ok(None);
+        };
+
+        let value = self.read_dynamic_address_value(element_address, &element_type)?;
+        Ok(Some((value, element_type)))
+    }
+
+    pub(super) fn compile_dynamic_member_access_value(
+        &mut self,
+        obj_expr: &Expr,
+        field: &str,
+    ) -> Result<Option<(BasicValueEnum<'ctx>, DwarfType)>> {
+        let Some((object_address, object_type)) = self.dynamic_lvalue_address_and_type(obj_expr)?
+        else {
+            return Ok(None);
+        };
+
+        let Some((element_address, element_type)) =
+            self.dynamic_member_base_address_and_type(object_address, object_type)?
+        else {
+            return Ok(None);
+        };
+        let (member_offset, member_type) =
+            self.dynamic_member_offset_and_type(&element_type, field)?;
+
+        let member_offset = self.context.i64_type().const_int(member_offset, false);
+        let member_address = self
+            .builder
+            .build_int_add(element_address, member_offset, "dynamic_member_address")
+            .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+        let value = self.read_dynamic_address_value(member_address, &member_type)?;
+        Ok(Some((value, member_type)))
+    }
+
+    fn dynamic_lvalue_address_and_type(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<Option<(IntValue<'ctx>, DwarfType)>> {
+        if let Expr::ArrayAccess(array_expr, index_expr) = expr {
+            return self.compile_dynamic_array_element_address(array_expr, index_expr);
+        }
+
+        if self.expands_to_nonliteral_pointer_arithmetic(expr)? {
+            let Some((element_type, _stride)) = self.indexable_element_type_and_stride(expr)?
+            else {
+                return Ok(None);
+            };
+            let element_address = self.resolve_ptr_i64_from_expr(expr)?;
+            return Ok(Some((element_address, element_type)));
+        }
+
+        if let Expr::MemberAccess(obj_expr, field) = expr {
+            let Some((object_address, object_type)) =
+                self.dynamic_lvalue_address_and_type(obj_expr)?
+            else {
+                return Ok(None);
+            };
+            let Some((base_address, aggregate_type)) =
+                self.dynamic_member_base_address_and_type(object_address, object_type)?
+            else {
+                return Ok(None);
+            };
+            let (member_offset, member_type) =
+                self.dynamic_member_offset_and_type(&aggregate_type, field)?;
+            let member_offset = self.context.i64_type().const_int(member_offset, false);
+            let member_address = self
+                .builder
+                .build_int_add(base_address, member_offset, "dynamic_member_lvalue_address")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+            return Ok(Some((member_address, member_type)));
+        }
+
+        Ok(None)
+    }
+
+    fn dynamic_member_base_address_and_type(
+        &mut self,
+        address: IntValue<'ctx>,
+        object_type: DwarfType,
+    ) -> Result<Option<(IntValue<'ctx>, DwarfType)>> {
+        let object_type = self.complete_dynamic_member_element_type(object_type);
+        match ghostscope_dwarf::strip_type_aliases(&object_type) {
+            DwarfType::StructType { .. } | DwarfType::UnionType { .. } => {
+                Ok(Some((address, object_type)))
+            }
+            DwarfType::PointerType { target_type, .. } => {
+                let pointer_value = self.read_dynamic_address_value(address, &object_type)?;
+                let pointer_value = match pointer_value {
+                    BasicValueEnum::IntValue(value) => {
+                        self.normalize_int_to_i64(value, "dynamic_member_pointer_i64")?
+                    }
+                    BasicValueEnum::PointerValue(value) => self
+                        .builder
+                        .build_ptr_to_int(
+                            value,
+                            self.context.i64_type(),
+                            "dynamic_member_pointer_ptr",
+                        )
+                        .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                    _ => {
+                        return Err(CodeGenError::TypeError(
+                            "dynamic member pointer base did not compile to an address".to_string(),
+                        ))
+                    }
+                };
+                let target_type =
+                    self.complete_dynamic_member_element_type(target_type.as_ref().clone());
+                Ok(Some((pointer_value, target_type)))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn dynamic_member_offset_and_type(
+        &self,
+        aggregate_type: &DwarfType,
+        field: &str,
+    ) -> Result<(u64, DwarfType)> {
+        let aggregate_type = self.complete_dynamic_member_element_type(aggregate_type.clone());
+        match ghostscope_dwarf::strip_type_aliases(&aggregate_type) {
+            DwarfType::StructType { members, .. } | DwarfType::UnionType { members, .. } => {
+                let Some(member) = members.iter().find(|member| member.name == field) else {
+                    return Err(CodeGenError::DwarfError(format!(
+                        "member '{field}' not found on dynamic array element type '{}'",
+                        aggregate_type.type_name()
+                    )));
+                };
+                Ok((member.offset, member.member_type.clone()))
+            }
+            other => Err(CodeGenError::TypeError(format!(
+                "dynamic member access requires struct or union element type, got '{}'",
+                other.type_name()
+            ))),
+        }
+    }
+
+    fn compile_dynamic_array_element_address(
+        &mut self,
+        array_expr: &Expr,
+        index_expr: &Expr,
+    ) -> Result<Option<(IntValue<'ctx>, DwarfType)>> {
+        let literal_index = Self::integer_literal_value(index_expr);
+        let expanded_array_expr = self.expand_alias_variable_expr(array_expr)?;
+        let has_dynamic_base =
+            self.expands_to_nonliteral_pointer_arithmetic(&expanded_array_expr)?;
+
+        if literal_index.is_some() && !has_dynamic_base {
+            return Ok(None);
+        }
+
+        let compile_context = self.get_compile_time_context()?.clone();
+        let status_ptr = if self.condition_context_active {
+            Some(self.get_or_create_cond_error_global())
+        } else {
+            None
+        };
+
+        let (element_type, stride, base_address, static_index) = match self
+            .query_dwarf_for_complex_expr(array_expr)?
+        {
+            Some(array_plan) => {
+                let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
+                    CodeGenError::DwarfError(
+                        "Array expression has no DWARF type information".to_string(),
+                    )
+                })?;
+                match ghostscope_dwarf::strip_type_aliases(&array_type) {
+                    DwarfType::ArrayType { element_type, .. } => {
+                        let module_hint = self.current_resolved_var_module_path.clone();
+                        let base_address = self.variable_read_plan_to_lvalue_address_with_hint(
+                            &array_plan,
+                            compile_context.pc_address,
+                            status_ptr,
+                            module_hint.as_deref(),
+                        )?;
+                        (
+                            element_type.as_ref().clone(),
+                            element_type.size().max(1),
+                            base_address,
+                            0,
+                        )
+                    }
+                    DwarfType::PointerType { target_type, .. } => {
+                        let pointer_value = self.variable_read_plan_to_llvm_value(
+                            &array_plan,
+                            compile_context.pc_address,
+                            status_ptr,
+                        )?;
+                        let base_address = match pointer_value {
+                            BasicValueEnum::IntValue(value) => {
+                                self.normalize_int_to_i64(value, "dynamic_array_base_i64")?
+                            }
+                            BasicValueEnum::PointerValue(value) => self
+                                .builder
+                                .build_ptr_to_int(
+                                    value,
+                                    self.context.i64_type(),
+                                    "dynamic_array_base_ptr",
+                                )
+                                .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                            _ => {
+                                return Err(CodeGenError::TypeError(
+                                    "array base pointer did not compile to an address".to_string(),
+                                ))
+                            }
+                        };
+                        (
+                            target_type.as_ref().clone(),
+                            target_type.size().max(1),
+                            base_address,
+                            0,
+                        )
+                    }
+                    other => {
+                        return Err(CodeGenError::TypeError(format!(
+                            "dynamic array index requires array or pointer type, got '{}'",
+                            other.type_name()
+                        )))
+                    }
+                }
+            }
+            None => {
+                if let Some((base_expr, static_index)) =
+                    self.pointer_arithmetic_parts_expanding_aliases(&expanded_array_expr)?
+                {
+                    let array_plan =
+                        self.query_dwarf_for_complex_expr(&base_expr)?
+                            .ok_or_else(|| {
+                                CodeGenError::VariableNotFound(Self::expr_to_debug_string(
+                                    &base_expr,
+                                ))
+                            })?;
+                    let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
+                        CodeGenError::DwarfError(
+                            "Array expression has no DWARF type information".to_string(),
+                        )
+                    })?;
+                    match ghostscope_dwarf::strip_type_aliases(&array_type) {
+                        DwarfType::ArrayType { element_type, .. } => {
+                            let module_hint = self.current_resolved_var_module_path.clone();
+                            let base_address = self
+                                .variable_read_plan_to_lvalue_address_with_hint(
+                                    &array_plan,
+                                    compile_context.pc_address,
+                                    status_ptr,
+                                    module_hint.as_deref(),
+                                )?;
+                            (
+                                element_type.as_ref().clone(),
+                                element_type.size().max(1),
+                                base_address,
+                                static_index,
+                            )
+                        }
+                        DwarfType::PointerType { target_type, .. } => {
+                            let pointer_value = self.variable_read_plan_to_llvm_value(
+                                &array_plan,
+                                compile_context.pc_address,
+                                status_ptr,
+                            )?;
+                            let base_address = match pointer_value {
+                                BasicValueEnum::IntValue(value) => {
+                                    self.normalize_int_to_i64(value, "dynamic_array_base_i64")?
+                                }
+                                BasicValueEnum::PointerValue(value) => self
+                                    .builder
+                                    .build_ptr_to_int(
+                                        value,
+                                        self.context.i64_type(),
+                                        "dynamic_array_base_ptr",
+                                    )
+                                    .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                                _ => {
+                                    return Err(CodeGenError::TypeError(
+                                        "array base pointer did not compile to an address"
+                                            .to_string(),
+                                    ))
+                                }
+                            };
+                            (
+                                target_type.as_ref().clone(),
+                                target_type.size().max(1),
+                                base_address,
+                                static_index,
+                            )
+                        }
+                        other => {
+                            return Err(CodeGenError::TypeError(format!(
+                                "dynamic array index requires array or pointer type, got '{}'",
+                                other.type_name()
+                            )))
+                        }
+                    }
+                } else if has_dynamic_base {
+                    let (element_type, stride) = self
+                        .indexable_element_type_and_stride(&expanded_array_expr)?
+                        .ok_or_else(|| {
+                            CodeGenError::VariableNotFound(Self::expr_to_debug_string(array_expr))
+                        })?;
+                    let base_address = self.resolve_ptr_i64_from_expr(&expanded_array_expr)?;
+                    (element_type, stride, base_address, 0)
+                } else if let Some((base_address, array_type)) =
+                    self.dynamic_lvalue_address_and_type(&expanded_array_expr)?
+                {
+                    match ghostscope_dwarf::strip_type_aliases(&array_type) {
+                        DwarfType::ArrayType { element_type, .. } => (
+                            element_type.as_ref().clone(),
+                            element_type.size().max(1),
+                            base_address,
+                            0,
+                        ),
+                        DwarfType::PointerType { target_type, .. } => {
+                            let pointer_value =
+                                self.read_dynamic_address_value(base_address, &array_type)?;
+                            let base_address = match pointer_value {
+                                BasicValueEnum::IntValue(value) => self
+                                    .normalize_int_to_i64(value, "dynamic_array_member_ptr_i64")?,
+                                BasicValueEnum::PointerValue(value) => self
+                                    .builder
+                                    .build_ptr_to_int(
+                                        value,
+                                        self.context.i64_type(),
+                                        "dynamic_array_member_ptr",
+                                    )
+                                    .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                                _ => {
+                                    return Err(CodeGenError::TypeError(
+                                        "array member pointer did not compile to an address"
+                                            .to_string(),
+                                    ))
+                                }
+                            };
+                            (
+                                target_type.as_ref().clone(),
+                                target_type.size().max(1),
+                                base_address,
+                                0,
+                            )
+                        }
+                        other => {
+                            return Err(CodeGenError::TypeError(format!(
+                                "dynamic array index requires array or pointer type, got '{}'",
+                                other.type_name()
+                            )))
+                        }
+                    }
+                } else {
+                    return Err(CodeGenError::VariableNotFound(Self::expr_to_debug_string(
+                        array_expr,
+                    )));
+                }
+            }
+        };
+
+        let index_value = if let Some(index) = literal_index {
+            self.context.i64_type().const_int(index as u64, true)
+        } else {
+            match self.compile_expr(index_expr)? {
+                BasicValueEnum::IntValue(value) => {
+                    self.normalize_int_to_i64(value, "dynamic_array_index_i64")?
+                }
+                _ => {
+                    return Err(CodeGenError::TypeError(
+                        "array index expression must compile to an integer".to_string(),
+                    ))
+                }
+            }
+        };
+        let index_value = if static_index == 0 {
+            index_value
+        } else {
+            let static_index_value = self.context.i64_type().const_int(static_index as u64, true);
+            self.builder
+                .build_int_add(
+                    index_value,
+                    static_index_value,
+                    "dynamic_array_static_index",
+                )
+                .map_err(|err| CodeGenError::Builder(err.to_string()))?
+        };
+        let stride_value = self.context.i64_type().const_int(stride, false);
+        let byte_offset = self
+            .builder
+            .build_int_mul(index_value, stride_value, "dynamic_array_byte_offset")
+            .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+        let element_address = self
+            .builder
+            .build_int_add(base_address, byte_offset, "dynamic_array_element_address")
+            .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+
+        Ok(Some((element_address, element_type)))
+    }
+
+    fn indexable_element_type_and_stride(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<Option<(DwarfType, u64)>> {
+        use crate::script::ast::BinaryOp as BO;
+        use crate::script::ast::Expr as E;
+
+        let expanded = self.expand_alias_variable_expr(expr)?;
+
+        if let Some(plan) = self.query_dwarf_for_complex_expr(&expanded)? {
+            if let Some(dwarf_type) = plan.dwarf_type {
+                if let Some(info) = Self::element_type_and_stride_from_type(&dwarf_type) {
+                    return Ok(Some(info));
+                }
+            }
+        }
+
+        if let Some((base_expr, _static_index)) =
+            self.pointer_arithmetic_parts_expanding_aliases(&expanded)?
+        {
+            if let Some(plan) = self.query_dwarf_for_complex_expr(&base_expr)? {
+                if let Some(dwarf_type) = plan.dwarf_type {
+                    if let Some(info) = Self::element_type_and_stride_from_type(&dwarf_type) {
+                        return Ok(Some(info));
+                    }
+                }
+            }
+        }
+
+        match expanded {
+            E::BinaryOp {
+                ref left,
+                op: BO::Add,
+                ref right,
+            } => {
+                if let Some(info) = self.indexable_element_type_and_stride(left)? {
+                    return Ok(Some(info));
+                }
+                self.indexable_element_type_and_stride(right)
+            }
+            E::BinaryOp {
+                ref left,
+                op: BO::Subtract,
+                ..
+            } => self.indexable_element_type_and_stride(left),
+            _ => Ok(None),
+        }
+    }
+
+    fn element_type_and_stride_from_type(dwarf_type: &DwarfType) -> Option<(DwarfType, u64)> {
+        match ghostscope_dwarf::strip_type_aliases(dwarf_type) {
+            DwarfType::ArrayType { element_type, .. } => {
+                Some((element_type.as_ref().clone(), element_type.size().max(1)))
+            }
+            DwarfType::PointerType { target_type, .. } => {
+                Some((target_type.as_ref().clone(), target_type.size().max(1)))
+            }
+            _ => None,
+        }
+    }
+
+    fn complete_dynamic_member_element_type(&self, element_type: DwarfType) -> DwarfType {
+        let candidate_name = match ghostscope_dwarf::strip_type_aliases(&element_type) {
+            DwarfType::UnknownType { name } => Some(name.clone()),
+            _ => None,
+        };
+        let Some(candidate_name) = candidate_name else {
+            return element_type;
+        };
+        let Some(resolved) = self.resolve_named_aggregate_type_for_dynamic_member(&candidate_name)
+        else {
+            return element_type;
+        };
+
+        match element_type {
+            DwarfType::TypedefType { name, .. } => DwarfType::TypedefType {
+                name,
+                underlying_type: Box::new(resolved),
+            },
+            DwarfType::QualifiedType {
+                qualifier,
+                underlying_type,
+            } => DwarfType::QualifiedType {
+                qualifier,
+                underlying_type: Box::new(
+                    self.complete_dynamic_member_element_type(*underlying_type),
+                ),
+            },
+            _ => resolved,
+        }
+    }
+
+    fn resolve_named_aggregate_type_for_dynamic_member(&self, name: &str) -> Option<DwarfType> {
+        let analyzer = self.process_analyzer?;
+        let mut candidates = Vec::new();
+        let mut push_candidate = |candidate: &str| {
+            let candidate = candidate.trim();
+            if !candidate.is_empty() && candidate != "void" {
+                candidates.push(candidate.to_string());
+            }
+        };
+
+        push_candidate(name);
+        for prefix in [
+            "const ",
+            "volatile ",
+            "restrict ",
+            "struct ",
+            "class ",
+            "union ",
+        ] {
+            if let Some(stripped) = name.strip_prefix(prefix) {
+                push_candidate(stripped);
+            }
+        }
+
+        let module_path = self
+            .current_resolved_var_module_path
+            .clone()
+            .or_else(|| {
+                self.current_compile_time_context
+                    .as_ref()
+                    .map(|ctx| ctx.module_path.clone())
+            })
+            .map(std::path::PathBuf::from);
+
+        for candidate in candidates {
+            let in_module = module_path.as_ref().and_then(|module_path| {
+                analyzer
+                    .resolve_struct_type_shallow_by_name_in_module(module_path, &candidate)
+                    .or_else(|| {
+                        analyzer
+                            .resolve_union_type_shallow_by_name_in_module(module_path, &candidate)
+                    })
+            });
+            let resolved = in_module
+                .or_else(|| analyzer.resolve_struct_type_shallow_by_name(&candidate))
+                .or_else(|| analyzer.resolve_union_type_shallow_by_name(&candidate));
+            if let Some(resolved) = resolved.filter(|ty| ty.size() > 0) {
+                return Some(resolved);
+            }
+        }
+
+        None
+    }
+
+    fn read_dynamic_address_value(
+        &mut self,
+        address: IntValue<'ctx>,
+        dwarf_type: &DwarfType,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        if ghostscope_dwarf::is_c_aggregate_type(dwarf_type) {
+            let ptr_ty = self.context.ptr_type(AddressSpace::default());
+            let as_ptr = self
+                .builder
+                .build_int_to_ptr(address, ptr_ty, "dynamic_aggregate_ptr")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+            return Ok(as_ptr.into());
+        }
+
+        let access_size = self.dwarf_type_to_memory_access_size(dwarf_type);
+        let value = if self.condition_context_active {
+            self.generate_memory_read_with_status(address, access_size)?
+        } else {
+            self.generate_memory_read(address, access_size, None)?
+        };
+        self.sign_extend_memory_read_if_needed(value, dwarf_type, access_size)
+    }
+
+    fn expand_alias_variable_expr(&self, expr: &Expr) -> Result<Expr> {
+        let mut expanded = expr.clone();
+        let mut visited = std::collections::HashSet::new();
+
+        loop {
+            let Expr::Variable(name) = &expanded else {
+                return Ok(expanded);
+            };
+            if !self.alias_variable_exists(name) {
+                return Ok(expanded);
+            }
+            if !visited.insert(name.clone()) {
+                return Err(CodeGenError::TypeError(format!(
+                    "alias cycle detected for '{name}'"
+                )));
+            }
+            let Some(target) = self.get_alias_variable(name) else {
+                return Ok(expanded);
+            };
+            expanded = target;
+        }
+    }
+
+    fn normalize_int_to_i64(&self, value: IntValue<'ctx>, name: &str) -> Result<IntValue<'ctx>> {
+        let width = value.get_type().get_bit_width();
+        if width == 64 {
+            return Ok(value);
+        }
+
+        if width < 64 {
+            return self
+                .builder
+                .build_int_s_extend(value, self.context.i64_type(), name)
+                .map_err(|err| CodeGenError::Builder(err.to_string()));
+        }
+
+        self.builder
+            .build_int_truncate(value, self.context.i64_type(), name)
+            .map_err(|err| CodeGenError::Builder(err.to_string()))
     }
 
     pub(crate) fn dwarf_expression_unavailable_error(

--- a/ghostscope-compiler/src/ebpf/helper_functions.rs
+++ b/ghostscope-compiler/src/ebpf/helper_functions.rs
@@ -721,11 +721,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         reg_num: u16,
         pt_regs_ptr: PointerValue<'ctx>,
     ) -> Result<BasicValueEnum<'ctx>> {
-        // Check cache first
-        if let Some(cached_value) = self.register_cache.get(&reg_num) {
-            return Ok((*cached_value).into());
-        }
-
         // Map DWARF register number to pt_regs offset
         let pt_regs_offset = self.dwarf_reg_to_pt_regs_offset(reg_num)?;
 
@@ -750,9 +745,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .build_load(i64_type, reg_ptr, &format!("reg_{reg_num}"))
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
 
-        if let BasicValueEnum::IntValue(int_val) = reg_value {
-            // Cache the value
-            self.register_cache.insert(reg_num, int_val);
+        if let BasicValueEnum::IntValue(_) = reg_value {
             Ok(reg_value)
         } else {
             Err(CodeGenError::RegisterMappingError(format!(
@@ -1053,12 +1046,25 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     /// Map DWARF register number to pt_regs offset (simplified)
     pub fn dwarf_reg_to_pt_regs_offset(&self, dwarf_reg: u16) -> Result<usize> {
         // Use platform-specific register mapping to get byte offset
-        let byte_offset = register_mapping::dwarf_reg_to_pt_regs_byte_offset(dwarf_reg)
-            .ok_or_else(|| {
-                CodeGenError::RegisterMappingError(format!(
-                    "Unsupported DWARF register: {dwarf_reg}"
-                ))
-            })?;
+        let byte_offset = register_mapping::dwarf_reg_to_pt_regs_byte_offset(dwarf_reg).ok_or_else(
+            || {
+                let reg_name = register_mapping::dwarf_reg_to_name(dwarf_reg);
+                if matches!(reg_name, Some(name) if name.starts_with("XMM")) {
+                    CodeGenError::RegisterMappingError(format!(
+                        "Unsupported DWARF register: {dwarf_reg} ({}) is a SIMD/FP register; uprobe pt_regs does not expose XMM register values, so optimized float by-value parameters are unavailable unless the compiler spills them to memory",
+                        reg_name.unwrap()
+                    ))
+                } else if let Some(reg_name) = reg_name {
+                    CodeGenError::RegisterMappingError(format!(
+                        "Unsupported DWARF register: {dwarf_reg} ({reg_name})"
+                    ))
+                } else {
+                    CodeGenError::RegisterMappingError(format!(
+                        "Unsupported DWARF register: {dwarf_reg}"
+                    ))
+                }
+            },
+        )?;
 
         // Convert byte offset to u64 array index for pt_regs access
         let u64_index = byte_offset / core::mem::size_of::<u64>();

--- a/ghostscope-compiler/src/script/parser.rs
+++ b/ghostscope-compiler/src/script/parser.rs
@@ -435,6 +435,26 @@ fn parse_expr(pair: Pair<Rule>) -> Result<Expr> {
 
 /// Determine if an expression should be treated as a DWARF alias binding.
 /// This is a purely syntactic check (parser phase) and does not consult DWARF.
+fn integer_literal_value(e: &Expr) -> Option<i64> {
+    use crate::script::ast::BinaryOp as BO;
+    use crate::script::ast::Expr as E;
+
+    match e {
+        E::Int(value) => Some(*value),
+        E::BinaryOp {
+            left,
+            op: BO::Add,
+            right,
+        } => integer_literal_value(left)?.checked_add(integer_literal_value(right)?),
+        E::BinaryOp {
+            left,
+            op: BO::Subtract,
+            right,
+        } => integer_literal_value(left)?.checked_sub(integer_literal_value(right)?),
+        _ => None,
+    }
+}
+
 fn is_alias_expr(e: &Expr) -> bool {
     use crate::script::ast::BinaryOp as BO;
     use crate::script::ast::Expr as E;
@@ -446,9 +466,8 @@ fn is_alias_expr(e: &Expr) -> bool {
             op: BO::Add,
             right,
         } => {
-            let is_nonneg_lit = |x: &E| matches!(x, E::Int(v) if *v >= 0);
-            (is_alias_expr(left) && is_nonneg_lit(right))
-                || (is_alias_expr(right) && is_nonneg_lit(left))
+            (is_alias_expr(left) && integer_literal_value(right).is_some())
+                || (is_alias_expr(right) && integer_literal_value(left).is_some())
         }
         _ => false,
     }
@@ -1038,21 +1057,39 @@ fn parse_builtin_call(pair: Pair<Rule>) -> Result<Expr> {
             })
         }
         Rule::strncmp_call => {
-            // grammar: strncmp("(" expr "," expr "," expr ")") [len must be non-negative integer literal]
+            // grammar: strncmp("(" expr "," expr "," expr ")")
             let arg0 = parse_expr(it.next().ok_or(ParseError::InvalidExpression)?)?;
             let arg1 = parse_expr(it.next().ok_or(ParseError::InvalidExpression)?)?;
             let n_expr_parsed = parse_expr(it.next().ok_or(ParseError::InvalidExpression)?)?;
-            let n_val: i64 = match n_expr_parsed {
-                Expr::Int(v) if v >= 0 => v,
-                _ => {
-                    return Err(ParseError::TypeError(
-                        "strncmp third argument must be a non-negative integer literal".to_string(),
-                    ))
+            let literal_len_opt: Option<isize> = match &n_expr_parsed {
+                Expr::Int(n) => Some(*n as isize),
+                Expr::BinaryOp {
+                    left,
+                    op: BinaryOp::Subtract,
+                    right,
+                } => {
+                    if matches!(left.as_ref(), Expr::Int(0)) {
+                        if let Expr::Int(k) = right.as_ref() {
+                            Some(-(*k as isize))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
                 }
+                _ => None,
             };
+            if literal_len_opt.is_some_and(|n| n < 0) {
+                return Err(ParseError::TypeError(
+                    "strncmp third argument must be non-negative".to_string(),
+                ));
+            }
             // Optional constant fold when both sides are string literals
-            if let (Expr::String(a), Expr::String(b)) = (&arg0, &arg1) {
-                let ln = n_val.max(0) as usize;
+            if let (Expr::String(a), Expr::String(b), Expr::Int(n_val)) =
+                (&arg0, &arg1, &n_expr_parsed)
+            {
+                let ln = (*n_val).max(0) as usize;
                 let eq = a
                     .as_bytes()
                     .iter()
@@ -1062,7 +1099,7 @@ fn parse_builtin_call(pair: Pair<Rule>) -> Result<Expr> {
             }
             Ok(Expr::BuiltinCall {
                 name: "strncmp".to_string(),
-                args: vec![arg0, arg1, Expr::Int(n_val)],
+                args: vec![arg0, arg1, n_expr_parsed],
             })
         }
         Rule::starts_with_call => {
@@ -1318,14 +1355,13 @@ fn parse_chain_access(pair: Pair<Rule>) -> Result<Expr> {
                 chain.push(inner_pair.as_str().to_string());
             }
             Rule::expr => {
-                // Support array index only at the end of the chain (Phase 1: require literal int)
+                // Array tail index can be a literal or a runtime expression.
                 let parsed = parse_expr(inner_pair)?;
-                if !matches!(parsed, Expr::Int(_)) {
-                    return Err(ParseError::UnsupportedFeature(
-                        "array index must be a literal integer (TODO: dynamic index)".to_string(),
-                    ));
-                }
-                opt_index = Some(parsed);
+                opt_index = Some(
+                    integer_literal_value(&parsed)
+                        .map(Expr::Int)
+                        .unwrap_or(parsed),
+                );
             }
             _ => {}
         }
@@ -1357,13 +1393,9 @@ fn parse_array_access(pair: Pair<Rule>) -> Result<Expr> {
 
     let _array_expr = Box::new(Expr::Variable(array_name.as_str().to_string()));
     let parsed_index = parse_expr(index_expr)?;
-
-    // Enforce: array index must be a literal integer at parse stage
-    if !matches!(parsed_index, Expr::Int(_)) {
-        return Err(ParseError::UnsupportedFeature(
-            "array index must be a literal integer (TODO: support non-literal)".to_string(),
-        ));
-    }
+    let parsed_index = integer_literal_value(&parsed_index)
+        .map(Expr::Int)
+        .unwrap_or(parsed_index);
 
     // Build base array access expression
     let mut expr = Expr::ArrayAccess(
@@ -1933,7 +1965,7 @@ trace foo {
 
     #[test]
     fn parse_strncmp_negative_len_rejected() {
-        // Third argument must be a non-negative integer literal
+        // Negative literal lengths are rejected early.
         let script = r#"
 trace foo {
     if strncmp(lhs, rhs, -1) { print "X"; }
@@ -1947,8 +1979,7 @@ trace foo {
     }
 
     #[test]
-    fn parse_strncmp_nonliteral_len_rejected_with_friendly_message() {
-        // len is variable -> reject with friendly message
+    fn parse_strncmp_accepts_nonliteral_len() {
         let script = r#"
 trace foo {
     let n = 3;
@@ -1956,15 +1987,7 @@ trace foo {
 }
 "#;
         let r = parse(script);
-        match r {
-            Err(ParseError::TypeError(msg)) => {
-                assert!(
-                    msg.contains("third argument must be a non-negative integer literal"),
-                    "{msg}"
-                );
-            }
-            other => panic!("expected TypeError for non-literal len, got {other:?}"),
-        }
+        assert!(r.is_ok(), "parse failed: {:?}", r.err());
     }
 
     #[test]
@@ -2143,32 +2166,74 @@ trace foo {
     }
 
     #[test]
-    fn parse_array_index_must_be_literal() {
+    fn parse_array_index_accepts_dynamic_expr() {
         // Dynamic index on top-level array
         let s1 = r#"
 trace foo {
     print arr[i];
 }
 "#;
-        let r1 = parse(s1);
-        assert!(r1.is_err(), "expected error for non-literal array index");
-        if let Err(ParseError::UnsupportedFeature(msg)) = r1 {
-            assert!(
-                msg.contains("array index must be a literal integer"),
-                "unexpected msg: {msg}"
-            );
+        let r1 = parse(s1).expect("dynamic top-level index should parse");
+        match r1.statements.first().expect("trace") {
+            Statement::TracePoint { body, .. } => match &body[0] {
+                Statement::Print(PrintStatement::ComplexVariable(Expr::ArrayAccess(_, index))) => {
+                    assert!(matches!(index.as_ref(), Expr::Variable(name) if name == "i"))
+                }
+                other => panic!("unexpected first print body: {other:?}"),
+            },
+            other => panic!("expected TracePoint, got {other:?}"),
         }
 
         // Dynamic index at chain tail
         let s2 = r#"
 trace foo {
-    print obj.arr[i];
+    print obj.arr[i - (i / 0x8) * 0x8];
 }
 "#;
-        let r2 = parse(s2);
-        assert!(r2.is_err(), "expected error for non-literal chain index");
-        if let Err(ParseError::UnsupportedFeature(msg)) = r2 {
-            assert!(msg.contains("literal integer"), "unexpected msg: {msg}");
+        let r2 = parse(s2).expect("dynamic chain index should parse");
+        match r2.statements.first().expect("trace") {
+            Statement::TracePoint { body, .. } => match &body[0] {
+                Statement::Print(PrintStatement::ComplexVariable(Expr::ArrayAccess(_, index))) => {
+                    assert!(matches!(index.as_ref(), Expr::BinaryOp { .. }))
+                }
+                other => panic!("unexpected first print body: {other:?}"),
+            },
+            other => panic!("expected TracePoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_array_index_accepts_constant_negative_literal() {
+        let script = r#"
+trace foo {
+    print arr[-0x1];
+    print obj.arr[0b10 - 0x3];
+}
+"#;
+        let prog = parse(script).expect("parse ok");
+        let trace = prog.statements.first().expect("trace");
+        match trace {
+            Statement::TracePoint { body, .. } => {
+                match &body[0] {
+                    Statement::Print(PrintStatement::ComplexVariable(Expr::ArrayAccess(
+                        _,
+                        index,
+                    ))) => {
+                        assert!(matches!(index.as_ref(), Expr::Int(-1)));
+                    }
+                    other => panic!("unexpected first print body: {other:?}"),
+                }
+                match &body[1] {
+                    Statement::Print(PrintStatement::ComplexVariable(Expr::ArrayAccess(
+                        _,
+                        index,
+                    ))) => {
+                        assert!(matches!(index.as_ref(), Expr::Int(-1)));
+                    }
+                    other => panic!("unexpected second print body: {other:?}"),
+                }
+            }
+            other => panic!("expected TracePoint, got {other:?}"),
         }
     }
 

--- a/ghostscope-dwarf/src/dwarf_expr/lower.rs
+++ b/ghostscope-dwarf/src/dwarf_expr/lower.rs
@@ -75,6 +75,7 @@ impl ExpressionEvaluator {
                     expr.0.endian(),
                     unit.encoding(),
                     Some(dwarf),
+                    Some(unit),
                     address,
                     get_cfa,
                     function_context,
@@ -166,6 +167,7 @@ impl ExpressionEvaluator {
                                 expr.0.endian(),
                                 unit.encoding(),
                                 Some(dwarf),
+                                Some(unit),
                                 address,
                                 get_cfa,
                                 function_context,
@@ -219,6 +221,7 @@ impl ExpressionEvaluator {
             endian,
             unit.encoding(),
             Some(dwarf),
+            Some(unit),
             address,
             get_cfa,
             function_context,
@@ -303,6 +306,7 @@ impl ExpressionEvaluator {
         endian: DwarfEndian,
         encoding: gimli::Encoding,
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        unit: Option<&gimli::Unit<DwarfReader>>,
         address: u64,
         get_cfa: Option<&dyn Fn(u64) -> Result<Option<crate::core::CfaResult>>>,
         function_context: Option<&FunctionBlocks>,
@@ -319,6 +323,7 @@ impl ExpressionEvaluator {
             endian,
             encoding,
             dwarf,
+            unit,
             address,
             get_cfa,
             function_context,
@@ -387,6 +392,12 @@ impl ExpressionEvaluator {
                     steps: vec![PlanExprOp::PushConstant(value)],
                 })
             }
+            EvaluationResult::DirectValue(DirectValueResult::RegisterValue(register)) => {
+                Some(CfaResult::RegisterPlusOffset {
+                    register,
+                    offset: 0,
+                })
+            }
             EvaluationResult::DirectValue(DirectValueResult::ImplicitValue(bytes))
                 if bytes.len() == 8 =>
             {
@@ -409,6 +420,28 @@ impl ExpressionEvaluator {
         steps
     }
 
+    fn resolve_address_index(
+        dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        unit: Option<&gimli::Unit<DwarfReader>>,
+        index: gimli::DebugAddrIndex<usize>,
+    ) -> Result<u64> {
+        let Some(dwarf) = dwarf else {
+            return Err(anyhow::anyhow!(
+                "DW_OP_addrx requires DWARF context to resolve .debug_addr index {:?}",
+                index
+            ));
+        };
+        let Some(unit) = unit else {
+            return Err(anyhow::anyhow!(
+                "DW_OP_addrx requires unit context to resolve .debug_addr index {:?}",
+                index
+            ));
+        };
+        dwarf.address(unit, index).map_err(|err| {
+            anyhow::anyhow!("failed to resolve DW_OP_addrx index {:?}: {}", index, err)
+        })
+    }
+
     fn has_piece_expression<R>(operations: &[ParsedOperation<R>]) -> bool
     where
         R: Reader<Offset = usize>,
@@ -428,6 +461,7 @@ impl ExpressionEvaluator {
     fn lower_parsed_operations<R>(
         operations: &[ParsedOperation<R>],
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        unit: Option<&gimli::Unit<DwarfReader>>,
         address: u64,
         get_cfa: Option<&dyn Fn(u64) -> Result<Option<crate::core::CfaResult>>>,
         depth: usize,
@@ -442,12 +476,13 @@ impl ExpressionEvaluator {
         // Fast path for single operations - avoid compute processing.
         if operations.len() == 1 {
             if let ParsedOperation::Operation(op) = &operations[0] {
-                return Self::handle_single_operation(op, dwarf, address, get_cfa, depth);
+                return Self::handle_single_operation(op, dwarf, unit, address, get_cfa, depth);
             }
         }
 
         let mut steps = Vec::new();
         let mut has_stack_value = false;
+        let mut has_link_time_address = false;
 
         for op in operations {
             match op {
@@ -536,6 +571,15 @@ impl ExpressionEvaluator {
                 ParsedOperation::Operation(Operation::SignedConstant { value }) => {
                     steps.push(PlanExprOp::PushConstant(*value));
                 }
+                ParsedOperation::Operation(Operation::Address { address }) => {
+                    steps.push(PlanExprOp::PushConstant(*address as i64));
+                    has_link_time_address = true;
+                }
+                ParsedOperation::Operation(Operation::AddressIndex { index }) => {
+                    let resolved = Self::resolve_address_index(dwarf, unit, *index)?;
+                    steps.push(PlanExprOp::PushConstant(resolved as i64));
+                    has_link_time_address = true;
+                }
                 ParsedOperation::Operation(Operation::StackValue) => {
                     has_stack_value = true;
                 }
@@ -595,6 +639,11 @@ impl ExpressionEvaluator {
                 }
                 PlanExprOp::PushConstant(val) => {
                     if has_stack_value {
+                        if has_link_time_address && *val >= 0 {
+                            return Ok(EvaluationResult::DirectValue(
+                                DirectValueResult::AbsoluteAddress(*val as u64),
+                            ));
+                        }
                         return Ok(EvaluationResult::DirectValue(DirectValueResult::Constant(
                             *val,
                         )));
@@ -626,6 +675,13 @@ impl ExpressionEvaluator {
         }
 
         if has_stack_value {
+            if has_link_time_address {
+                if let Some(address) = Self::fold_constant_steps_to_u64(&steps) {
+                    return Ok(EvaluationResult::DirectValue(
+                        DirectValueResult::AbsoluteAddress(address),
+                    ));
+                }
+            }
             Ok(EvaluationResult::DirectValue(
                 DirectValueResult::ComputedValue {
                     steps,
@@ -639,10 +695,28 @@ impl ExpressionEvaluator {
         }
     }
 
+    fn fold_constant_steps_to_u64(steps: &[PlanExprOp]) -> Option<u64> {
+        let mut stack = Vec::new();
+        for step in steps {
+            match step {
+                PlanExprOp::PushConstant(value) => stack.push(*value),
+                PlanExprOp::Add => {
+                    let rhs = stack.pop()?;
+                    let lhs = stack.pop()?;
+                    stack.push(lhs.saturating_add(rhs));
+                }
+                _ => return None,
+            }
+        }
+
+        (stack.len() == 1 && stack[0] >= 0).then_some(stack[0] as u64)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn lower_piece_expression<R>(
         operations: &[ParsedOperation<R>],
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        unit: Option<&gimli::Unit<DwarfReader>>,
         address: u64,
         get_cfa: Option<&dyn Fn(u64) -> Result<Option<crate::core::CfaResult>>>,
         depth: usize,
@@ -682,7 +756,7 @@ impl ExpressionEvaluator {
             let location = if segment.is_empty() {
                 EvaluationResult::Optimized
             } else {
-                Self::lower_parsed_operations(segment, dwarf, address, get_cfa, depth)?
+                Self::lower_parsed_operations(segment, dwarf, unit, address, get_cfa, depth)?
             };
 
             if matches!(location, EvaluationResult::Composite(_)) {
@@ -716,6 +790,7 @@ impl ExpressionEvaluator {
         endian: DwarfEndian,
         encoding: gimli::Encoding,
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        unit: Option<&gimli::Unit<DwarfReader>>,
         address: u64,
         get_cfa: Option<&dyn Fn(u64) -> Result<Option<crate::core::CfaResult>>>,
         function_context: Option<&FunctionBlocks>,
@@ -774,16 +849,17 @@ impl ExpressionEvaluator {
         debug!("Parsed {} operations in expression", operations.len());
 
         if Self::has_piece_expression(&operations) {
-            return Self::lower_piece_expression(&operations, dwarf, address, get_cfa, depth);
+            return Self::lower_piece_expression(&operations, dwarf, unit, address, get_cfa, depth);
         }
 
-        Self::lower_parsed_operations(&operations, dwarf, address, get_cfa, depth)
+        Self::lower_parsed_operations(&operations, dwarf, unit, address, get_cfa, depth)
     }
 
     /// Handle single DWARF operation - fast path without compute processing
     fn handle_single_operation<R>(
         op: &Operation<R>,
         dwarf: Option<&gimli::Dwarf<DwarfReader>>,
+        unit: Option<&gimli::Unit<DwarfReader>>,
         address: u64,
         get_cfa: Option<&dyn Fn(u64) -> Result<Option<crate::core::CfaResult>>>,
         depth: usize,
@@ -868,6 +944,16 @@ impl ExpressionEvaluator {
                 );
                 Ok(EvaluationResult::MemoryLocation(LocationResult::Address(
                     *address,
+                )))
+            }
+            Operation::AddressIndex { index } => {
+                let resolved = Self::resolve_address_index(dwarf, unit, *index)?;
+                debug!(
+                    "Single DW_OP_addrx {:?} -> 0x{:x} - direct memory address",
+                    index, resolved
+                );
+                Ok(EvaluationResult::MemoryLocation(LocationResult::Address(
+                    resolved,
                 )))
             }
 
@@ -1156,6 +1242,7 @@ impl ExpressionEvaluator {
                         location_list_entry.data.0.endian(),
                         unit.encoding(),
                         Some(dwarf),
+                        Some(unit),
                         address,
                         get_cfa,
                         function_context,
@@ -1231,6 +1318,7 @@ impl ExpressionEvaluator {
                                     data.0.endian(),
                                     unit.encoding(),
                                     Some(dwarf),
+                                    Some(unit),
                                     address,
                                     get_cfa,
                                     function_context,
@@ -1267,6 +1355,7 @@ impl ExpressionEvaluator {
                                     data.0.endian(),
                                     unit.encoding(),
                                     Some(dwarf),
+                                    Some(unit),
                                     address,
                                     get_cfa,
                                     function_context,
@@ -1306,6 +1395,7 @@ impl ExpressionEvaluator {
                                     data.0.endian(),
                                     unit.encoding(),
                                     Some(dwarf),
+                                    Some(unit),
                                     address,
                                     get_cfa,
                                     function_context,
@@ -1348,6 +1438,7 @@ impl ExpressionEvaluator {
                                         data.0.endian(),
                                         unit.encoding(),
                                         Some(dwarf),
+                                        Some(unit),
                                         address,
                                         get_cfa,
                                         function_context,
@@ -1391,6 +1482,7 @@ impl ExpressionEvaluator {
                                         data.0.endian(),
                                         unit.encoding(),
                                         Some(dwarf),
+                                        Some(unit),
                                         address,
                                         get_cfa,
                                         function_context,
@@ -1420,6 +1512,7 @@ impl ExpressionEvaluator {
                                 data.0.endian(),
                                 unit.encoding(),
                                 Some(dwarf),
+                                Some(unit),
                                 address,
                                 get_cfa,
                                 function_context,
@@ -1506,6 +1599,7 @@ mod tests {
             RunTimeEndian::Little,
             test_encoding(),
             None,
+            None,
             0,
             None,
             None,
@@ -1577,6 +1671,15 @@ mod tests {
                 "DW_OP_stack_value",
                 vec![constants::DW_OP_lit1.0, constants::DW_OP_stack_value.0],
                 EvaluationResult::DirectValue(DirectValueResult::Constant(1)),
+            ),
+            (
+                "DW_OP_addr stack value",
+                {
+                    let mut bytes = addr_expr(0x1234);
+                    bytes.push(constants::DW_OP_stack_value.0);
+                    bytes
+                },
+                EvaluationResult::DirectValue(DirectValueResult::AbsoluteAddress(0x1234)),
             ),
             (
                 "arithmetic stack value subset",
@@ -1683,6 +1786,7 @@ mod tests {
             RunTimeEndian::Little,
             test_encoding(),
             None,
+            None,
             0,
             Some(&get_cfa),
             None,
@@ -1697,6 +1801,21 @@ mod tests {
                 register: 7,
                 offset: Some(20),
                 size: None,
+            })
+        );
+    }
+
+    #[test]
+    fn dwarf_frame_base_reg_lowers_to_register_cfa() {
+        let cfa = ExpressionEvaluator::evaluation_result_to_cfa(EvaluationResult::DirectValue(
+            DirectValueResult::RegisterValue(6),
+        ));
+
+        assert_eq!(
+            cfa,
+            Some(CfaResult::RegisterPlusOffset {
+                register: 6,
+                offset: 0,
             })
         );
     }
@@ -1794,6 +1913,7 @@ mod tests {
             RunTimeEndian::Little,
             test_encoding(),
             None,
+            None,
             0,
             None,
             None,
@@ -1820,6 +1940,7 @@ mod tests {
             &expr_bytes,
             RunTimeEndian::Little,
             test_encoding(),
+            None,
             None,
             0,
             None,
@@ -1849,6 +1970,7 @@ mod tests {
             RunTimeEndian::Little,
             test_encoding(),
             None,
+            None,
             0,
             Some(&get_cfa),
             None,
@@ -1874,6 +1996,7 @@ mod tests {
             &expr_bytes,
             gimli::RunTimeEndian::Big,
             test_encoding(),
+            None,
             None,
             0,
             None,

--- a/ghostscope-dwarf/src/dwarf_expr/lower.rs
+++ b/ghostscope-dwarf/src/dwarf_expr/lower.rs
@@ -1141,6 +1141,11 @@ impl ExpressionEvaluator {
                     },
                 ))
             }
+            EvaluationResult::DirectValue(DirectValueResult::AbsoluteAddress(addr)) => {
+                Ok(EvaluationResult::DirectValue(
+                    DirectValueResult::AbsoluteAddress(checked_add_u64(addr, byte_offset)?),
+                ))
+            }
             EvaluationResult::Optimized => Ok(EvaluationResult::Optimized),
             EvaluationResult::Composite(_) => Err(anyhow::anyhow!(
                 "DW_OP_implicit_pointer target is a composite location"
@@ -1904,6 +1909,20 @@ mod tests {
             0x10,
         )
         .expect("static address should convert to an implicit pointer value");
+
+        assert_eq!(
+            result,
+            EvaluationResult::DirectValue(DirectValueResult::AbsoluteAddress(0x1244))
+        );
+    }
+
+    #[test]
+    fn implicit_pointer_accepts_target_absolute_address_value() {
+        let result = ExpressionEvaluator::addressable_location_to_pointer_value(
+            EvaluationResult::DirectValue(DirectValueResult::AbsoluteAddress(0x1234)),
+            0x10,
+        )
+        .expect("static address values should convert to an implicit pointer value");
 
         assert_eq!(
             result,

--- a/ghostscope-dwarf/src/dwarf_expr/lower.rs
+++ b/ghostscope-dwarf/src/dwarf_expr/lower.rs
@@ -425,17 +425,28 @@ impl ExpressionEvaluator {
         unit: Option<&gimli::Unit<DwarfReader>>,
         index: gimli::DebugAddrIndex<usize>,
     ) -> Result<u64> {
+        let op = Operation::<DwarfReader>::AddressIndex { index };
         let Some(dwarf) = dwarf else {
-            return Err(anyhow::anyhow!(
-                "DW_OP_addrx requires DWARF context to resolve .debug_addr index {:?}",
-                index
-            ));
+            return Err(
+                crate::dwarf_expr::ops::unsupported_operation_error_with_detail(
+                    "DWARF expression",
+                    &op,
+                    format!(
+                        "DW_OP_addrx requires DWARF context to resolve .debug_addr index {index:?}"
+                    ),
+                ),
+            );
         };
         let Some(unit) = unit else {
-            return Err(anyhow::anyhow!(
-                "DW_OP_addrx requires unit context to resolve .debug_addr index {:?}",
-                index
-            ));
+            return Err(
+                crate::dwarf_expr::ops::unsupported_operation_error_with_detail(
+                    "DWARF expression",
+                    &op,
+                    format!(
+                        "DW_OP_addrx requires unit context to resolve .debug_addr index {index:?}"
+                    ),
+                ),
+            );
         };
         dwarf.address(unit, index).map_err(|err| {
             anyhow::anyhow!("failed to resolve DW_OP_addrx index {:?}: {}", index, err)

--- a/ghostscope-platform/src/register_mapping.rs
+++ b/ghostscope-platform/src/register_mapping.rs
@@ -124,6 +124,22 @@ pub fn dwarf_reg_to_name_x86_64(dwarf_reg: u16) -> Option<&'static str> {
         14 => Some("R14"), // DWARF 14 = R14
         15 => Some("R15"), // DWARF 15 = R15
         16 => Some("RIP"), // DWARF 16 = RIP
+        17 => Some("XMM0"),
+        18 => Some("XMM1"),
+        19 => Some("XMM2"),
+        20 => Some("XMM3"),
+        21 => Some("XMM4"),
+        22 => Some("XMM5"),
+        23 => Some("XMM6"),
+        24 => Some("XMM7"),
+        25 => Some("XMM8"),
+        26 => Some("XMM9"),
+        27 => Some("XMM10"),
+        28 => Some("XMM11"),
+        29 => Some("XMM12"),
+        30 => Some("XMM13"),
+        31 => Some("XMM14"),
+        32 => Some("XMM15"),
         _ => None,
     }
 }
@@ -159,6 +175,7 @@ mod tests {
         assert_eq!(dwarf_reg_to_pt_regs_byte_offset_x86_64(6), Some(32)); // RBP
         assert_eq!(dwarf_reg_to_pt_regs_byte_offset_x86_64(7), Some(152)); // RSP
         assert_eq!(dwarf_reg_to_pt_regs_byte_offset_x86_64(16), Some(128)); // RIP
+        assert_eq!(dwarf_reg_to_pt_regs_byte_offset_x86_64(17), None); // XMM0
 
         // Test invalid register
         assert_eq!(dwarf_reg_to_pt_regs_byte_offset_x86_64(99), None);
@@ -181,6 +198,8 @@ mod tests {
 
         // Test special registers
         assert_eq!(dwarf_reg_to_name_x86_64(16), Some("RIP"));
+        assert_eq!(dwarf_reg_to_name_x86_64(17), Some("XMM0"));
+        assert_eq!(dwarf_reg_to_name_x86_64(32), Some("XMM15"));
 
         // Test invalid register
         assert_eq!(dwarf_reg_to_name_x86_64(99), None);


### PR DESCRIPTION
This PR expands GhostScope support for highly optimized C programs, especially cases where DWARF expressions and script aliases resolve through runtime-computed addresses.