### PR TITLE
fix: handle short-lived -t executable targets

### DIFF
--- a/e2e-tests/compile-fixtures.sh
+++ b/e2e-tests/compile-fixtures.sh
@@ -61,6 +61,9 @@ run_make_fixture globals_program all
 run_make_fixture late_globals_program clean
 run_make_fixture late_globals_program all
 
+run_make_fixture short_lived_long_comm_program clean
+run_make_fixture short_lived_long_comm_program all
+
 run_make_fixture scalar_types_program clean
 run_make_fixture scalar_types_program all
 

--- a/e2e-tests/tests/common/mod.rs
+++ b/e2e-tests/tests/common/mod.rs
@@ -30,6 +30,8 @@ lazy_static! {
     static ref COMPILE_GLOBALS_OPTIMIZED_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
     static ref COMPILE_LATE_GLOBALS_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
+    static ref COMPILE_SHORT_LIVED_LONG_COMM_RESULT: Mutex<Option<anyhow::Result<()>>> =
+        Mutex::new(None);
     static ref COMPILE_SCALAR_TYPES_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_SCALAR_TYPES_OPTIMIZED_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
@@ -70,6 +72,7 @@ enum RegisteredFixtureKind {
     MemberPointer,
     Globals,
     LateGlobals,
+    ShortLivedLongComm,
     ScalarTypes,
     RustGlobal,
     InlineCallsite,
@@ -126,6 +129,12 @@ const REGISTERED_FIXTURES: &[RegisteredFixture] = &[
         directory: "late_globals_program",
         cleanup: CleanupCommand::Make,
         kind: RegisteredFixtureKind::LateGlobals,
+    },
+    RegisteredFixture {
+        name: "short_lived_long_comm_program",
+        directory: "short_lived_long_comm_program",
+        cleanup: CleanupCommand::Make,
+        kind: RegisteredFixtureKind::ShortLivedLongComm,
     },
     RegisteredFixture {
         name: "scalar_types_program",
@@ -423,6 +432,10 @@ impl RegisteredFixture {
             RegisteredFixtureKind::LateGlobals => {
                 ensure_late_globals_program_compiled()?;
                 Ok(dir.join("late_globals_program"))
+            }
+            RegisteredFixtureKind::ShortLivedLongComm => {
+                ensure_short_lived_long_comm_program_compiled()?;
+                Ok(dir.join("short_lived_long_comm_program"))
             }
             RegisteredFixtureKind::ScalarTypes => {
                 let bin_name = match opt_level {
@@ -1205,6 +1218,7 @@ pub mod termination;
 static COMPILE_GLOBALS: Once = Once::new();
 static COMPILE_GLOBALS_OPTIMIZED: Once = Once::new();
 static COMPILE_LATE_GLOBALS: Once = Once::new();
+static COMPILE_SHORT_LIVED_LONG_COMM: Once = Once::new();
 static COMPILE_SCALAR_TYPES: Once = Once::new();
 static COMPILE_SCALAR_TYPES_OPTIMIZED: Once = Once::new();
 static COMPILE_RUST_GLOBAL: Once = Once::new();
@@ -1337,6 +1351,49 @@ fn ensure_late_globals_program_compiled() -> anyhow::Result<()> {
     });
 
     match COMPILE_LATE_GLOBALS_RESULT.lock().unwrap().as_ref() {
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+        None => panic!("Compilation result should be set after call_once"),
+    }
+}
+
+fn ensure_short_lived_long_comm_program_compiled() -> anyhow::Result<()> {
+    COMPILE_SHORT_LIVED_LONG_COMM.call_once(|| {
+        let compile_result = (|| -> anyhow::Result<()> {
+            let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/short_lived_long_comm_program");
+            if let Some(result) = use_precompiled_outputs(
+                "short_lived_long_comm_program",
+                &[base.join("short_lived_long_comm_program")],
+            ) {
+                return result;
+            }
+            println!("Compiling short_lived_long_comm_program (Debug) in {base:?}");
+            let _ = Command::new("make")
+                .arg("clean")
+                .current_dir(base.clone())
+                .status()
+                .is_ok();
+            let out = Command::new("make").arg("all").current_dir(base).output()?;
+            if out.status.success() {
+                println!("✓ Successfully compiled short_lived_long_comm_program");
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                Err(anyhow::anyhow!(
+                    "Failed to compile short_lived_long_comm_program: {}",
+                    stderr
+                ))
+            }
+        })();
+        *COMPILE_SHORT_LIVED_LONG_COMM_RESULT.lock().unwrap() = Some(compile_result);
+    });
+
+    match COMPILE_SHORT_LIVED_LONG_COMM_RESULT
+        .lock()
+        .unwrap()
+        .as_ref()
+    {
         Some(Ok(())) => Ok(()),
         Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
         None => panic!("Compilation result should be set after call_once"),

--- a/e2e-tests/tests/common/targets.rs
+++ b/e2e-tests/tests/common/targets.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use std::env;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::process::Output;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -173,6 +174,34 @@ pub(crate) fn ensure_target_binary_ready_for_default_sandbox(
     Ok(sandbox)
 }
 
+pub(crate) fn run_binary_to_completion(
+    sandbox: &SandboxHandle,
+    binary_path: &Path,
+    working_dir: Option<&Path>,
+) -> Result<Output> {
+    let binary_path = sandbox.path_in_sandbox(binary_path)?;
+    let working_dir = working_dir
+        .map(|path| sandbox.path_in_sandbox(path))
+        .transpose()?
+        .or_else(|| binary_path.parent().map(Path::to_path_buf));
+
+    // This helper intentionally does not construct TargetHandle. Short-lived
+    // `-t` targets do not need a PID handle, and TargetLauncher waits for
+    // `/proc/<pid>/status` so it can resolve PID mappings for `-p`-style
+    // assertions. That PID settle path can outlive a process that only fires
+    // one probe, while `-t` only needs the binary to execute in the target
+    // sandbox topology.
+    let command = match working_dir {
+        Some(dir) => format!(
+            "cd {} && exec {}",
+            shell_quote(&dir.display().to_string()),
+            shell_quote(&binary_path.display().to_string())
+        ),
+        None => format!("exec {}", shell_quote(&binary_path.display().to_string())),
+    };
+    sandbox.run_shell(&command)
+}
+
 impl TargetHandle {
     pub fn sandbox(&self) -> &SandboxHandle {
         &self.inner.sandbox
@@ -337,6 +366,10 @@ async fn spawn_binary_target(
             },
         }),
     })
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r#"'"'"'"#))
 }
 
 fn default_target_launch_mode() -> Result<TargetLaunchMode> {

--- a/e2e-tests/tests/fixtures/short_lived_long_comm_program/Makefile
+++ b/e2e-tests/tests/fixtures/short_lived_long_comm_program/Makefile
@@ -1,0 +1,18 @@
+CC ?= gcc
+BASE_CFLAGS ?= -Wall -Wextra -g
+CFLAGS ?= $(BASE_CFLAGS) -O0
+BINARY ?= short_lived_long_comm_program
+OBJ ?= $(BINARY).o
+
+all: $(BINARY)
+
+$(BINARY): $(OBJ)
+	$(CC) $(CFLAGS) -o $@ $^
+
+$(OBJ): short_lived_long_comm_program.c
+	$(CC) $(CFLAGS) -c -o $@ short_lived_long_comm_program.c
+
+clean:
+	rm -f *.o short_lived_long_comm_program
+
+.PHONY: clean all

--- a/e2e-tests/tests/fixtures/short_lived_long_comm_program/short_lived_long_comm_program.c
+++ b/e2e-tests/tests/fixtures/short_lived_long_comm_program/short_lived_long_comm_program.c
@@ -1,0 +1,19 @@
+#include <unistd.h>
+
+volatile int short_lived_global = 41;
+
+__attribute__((noinline)) int short_lived_probe(void) {
+    return short_lived_global;
+}
+
+int main(void) {
+    /*
+     * Give sysmon a narrow window to consume sched_process_exec and prefill
+     * offsets, then fire exactly one probe before periodic refresh can recover
+     * a missed exec event.
+     */
+    usleep(100000);
+    int value = short_lived_probe();
+    usleep(10000);
+    return value == 41 ? 0 : 1;
+}

--- a/e2e-tests/tests/globals_target_execution.rs
+++ b/e2e-tests/tests/globals_target_execution.rs
@@ -366,6 +366,72 @@ trace globals_program.c:32 {
 
 #[tokio::test]
 #[serial(globals_target)]
+async fn test_t_mode_executable_late_start_short_lived_long_comm_globals_prints(
+) -> anyhow::Result<()> {
+    init();
+    if skip_if_nested_t_mode_unsupported() {
+        return Ok(());
+    }
+
+    let binary_path = FIXTURES.get_test_binary("short_lived_long_comm_program")?;
+    let basename = binary_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    assert!(basename.len() > 15);
+    let target_sandbox = prepare_late_start_launcher(&binary_path)?;
+
+    let script = r#"
+trace short_lived_probe {
+    print "VALUE:{}", short_lived_global;
+}
+"#;
+
+    let (exit_code, stdout, stderr, target_status) = common::runner::GhostscopeRunner::new()
+        .with_script(script)
+        .with_target(&binary_path)
+        .timeout_secs(2)
+        .run_after_ready(|| {
+            // This is a pure `-t` regression: start the short-lived target in
+            // the configured target sandbox, but do not build a TargetHandle.
+            // The handle path waits for PID mapping state that this test does
+            // not need and the process may exit before that settle completes.
+            let binary_path = binary_path.clone();
+            let target_sandbox = target_sandbox.clone();
+            async move {
+                let bin_dir = binary_path
+                    .parent()
+                    .ok_or_else(|| anyhow::anyhow!("short-lived target has no parent directory"))?;
+                let output = common::targets::run_binary_to_completion(
+                    &target_sandbox,
+                    &binary_path,
+                    Some(bin_dir),
+                )?;
+                Ok(output.status)
+            }
+        })
+        .await?;
+
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(
+        target_status.success(),
+        "short-lived target exited with {target_status}; stderr={stderr} stdout={stdout}"
+    );
+
+    let re = Regex::new(r"VALUE:([0-9]+)").unwrap();
+    let saw_global = stdout
+        .lines()
+        .any(|line| re.captures(line).and_then(|c| c[1].parse::<i32>().ok()) == Some(41));
+    assert!(
+        saw_global,
+        "Late-start short-lived long comm: expected global output. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(globals_target)]
 async fn test_t_mode_library_late_start_globals_prints() -> anyhow::Result<()> {
     init();
     if skip_if_nested_t_mode_unsupported() {

--- a/ghostscope-process/src/sysmon.rs
+++ b/ghostscope-process/src/sysmon.rs
@@ -373,6 +373,8 @@ fn run_sysmon_loop(
     let mut bpf = loader.load(obj)?;
 
     // Configure optional exec comm filter when targeting executables (-t binary).
+    // This is only a first-pass narrowing filter in BPF; userspace still validates
+    // the proc comm and target module/path before inserting offsets or allowed PIDs.
     {
         let mut filter_bytes = [0u8; 16];
         let mut filter_len = 0usize;
@@ -380,7 +382,10 @@ fn run_sysmon_loop(
             if !crate::util::is_shared_object(tpath) {
                 if let Some(name) = tpath.file_name().and_then(|s| s.to_str()) {
                     let bytes = name.as_bytes();
-                    let len = bytes.len().min(filter_bytes.len());
+                    // task->comm stores at most TASK_COMM_LEN - 1 visible bytes plus NUL.
+                    // Keep the filter null-terminated so long executable basenames compare
+                    // against the same truncation that bpf_get_current_comm() returns.
+                    let len = bytes.len().min(filter_bytes.len() - 1);
                     filter_bytes[..len].copy_from_slice(&bytes[..len]);
                     filter_len = len;
                 } else {
@@ -471,16 +476,22 @@ fn run_sysmon_loop(
         }
     }
     tracing::info!("Sysmon: setup complete");
-    let mut last_module_refresh = Instant::now()
-        .checked_sub(MODULE_REFRESH_INTERVAL)
-        .unwrap_or_else(Instant::now);
+    // Initial prefill already ran above. Do not make the first periodic module
+    // refresh immediately due: for `-t executable`, the exec event is the fast
+    // path that inserts proc_module_offsets and allowed_pids. A fallback /proc
+    // scan here can delay a short-lived target past its only probe.
+    let mut last_module_refresh = Instant::now();
 
     // Event loop: prefer ringbuf; fallback to perf
     if let Some(map) = bpf.take_map("sysmon_events") {
         let mut rb: RingBuf<MapData> = map.try_into()?;
         loop {
             let mut had_event = false;
-            if let Some(item) = rb.next() {
+            // Drain queued lifecycle events before periodic refresh. In the
+            // short-lived `-t executable` path, sched_process_exec must be
+            // handled promptly so offsets are ready before the first uprobe.
+            while let Some(item) = rb.next() {
+                had_event = true;
                 if item.len() == core::mem::size_of::<SysEvent>() {
                     let ev = unsafe { core::ptr::read_unaligned(item.as_ptr() as *const SysEvent) };
                     if let Err(e) = ProcessSysmon::handle_event(&mgr, &target, &pending, &ev) {
@@ -492,7 +503,6 @@ fn run_sysmon_loop(
                         );
                     }
                     let _ = tx.send(ev);
-                    had_event = true;
                 }
             }
             poll_pending_offsets(&mgr, &pending);


### PR DESCRIPTION
Keep the sysmon exec comm filter aligned with TASK_COMM_LEN truncation, and let queued exec lifecycle events populate offsets before periodic /proc refresh.

Add a short-lived long-comm e2e fixture that exercises global printing without relying on PID handle setup.