### PR TITLE
fix: carry DWARF module origin in read plans

### DIFF
--- a/e2e-tests/tests/fixtures/globals_program/globals_program.c
+++ b/e2e-tests/tests/fixtures/globals_program/globals_program.c
@@ -76,3 +76,11 @@ int main() {
     }
     return 0;
 }
+
+struct AmbiguousDynamic {
+    int decoy;
+    int want;
+};
+
+__attribute__((used)) static volatile struct AmbiguousDynamic
+    main_ambiguous_dynamic_probe = {9001, 9002};

--- a/e2e-tests/tests/fixtures/globals_program/gvars_lib.c
+++ b/e2e-tests/tests/fixtures/globals_program/gvars_lib.c
@@ -1,6 +1,17 @@
 #include "gvars_lib.h"
 #include <string.h>
 
+struct AmbiguousDynamic {
+    int want;
+    int decoy;
+};
+
+struct AmbiguousDynamic lib_ambiguous_dynamic_items[2] = {
+    {701, 1701},
+    {702, 1702},
+};
+struct AmbiguousDynamic* LIB_AMBIGUOUS_DYNAMIC = lib_ambiguous_dynamic_items;
+
 // Visible globals
 int lib_counter = 100;                 // .data
 const char lib_message[] = "LIB_MESSAGE"; // .rodata

--- a/e2e-tests/tests/globals_execution.rs
+++ b/e2e-tests/tests/globals_execution.rs
@@ -1824,6 +1824,31 @@ trace globals_program.c:32 {
 }
 
 #[tokio::test]
+async fn test_dynamic_cross_module_member_completion_uses_global_module() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("globals_program")?;
+    let target = spawn_globals_program(&binary_path).await?;
+
+    let script = r#"
+trace globals_program.c:32 {
+    let dyn_idx = $pid - $pid;
+    print "LAD:{}", LIB_AMBIGUOUS_DYNAMIC[dyn_idx].want;
+}
+"#;
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 3, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("LAD:701"),
+        "Expected shared-library struct layout for dynamic member access. STDOUT: {stdout}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_tick_once_entry_strings_and_structs() -> anyhow::Result<()> {
     init();
 

--- a/ghostscope-compiler/src/ebpf/codegen.rs
+++ b/ghostscope-compiler/src/ebpf/codegen.rs
@@ -213,7 +213,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 if data_len == 0 {
                     return Err(CodeGenError::TypeSizeNotAvailable(display_name));
                 }
-                let module_hint = self.take_module_hint();
+                let module_hint =
+                    Self::module_path_for_offsets(materialized.module_path.as_deref());
                 Ok(ComplexArg {
                     var_name_index: self.trace_context.add_variable_name(display_name),
                     type_index: self.trace_context.add_type(dwarf_type.clone()),
@@ -444,7 +445,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         )))
                     }
                 };
-                let module_hint = self.take_module_hint();
+                let module_hint =
+                    Self::module_path_for_offsets(materialized.module_path.as_deref());
                 Ok(ComplexArg {
                     var_name_index: self
                         .trace_context
@@ -585,7 +587,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     )),
                                 };
                             let data_len = Self::compute_read_size_for_type(&elem_ty);
-                            let module_hint = self.take_module_hint();
+                            let module_hint =
+                                Self::module_path_for_offsets(materialized.module_path.as_deref());
                             if data_len == 0 {
                                 // Fallback for unsized/void targets: print computed address as pointer
                                 let ptr_ti = ghostscope_dwarf::TypeInfo::PointerType {
@@ -1751,7 +1754,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             if let Some(var) = self.query_dwarf_for_complex_expr(expr)? {
                 if let Some(ref ty) = var.dwarf_type {
                     if matches!(ty, ghostscope_dwarf::TypeInfo::PointerType { .. }) {
-                        let _ = self.take_module_hint();
                         return Ok(iv);
                     }
                 }
@@ -1759,21 +1761,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
 
         if let Ok(addr) = self.resolve_ptr_i64_from_expr(expr) {
-            let _ = self.take_module_hint();
             return Ok(addr);
         }
 
         let var = self
             .query_dwarf_for_complex_expr(expr)?
             .ok_or_else(|| CodeGenError::VariableNotFound(format!("{expr:?}")))?;
-        let module_hint = self.take_module_hint();
         let pc_address = self.get_compile_time_context()?.pc_address;
-        self.variable_read_plan_to_lvalue_address_with_hint(
-            &var,
-            pc_address,
-            None,
-            module_hint.as_deref(),
-        )
+        self.variable_read_plan_to_lvalue_address(&var, pc_address, None)
     }
 
     fn compile_formatted_print(

--- a/ghostscope-compiler/src/ebpf/context.rs
+++ b/ghostscope-compiler/src/ebpf/context.rs
@@ -85,7 +85,6 @@ pub struct EbpfContext<'ctx, 'dw> {
 
     // === New instruction-based compilation system ===
     pub trace_context: ghostscope_protocol::TraceContext, // Trace context for optimized transmission
-    pub current_resolved_var_module_path: Option<String>,
 
     // Per-invocation stack key for proc_module_offsets lookups (allocated in entry block)
     // Backed by `[4 x i32]`, so consumers may only assume i32 alignment.
@@ -204,7 +203,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
             // Initialize new instruction-based compilation system
             trace_context: ghostscope_protocol::TraceContext::new(),
-            current_resolved_var_module_path: None,
             pm_key_alloca: None,
             event_offset_alloca: None,
             compile_time_event_bytes_upper_bound: 0,
@@ -304,11 +302,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         self.current_compile_time_context
             .as_ref()
             .ok_or_else(|| CodeGenError::DwarfError("No compile-time context set".to_string()))
-    }
-
-    /// Take and clear the current module hint for offsets (if any)
-    pub fn take_module_hint(&mut self) -> Option<String> {
-        self.current_resolved_var_module_path.take()
     }
 
     /// Declare trace_printk eBPF helper function

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -14,6 +14,10 @@ use inkwell::values::{BasicValueEnum, IntValue, PointerValue};
 use tracing::{debug, warn};
 
 impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
+    pub(super) fn module_path_for_offsets(module_path: Option<&std::path::Path>) -> Option<String> {
+        module_path.map(|path| path.to_string_lossy().into_owned())
+    }
+
     /// Compute a stable cookie for a module when per-PID offsets are unavailable (via coordinator).
     fn fallback_cookie_from_module_path(&self, module_path: &str) -> u64 {
         module_probe::cookie_for_path(module_path)
@@ -44,6 +48,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         value: &ghostscope_dwarf::PlannedValue,
         var_name: &str,
         status_ptr: Option<PointerValue<'ctx>>,
+        module_hint: Option<&str>,
     ) -> Result<BasicValueEnum<'ctx>> {
         let pt_regs_ptr = self.get_pt_regs_parameter()?;
         match value {
@@ -72,6 +77,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     Some(*result_size),
                     runtime_status_ptr,
                     None,
+                    module_hint,
                 )
             }
             ghostscope_dwarf::PlannedValue::ImplicitBytes(bytes) => {
@@ -89,7 +95,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 } else {
                     status_ptr
                 };
-                self.planned_address_to_llvm_address(address, runtime_status_ptr, None)
+                self.planned_address_to_llvm_address(address, runtime_status_ptr, module_hint)
                     .map(Into::into)
             }
         }
@@ -133,6 +139,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     None,
                     status_ptr,
                     Some(runtime_base),
+                    module_hint,
                 )?;
                 match value {
                     BasicValueEnum::IntValue(value) => Ok(value),
@@ -142,7 +149,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 }
             }
             AddressOrigin::RuntimeDerived | AddressOrigin::Unknown => {
-                self.planned_address_without_rebase(address, pt_regs_ptr, status_ptr)
+                self.planned_address_without_rebase(address, pt_regs_ptr, status_ptr, module_hint)
             }
         }
     }
@@ -152,6 +159,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         address: &PlannedAddress,
         pt_regs_ptr: PointerValue<'ctx>,
         status_ptr: Option<PointerValue<'ctx>>,
+        module_hint: Option<&str>,
     ) -> Result<IntValue<'ctx>> {
         match &address.kind {
             PlannedAddressKind::Constant { address } => {
@@ -175,7 +183,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 }
             }
             PlannedAddressKind::RuntimeComputed { expr } => {
-                self.runtime_expr_to_unrebased_address(expr, pt_regs_ptr, status_ptr)
+                self.runtime_expr_to_unrebased_address(expr, pt_regs_ptr, status_ptr, module_hint)
             }
             PlannedAddressKind::FrameBaseRelative { .. } => Err(CodeGenError::NotImplemented(
                 "Frame-base-relative planned address requires resolved frame base".to_string(),
@@ -188,9 +196,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         expr: &RuntimeComputedExpr,
         pt_regs_ptr: PointerValue<'ctx>,
         status_ptr: Option<PointerValue<'ctx>>,
+        module_hint: Option<&str>,
     ) -> Result<IntValue<'ctx>> {
-        let val =
-            self.generate_runtime_expr_ops(expr.ops(), pt_regs_ptr, None, status_ptr, None)?;
+        let val = self.generate_runtime_expr_ops(
+            expr.ops(),
+            pt_regs_ptr,
+            None,
+            status_ptr,
+            None,
+            module_hint,
+        )?;
         match val {
             BasicValueEnum::IntValue(value) => Ok(value),
             _ => Err(CodeGenError::LLVMError(
@@ -208,7 +223,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let ctx = self.get_compile_time_context()?;
         let module_for_offsets = module_hint
             .map(|s| s.to_string())
-            .or_else(|| self.current_resolved_var_module_path.clone())
             .unwrap_or_else(|| ctx.module_path.clone());
         let st_code = self.section_code_for_address(&module_for_offsets, link_addr);
         let cookie = self.cookie_for_module_or_fallback(&module_for_offsets);
@@ -217,7 +231,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.generate_runtime_address_from_offsets(link_val, st_code, cookie)?;
         self.store_offsets_unavailable_status(status_ptr, found_flag)?;
         self.store_offsets_found_flag(found_flag)?;
-        self.current_resolved_var_module_path = None;
         Ok(rt_addr)
     }
 
@@ -402,8 +415,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     ) -> Result<BasicValueEnum<'ctx>> {
         match &materialization.materialization {
             ghostscope_dwarf::VariableMaterialization::DirectValue { value } => {
-                let value =
-                    self.planned_value_to_llvm_value(value, &materialization.name, status_ptr)?;
+                let module_hint =
+                    Self::module_path_for_offsets(materialization.module_path.as_deref());
+                let value = self.planned_value_to_llvm_value(
+                    value,
+                    &materialization.name,
+                    status_ptr,
+                    module_hint.as_deref(),
+                )?;
                 self.normalize_direct_integer_value_if_needed(
                     value,
                     materialization.dwarf_type.as_ref(),
@@ -415,7 +434,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         "Expression has no DWARF type information".to_string(),
                     )
                 })?;
-                self.generate_memory_location_from_planned_address(address, dwarf_type, status_ptr)
+                let module_hint =
+                    Self::module_path_for_offsets(materialization.module_path.as_deref());
+                self.generate_memory_location_from_planned_address(
+                    address,
+                    dwarf_type,
+                    status_ptr,
+                    module_hint.as_deref(),
+                )
             }
             ghostscope_dwarf::VariableMaterialization::Unavailable { availability } => {
                 Err(Self::dwarf_expression_unavailable_error(
@@ -443,16 +469,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         self.variable_materialization_to_llvm_value(&materialized, pc_address, status_ptr)
     }
 
-    pub(super) fn variable_read_plan_to_lvalue_address_with_hint(
+    pub(super) fn variable_read_plan_to_lvalue_address(
         &mut self,
         plan: &VariableReadPlan,
         pc_address: u64,
         status_ptr: Option<PointerValue<'ctx>>,
-        module_hint: Option<&str>,
     ) -> Result<IntValue<'ctx>> {
+        let module_hint = Self::module_path_for_offsets(plan.module_path.as_deref());
         match plan.lvalue_address_plan() {
             LvalueAddressPlan::Address { address } => {
-                self.planned_address_to_llvm_address(&address, status_ptr, module_hint)
+                self.planned_address_to_llvm_address(&address, status_ptr, module_hint.as_deref())
             }
             LvalueAddressPlan::Unavailable { availability } => Err(
                 Self::dwarf_lvalue_address_unavailable_error(&plan.name, &availability, pc_address),
@@ -465,18 +491,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         address: &PlannedAddress,
         dwarf_type: &TypeInfo,
         status_ptr: Option<PointerValue<'ctx>>,
+        module_hint: Option<&str>,
     ) -> Result<BasicValueEnum<'ctx>> {
-        let module_hint = self.current_resolved_var_module_path.clone();
         let runtime_status_ptr = if self.condition_context_active {
             Some(self.get_or_create_cond_error_global())
         } else {
             status_ptr
         };
-        let addr = self.planned_address_to_llvm_address(
-            address,
-            runtime_status_ptr,
-            module_hint.as_deref(),
-        )?;
+        let addr =
+            self.planned_address_to_llvm_address(address, runtime_status_ptr, module_hint)?;
 
         if ghostscope_dwarf::is_c_aggregate_type(dwarf_type) {
             let ptr_ty = self.context.ptr_type(inkwell::AddressSpace::default());
@@ -606,6 +629,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         _result_size: Option<MemoryAccessSize>,
         status_ptr: Option<PointerValue<'ctx>>,
         initial_top: Option<IntValue<'ctx>>,
+        module_hint: Option<&str>,
     ) -> Result<BasicValueEnum<'ctx>> {
         // Implement stack-based computation
         let mut stack: Vec<IntValue<'ctx>> = Vec::new();
@@ -1054,6 +1078,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         pt_regs_ptr,
                         _result_size,
                         status_ptr,
+                        module_hint,
                     )?;
                     stack.push(value);
                 }
@@ -1085,6 +1110,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         pt_regs_ptr: PointerValue<'ctx>,
         result_size: Option<MemoryAccessSize>,
         status_ptr: Option<PointerValue<'ctx>>,
+        module_hint: Option<&str>,
     ) -> Result<IntValue<'ctx>> {
         if cases.is_empty() {
             return Err(CodeGenError::LLVMError(
@@ -1099,6 +1125,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 Some(MemoryAccessSize::U64),
                 status_ptr,
                 None,
+                module_hint,
             )?
             .into_int_value();
 
@@ -1117,8 +1144,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
         let module_for_offsets = {
             let ctx = self.get_compile_time_context()?;
-            self.current_resolved_var_module_path
-                .clone()
+            module_hint
+                .map(|module| module.to_string())
                 .unwrap_or_else(|| ctx.module_path.clone())
         };
         let module_cookie = self.cookie_for_module_or_fallback(&module_for_offsets);
@@ -1179,6 +1206,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     result_size,
                     status_ptr,
                     None,
+                    module_hint,
                 )?
                 .into_int_value();
             let case_value_block = self.builder.get_insert_block().ok_or_else(|| {
@@ -1413,13 +1441,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             return Ok(pc_plan);
         }
 
-        if let Some((global_module, plan)) = analyzer
+        if let Some((_global_module, plan)) = analyzer
             .plan_global_access_read_plan(&prefer_module, var_name, &VariableAccessPath::default())
             .map_err(|err| CodeGenError::DwarfError(err.to_string()))?
         {
             debug!("Found DWARF global '{}' via variable read plan", var_name);
-            self.current_resolved_var_module_path =
-                Some(global_module.to_string_lossy().to_string());
             return Ok(Some(plan));
         }
 
@@ -1484,12 +1510,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
         }
 
-        if let Some((module_path, plan)) = analyzer
+        if let Some((_module_path, plan)) = analyzer
             .plan_global_access_read_plan(&prefer_module, base_name, access_path)
             .map_err(|err| CodeGenError::DwarfError(err.to_string()))?
         {
             debug!("Found DWARF global access '{path_text}' via variable read plan");
-            self.current_resolved_var_module_path = Some(module_path.to_string_lossy().to_string());
             return Ok(Some(plan));
         }
 
@@ -1619,6 +1644,7 @@ mod tests {
             name: name.to_string(),
             type_name: type_name.to_string(),
             access_path: VariableAccessPath::default(),
+            module_path: None,
             dwarf_type,
             declaration: None,
             type_id: None,
@@ -2158,6 +2184,7 @@ mod tests {
             name: "x".to_string(),
             type_name: "int".to_string(),
             access_path: VariableAccessPath::default(),
+            module_path: None,
             dwarf_type: Some(dwarf_type),
             declaration: None,
             type_id: None,
@@ -2193,6 +2220,7 @@ mod tests {
             name: "x".to_string(),
             type_name: "int".to_string(),
             access_path: VariableAccessPath::default(),
+            module_path: None,
             dwarf_type: Some(dwarf_type),
             declaration: None,
             type_id: None,
@@ -2264,7 +2292,7 @@ mod tests {
         );
 
         let addr = ctx
-            .variable_read_plan_to_lvalue_address_with_hint(&plan, 0x1234, None, None)
+            .variable_read_plan_to_lvalue_address(&plan, 0x1234, None)
             .expect("address-only read plan should not require DWARF type info");
 
         assert_eq!(addr.get_type().get_bit_width(), 64);
@@ -2286,7 +2314,7 @@ mod tests {
         );
 
         let err = ctx
-            .variable_read_plan_to_lvalue_address_with_hint(&plan, 0x1234, None, None)
+            .variable_read_plan_to_lvalue_address(&plan, 0x1234, None)
             .expect_err("unavailable lvalue plans should be rejected");
 
         assert!(matches!(err, CodeGenError::VariableUnavailable(_)));

--- a/ghostscope-compiler/src/ebpf/expression.rs
+++ b/ghostscope-compiler/src/ebpf/expression.rs
@@ -11,9 +11,27 @@ use ghostscope_dwarf::{
 };
 use inkwell::values::{BasicValueEnum, IntValue};
 use inkwell::AddressSpace;
+use std::path::{Path, PathBuf};
 use tracing::debug;
 
 // compare cap is provided via compile_options.compare_cap (config: ebpf.compare_cap)
+
+#[derive(Clone)]
+struct DynamicTypeInfo {
+    dwarf_type: DwarfType,
+    module_path: Option<PathBuf>,
+}
+
+struct DynamicLvalue<'ctx> {
+    address: IntValue<'ctx>,
+    type_info: DynamicTypeInfo,
+}
+
+struct IndexableElementInfo {
+    element_type: DwarfType,
+    stride: u64,
+    module_path: Option<PathBuf>,
+}
 
 impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     pub(crate) fn get_host_pid_tid_values(&mut self) -> Result<(IntValue<'ctx>, IntValue<'ctx>)> {
@@ -585,18 +603,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     // Owned target for query
                     if let Some(target) = self.get_alias_variable(name) {
                         if let Some(var) = self.query_dwarf_for_complex_expr(&target)? {
-                            let module_hint = self.current_resolved_var_module_path.clone();
                             let status_ptr = if self.condition_context_active {
                                 Some(self.get_or_create_cond_error_global())
                             } else {
                                 None
                             };
                             let pc_address = self.get_compile_time_context()?.pc_address;
-                            return self.variable_read_plan_to_lvalue_address_with_hint(
-                                &var,
-                                pc_address,
-                                status_ptr,
-                                module_hint.as_deref(),
+                            return self.variable_read_plan_to_lvalue_address(
+                                &var, pc_address, status_ptr,
                             );
                         } else {
                             return Err(CodeGenError::TypeError(
@@ -616,27 +630,21 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             };
 
             if let E::ArrayAccess(array_expr, index_expr) = resolved_inner {
-                if let Some((element_address, _element_type)) =
+                if let Some(element_lvalue) =
                     self.compile_dynamic_array_element_address(array_expr, index_expr)?
                 {
-                    return Ok(element_address);
+                    return Ok(element_lvalue.address);
                 }
             }
 
             if let Some(var) = self.query_dwarf_for_complex_expr(resolved_inner)? {
-                let module_hint = self.current_resolved_var_module_path.clone();
                 let status_ptr = if self.condition_context_active {
                     Some(self.get_or_create_cond_error_global())
                 } else {
                     None
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                return self.variable_read_plan_to_lvalue_address_with_hint(
-                    &var,
-                    pc_address,
-                    status_ptr,
-                    module_hint.as_deref(),
-                );
+                return self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr);
             } else {
                 return Err(CodeGenError::TypeError(
                     "cannot take address of unresolved expression".into(),
@@ -662,18 +670,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     let pointed_plan = var
                         .plan_pointer_element_index(index)
                         .map_err(|err| CodeGenError::DwarfError(err.to_string()))?;
-                    let module_hint = self.current_resolved_var_module_path.clone();
                     let status_ptr = if self.condition_context_active {
                         Some(self.get_or_create_cond_error_global())
                     } else {
                         None
                     };
                     let pc_address = self.get_compile_time_context()?.pc_address;
-                    return self.variable_read_plan_to_lvalue_address_with_hint(
+                    return self.variable_read_plan_to_lvalue_address(
                         &pointed_plan,
                         pc_address,
                         status_ptr,
-                        module_hint.as_deref(),
                     );
                 }
             }
@@ -746,38 +752,26 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     }
                     DwarfType::ArrayType { .. } => {
                         // Use the base address of the array as pointer
-                        let module_hint = self.current_resolved_var_module_path.clone();
                         let status_ptr = if self.condition_context_active {
                             Some(self.get_or_create_cond_error_global())
                         } else {
                             None
                         };
                         let pc_address = self.get_compile_time_context()?.pc_address;
-                        self.variable_read_plan_to_lvalue_address_with_hint(
-                            &var,
-                            pc_address,
-                            status_ptr,
-                            module_hint.as_deref(),
-                        )
+                        self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)
                     }
                     _ => Err(CodeGenError::TypeError(
                         "DWARF value is not pointer/array".into(),
                     )),
                 }
             } else {
-                let module_hint = self.current_resolved_var_module_path.clone();
                 let status_ptr = if self.condition_context_active {
                     Some(self.get_or_create_cond_error_global())
                 } else {
                     None
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                self.variable_read_plan_to_lvalue_address_with_hint(
-                    &var,
-                    pc_address,
-                    status_ptr,
-                    module_hint.as_deref(),
-                )
+                self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)
             }
         } else {
             // No DWARF-backed address and not an address-of/alias+const: reject script-level pointers.
@@ -872,7 +866,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         index_expr: &Expr,
     ) -> Result<Option<IntValue<'ctx>>> {
         match self.compile_dynamic_array_element_address(base_expr, index_expr) {
-            Ok(Some((address, _element_type))) => Ok(Some(address)),
+            Ok(Some(element_lvalue)) => Ok(Some(element_lvalue.address)),
             Ok(None) => Ok(None),
             Err(CodeGenError::VariableNotFound(_))
             | Err(CodeGenError::VariableNotInScope(_))
@@ -1584,19 +1578,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             }
                         }
                         DwarfType::ArrayType { .. } => {
-                            let module_hint = self.current_resolved_var_module_path.clone();
                             let status_ptr = if self.condition_context_active {
                                 Some(self.get_or_create_cond_error_global())
                             } else {
                                 None
                             };
                             let pc_address = self.get_compile_time_context()?.pc_address;
-                            self.variable_read_plan_to_lvalue_address_with_hint(
-                                &var,
-                                pc_address,
-                                status_ptr,
-                                module_hint.as_deref(),
-                            )?
+                            self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)?
                         }
                         _ => {
                             // Not a pointer/array -> treat as error
@@ -2245,7 +2233,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 self.compile_dwarf_expression(expr)
             }
             Expr::AddressOf(inner) => {
-                // Address-of with ASLR-aware hint: compute runtime address using module hint
+                // Address-of computes runtime addresses using the module origin carried by the plan.
                 // Transparently support alias variables: &alias -> address of aliased DWARF expression
                 let target_inner: &Expr = if let Expr::Variable(var_name) = inner.as_ref() {
                     if self.alias_variable_exists(var_name) {
@@ -2253,8 +2241,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         let aliased = self
                             .get_alias_variable(var_name)
                             .expect("alias existence just checked");
-                        // First perform the DWARF query so that current_resolved_var_module_path
-                        // is set for the aliased symbol's module; then capture the hint.
                         let var =
                             self.query_dwarf_for_complex_expr(&aliased)?
                                 .ok_or_else(|| {
@@ -2262,14 +2248,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                         "cannot take address of unresolved expression".to_string(),
                                     )
                                 })?;
-                        let module_hint = self.current_resolved_var_module_path.clone();
                         let pc_address = self.get_compile_time_context()?.pc_address;
-                        match self.variable_read_plan_to_lvalue_address_with_hint(
-                            &var,
-                            pc_address,
-                            None,
-                            module_hint.as_deref(),
-                        ) {
+                        match self.variable_read_plan_to_lvalue_address(&var, pc_address, None) {
                             Ok(addr_i64) => {
                                 let ptr_ty = self.context.ptr_type(AddressSpace::default());
                                 let as_ptr = self
@@ -2298,15 +2278,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             "cannot take address of unresolved expression".to_string(),
                         )
                     })?;
-                // Use current resolved hint if available (set during DWARF resolution)
-                let module_hint = self.current_resolved_var_module_path.clone();
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                match self.variable_read_plan_to_lvalue_address_with_hint(
-                    &var,
-                    pc_address,
-                    None,
-                    module_hint.as_deref(),
-                ) {
+                match self.variable_read_plan_to_lvalue_address(&var, pc_address, None) {
                     Ok(addr_i64) => {
                         let ptr_ty = self.context.ptr_type(AddressSpace::default());
                         let as_ptr = self
@@ -3026,14 +2999,17 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         array_expr: &Expr,
         index_expr: &Expr,
     ) -> Result<Option<(BasicValueEnum<'ctx>, DwarfType)>> {
-        let Some((element_address, element_type)) =
+        let Some(element_lvalue) =
             self.compile_dynamic_array_element_address(array_expr, index_expr)?
         else {
             return Ok(None);
         };
 
-        let value = self.read_dynamic_address_value(element_address, &element_type)?;
-        Ok(Some((value, element_type)))
+        let value = self.read_dynamic_address_value(
+            element_lvalue.address,
+            &element_lvalue.type_info.dwarf_type,
+        )?;
+        Ok(Some((value, element_lvalue.type_info.dwarf_type)))
     }
 
     pub(super) fn compile_dynamic_member_access_value(
@@ -3041,23 +3017,24 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         obj_expr: &Expr,
         field: &str,
     ) -> Result<Option<(BasicValueEnum<'ctx>, DwarfType)>> {
-        let Some((object_address, object_type)) = self.dynamic_lvalue_address_and_type(obj_expr)?
-        else {
+        let Some(object_lvalue) = self.dynamic_lvalue_address_and_type(obj_expr)? else {
             return Ok(None);
         };
 
-        let Some((element_address, element_type)) =
-            self.dynamic_member_base_address_and_type(object_address, object_type)?
-        else {
+        let Some(element_lvalue) = self.dynamic_member_base_address_and_type(object_lvalue)? else {
             return Ok(None);
         };
         let (member_offset, member_type) =
-            self.dynamic_member_offset_and_type(&element_type, field)?;
+            self.dynamic_member_offset_and_type(&element_lvalue.type_info, field)?;
 
         let member_offset = self.context.i64_type().const_int(member_offset, false);
         let member_address = self
             .builder
-            .build_int_add(element_address, member_offset, "dynamic_member_address")
+            .build_int_add(
+                element_lvalue.address,
+                member_offset,
+                "dynamic_member_address",
+            )
             .map_err(|err| CodeGenError::Builder(err.to_string()))?;
         let value = self.read_dynamic_address_value(member_address, &member_type)?;
         Ok(Some((value, member_type)))
@@ -3066,39 +3043,51 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     fn dynamic_lvalue_address_and_type(
         &mut self,
         expr: &Expr,
-    ) -> Result<Option<(IntValue<'ctx>, DwarfType)>> {
+    ) -> Result<Option<DynamicLvalue<'ctx>>> {
         if let Expr::ArrayAccess(array_expr, index_expr) = expr {
             return self.compile_dynamic_array_element_address(array_expr, index_expr);
         }
 
         if self.expands_to_nonliteral_pointer_arithmetic(expr)? {
-            let Some((element_type, _stride)) = self.indexable_element_type_and_stride(expr)?
-            else {
+            let Some(element_info) = self.indexable_element_type_and_stride(expr)? else {
                 return Ok(None);
             };
             let element_address = self.resolve_ptr_i64_from_expr(expr)?;
-            return Ok(Some((element_address, element_type)));
+            return Ok(Some(DynamicLvalue {
+                address: element_address,
+                type_info: DynamicTypeInfo {
+                    dwarf_type: element_info.element_type,
+                    module_path: element_info.module_path,
+                },
+            }));
         }
 
         if let Expr::MemberAccess(obj_expr, field) = expr {
-            let Some((object_address, object_type)) =
-                self.dynamic_lvalue_address_and_type(obj_expr)?
-            else {
+            let Some(object_lvalue) = self.dynamic_lvalue_address_and_type(obj_expr)? else {
                 return Ok(None);
             };
-            let Some((base_address, aggregate_type)) =
-                self.dynamic_member_base_address_and_type(object_address, object_type)?
+            let Some(base_lvalue) = self.dynamic_member_base_address_and_type(object_lvalue)?
             else {
                 return Ok(None);
             };
             let (member_offset, member_type) =
-                self.dynamic_member_offset_and_type(&aggregate_type, field)?;
+                self.dynamic_member_offset_and_type(&base_lvalue.type_info, field)?;
             let member_offset = self.context.i64_type().const_int(member_offset, false);
             let member_address = self
                 .builder
-                .build_int_add(base_address, member_offset, "dynamic_member_lvalue_address")
+                .build_int_add(
+                    base_lvalue.address,
+                    member_offset,
+                    "dynamic_member_lvalue_address",
+                )
                 .map_err(|err| CodeGenError::Builder(err.to_string()))?;
-            return Ok(Some((member_address, member_type)));
+            return Ok(Some(DynamicLvalue {
+                address: member_address,
+                type_info: DynamicTypeInfo {
+                    dwarf_type: member_type,
+                    module_path: base_lvalue.type_info.module_path,
+                },
+            }));
         }
 
         Ok(None)
@@ -3106,16 +3095,24 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     fn dynamic_member_base_address_and_type(
         &mut self,
-        address: IntValue<'ctx>,
-        object_type: DwarfType,
-    ) -> Result<Option<(IntValue<'ctx>, DwarfType)>> {
-        let object_type = self.complete_dynamic_member_element_type(object_type);
+        object: DynamicLvalue<'ctx>,
+    ) -> Result<Option<DynamicLvalue<'ctx>>> {
+        let module_path = object.type_info.module_path.clone();
+        let object_type = self.complete_dynamic_member_element_type(
+            object.type_info.dwarf_type,
+            module_path.as_deref(),
+        );
         match ghostscope_dwarf::strip_type_aliases(&object_type) {
-            DwarfType::StructType { .. } | DwarfType::UnionType { .. } => {
-                Ok(Some((address, object_type)))
-            }
+            DwarfType::StructType { .. } | DwarfType::UnionType { .. } => Ok(Some(DynamicLvalue {
+                address: object.address,
+                type_info: DynamicTypeInfo {
+                    dwarf_type: object_type,
+                    module_path,
+                },
+            })),
             DwarfType::PointerType { target_type, .. } => {
-                let pointer_value = self.read_dynamic_address_value(address, &object_type)?;
+                let pointer_value =
+                    self.read_dynamic_address_value(object.address, &object_type)?;
                 let pointer_value = match pointer_value {
                     BasicValueEnum::IntValue(value) => {
                         self.normalize_int_to_i64(value, "dynamic_member_pointer_i64")?
@@ -3134,9 +3131,17 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         ))
                     }
                 };
-                let target_type =
-                    self.complete_dynamic_member_element_type(target_type.as_ref().clone());
-                Ok(Some((pointer_value, target_type)))
+                let target_type = self.complete_dynamic_member_element_type(
+                    target_type.as_ref().clone(),
+                    module_path.as_deref(),
+                );
+                Ok(Some(DynamicLvalue {
+                    address: pointer_value,
+                    type_info: DynamicTypeInfo {
+                        dwarf_type: target_type,
+                        module_path,
+                    },
+                }))
             }
             _ => Ok(None),
         }
@@ -3144,10 +3149,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     fn dynamic_member_offset_and_type(
         &self,
-        aggregate_type: &DwarfType,
+        aggregate: &DynamicTypeInfo,
         field: &str,
     ) -> Result<(u64, DwarfType)> {
-        let aggregate_type = self.complete_dynamic_member_element_type(aggregate_type.clone());
+        let aggregate_type = self.complete_dynamic_member_element_type(
+            aggregate.dwarf_type.clone(),
+            aggregate.module_path.as_deref(),
+        );
         match ghostscope_dwarf::strip_type_aliases(&aggregate_type) {
             DwarfType::StructType { members, .. } | DwarfType::UnionType { members, .. } => {
                 let Some(member) = members.iter().find(|member| member.name == field) else {
@@ -3169,7 +3177,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         &mut self,
         array_expr: &Expr,
         index_expr: &Expr,
-    ) -> Result<Option<(IntValue<'ctx>, DwarfType)>> {
+    ) -> Result<Option<DynamicLvalue<'ctx>>> {
         let literal_index = Self::integer_literal_value(index_expr);
         let expanded_array_expr = self.expand_alias_variable_expr(array_expr)?;
         let has_dynamic_base =
@@ -3186,10 +3194,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             None
         };
 
-        let (element_type, stride, base_address, static_index) = match self
+        let (element_info, base_address, static_index) = match self
             .query_dwarf_for_complex_expr(array_expr)?
         {
             Some(array_plan) => {
+                let module_path = array_plan.module_path.clone();
                 let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
                     CodeGenError::DwarfError(
                         "Array expression has no DWARF type information".to_string(),
@@ -3197,16 +3206,17 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 })?;
                 match ghostscope_dwarf::strip_type_aliases(&array_type) {
                     DwarfType::ArrayType { element_type, .. } => {
-                        let module_hint = self.current_resolved_var_module_path.clone();
-                        let base_address = self.variable_read_plan_to_lvalue_address_with_hint(
+                        let base_address = self.variable_read_plan_to_lvalue_address(
                             &array_plan,
                             compile_context.pc_address,
                             status_ptr,
-                            module_hint.as_deref(),
                         )?;
                         (
-                            element_type.as_ref().clone(),
-                            element_type.size().max(1),
+                            IndexableElementInfo {
+                                element_type: element_type.as_ref().clone(),
+                                stride: element_type.size().max(1),
+                                module_path,
+                            },
                             base_address,
                             0,
                         )
@@ -3236,8 +3246,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             }
                         };
                         (
-                            target_type.as_ref().clone(),
-                            target_type.size().max(1),
+                            IndexableElementInfo {
+                                element_type: target_type.as_ref().clone(),
+                                stride: target_type.size().max(1),
+                                module_path,
+                            },
                             base_address,
                             0,
                         )
@@ -3261,6 +3274,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     &base_expr,
                                 ))
                             })?;
+                    let module_path = array_plan.module_path.clone();
                     let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
                         CodeGenError::DwarfError(
                             "Array expression has no DWARF type information".to_string(),
@@ -3268,17 +3282,17 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     })?;
                     match ghostscope_dwarf::strip_type_aliases(&array_type) {
                         DwarfType::ArrayType { element_type, .. } => {
-                            let module_hint = self.current_resolved_var_module_path.clone();
-                            let base_address = self
-                                .variable_read_plan_to_lvalue_address_with_hint(
-                                    &array_plan,
-                                    compile_context.pc_address,
-                                    status_ptr,
-                                    module_hint.as_deref(),
-                                )?;
+                            let base_address = self.variable_read_plan_to_lvalue_address(
+                                &array_plan,
+                                compile_context.pc_address,
+                                status_ptr,
+                            )?;
                             (
-                                element_type.as_ref().clone(),
-                                element_type.size().max(1),
+                                IndexableElementInfo {
+                                    element_type: element_type.as_ref().clone(),
+                                    stride: element_type.size().max(1),
+                                    module_path,
+                                },
                                 base_address,
                                 static_index,
                             )
@@ -3309,8 +3323,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 }
                             };
                             (
-                                target_type.as_ref().clone(),
-                                target_type.size().max(1),
+                                IndexableElementInfo {
+                                    element_type: target_type.as_ref().clone(),
+                                    stride: target_type.size().max(1),
+                                    module_path,
+                                },
                                 base_address,
                                 static_index,
                             )
@@ -3323,26 +3340,32 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         }
                     }
                 } else if has_dynamic_base {
-                    let (element_type, stride) = self
+                    let element_info = self
                         .indexable_element_type_and_stride(&expanded_array_expr)?
                         .ok_or_else(|| {
                             CodeGenError::VariableNotFound(Self::expr_to_debug_string(array_expr))
                         })?;
                     let base_address = self.resolve_ptr_i64_from_expr(&expanded_array_expr)?;
-                    (element_type, stride, base_address, 0)
-                } else if let Some((base_address, array_type)) =
+                    (element_info, base_address, 0)
+                } else if let Some(array_lvalue) =
                     self.dynamic_lvalue_address_and_type(&expanded_array_expr)?
                 {
-                    match ghostscope_dwarf::strip_type_aliases(&array_type) {
+                    let module_path = array_lvalue.type_info.module_path.clone();
+                    match ghostscope_dwarf::strip_type_aliases(&array_lvalue.type_info.dwarf_type) {
                         DwarfType::ArrayType { element_type, .. } => (
-                            element_type.as_ref().clone(),
-                            element_type.size().max(1),
-                            base_address,
+                            IndexableElementInfo {
+                                element_type: element_type.as_ref().clone(),
+                                stride: element_type.size().max(1),
+                                module_path,
+                            },
+                            array_lvalue.address,
                             0,
                         ),
                         DwarfType::PointerType { target_type, .. } => {
-                            let pointer_value =
-                                self.read_dynamic_address_value(base_address, &array_type)?;
+                            let pointer_value = self.read_dynamic_address_value(
+                                array_lvalue.address,
+                                &array_lvalue.type_info.dwarf_type,
+                            )?;
                             let base_address = match pointer_value {
                                 BasicValueEnum::IntValue(value) => self
                                     .normalize_int_to_i64(value, "dynamic_array_member_ptr_i64")?,
@@ -3362,8 +3385,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 }
                             };
                             (
-                                target_type.as_ref().clone(),
-                                target_type.size().max(1),
+                                IndexableElementInfo {
+                                    element_type: target_type.as_ref().clone(),
+                                    stride: target_type.size().max(1),
+                                    module_path,
+                                },
                                 base_address,
                                 0,
                             )
@@ -3409,7 +3435,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 )
                 .map_err(|err| CodeGenError::Builder(err.to_string()))?
         };
-        let stride_value = self.context.i64_type().const_int(stride, false);
+        let stride_value = self
+            .context
+            .i64_type()
+            .const_int(element_info.stride, false);
         let byte_offset = self
             .builder
             .build_int_mul(index_value, stride_value, "dynamic_array_byte_offset")
@@ -3419,22 +3448,32 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .build_int_add(base_address, byte_offset, "dynamic_array_element_address")
             .map_err(|err| CodeGenError::Builder(err.to_string()))?;
 
-        Ok(Some((element_address, element_type)))
+        Ok(Some(DynamicLvalue {
+            address: element_address,
+            type_info: DynamicTypeInfo {
+                dwarf_type: element_info.element_type,
+                module_path: element_info.module_path,
+            },
+        }))
     }
 
     fn indexable_element_type_and_stride(
         &mut self,
         expr: &Expr,
-    ) -> Result<Option<(DwarfType, u64)>> {
+    ) -> Result<Option<IndexableElementInfo>> {
         use crate::script::ast::BinaryOp as BO;
         use crate::script::ast::Expr as E;
 
         let expanded = self.expand_alias_variable_expr(expr)?;
 
         if let Some(plan) = self.query_dwarf_for_complex_expr(&expanded)? {
-            if let Some(dwarf_type) = plan.dwarf_type {
-                if let Some(info) = Self::element_type_and_stride_from_type(&dwarf_type) {
-                    return Ok(Some(info));
+            if let Some(dwarf_type) = plan.dwarf_type.as_ref() {
+                if let Some(info) = Self::element_type_and_stride_from_type(dwarf_type) {
+                    return Ok(Some(IndexableElementInfo {
+                        element_type: info.0,
+                        stride: info.1,
+                        module_path: plan.module_path,
+                    }));
                 }
             }
         }
@@ -3443,9 +3482,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.pointer_arithmetic_parts_expanding_aliases(&expanded)?
         {
             if let Some(plan) = self.query_dwarf_for_complex_expr(&base_expr)? {
-                if let Some(dwarf_type) = plan.dwarf_type {
-                    if let Some(info) = Self::element_type_and_stride_from_type(&dwarf_type) {
-                        return Ok(Some(info));
+                if let Some(dwarf_type) = plan.dwarf_type.as_ref() {
+                    if let Some(info) = Self::element_type_and_stride_from_type(dwarf_type) {
+                        return Ok(Some(IndexableElementInfo {
+                            element_type: info.0,
+                            stride: info.1,
+                            module_path: plan.module_path,
+                        }));
                     }
                 }
             }
@@ -3483,7 +3526,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
     }
 
-    fn complete_dynamic_member_element_type(&self, element_type: DwarfType) -> DwarfType {
+    fn complete_dynamic_member_element_type(
+        &self,
+        element_type: DwarfType,
+        module_path: Option<&Path>,
+    ) -> DwarfType {
         let candidate_name = match ghostscope_dwarf::strip_type_aliases(&element_type) {
             DwarfType::UnknownType { name } => Some(name.clone()),
             _ => None,
@@ -3491,7 +3538,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let Some(candidate_name) = candidate_name else {
             return element_type;
         };
-        let Some(resolved) = self.resolve_named_aggregate_type_for_dynamic_member(&candidate_name)
+        let Some(resolved) =
+            self.resolve_named_aggregate_type_for_dynamic_member(&candidate_name, module_path)
         else {
             return element_type;
         };
@@ -3507,14 +3555,18 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             } => DwarfType::QualifiedType {
                 qualifier,
                 underlying_type: Box::new(
-                    self.complete_dynamic_member_element_type(*underlying_type),
+                    self.complete_dynamic_member_element_type(*underlying_type, module_path),
                 ),
             },
             _ => resolved,
         }
     }
 
-    fn resolve_named_aggregate_type_for_dynamic_member(&self, name: &str) -> Option<DwarfType> {
+    fn resolve_named_aggregate_type_for_dynamic_member(
+        &self,
+        name: &str,
+        module_path: Option<&Path>,
+    ) -> Option<DwarfType> {
         let analyzer = self.process_analyzer?;
         let mut candidates = Vec::new();
         let mut push_candidate = |candidate: &str| {
@@ -3538,18 +3590,17 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
         }
 
-        let module_path = self
-            .current_resolved_var_module_path
-            .clone()
-            .or_else(|| {
-                self.current_compile_time_context
-                    .as_ref()
-                    .map(|ctx| ctx.module_path.clone())
-            })
-            .map(std::path::PathBuf::from);
+        let fallback_module_path = if module_path.is_none() {
+            self.current_compile_time_context
+                .as_ref()
+                .map(|ctx| PathBuf::from(&ctx.module_path))
+        } else {
+            None
+        };
+        let module_path = module_path.or(fallback_module_path.as_deref());
 
         for candidate in candidates {
-            let in_module = module_path.as_ref().and_then(|module_path| {
+            let in_module = module_path.and_then(|module_path| {
                 analyzer
                     .resolve_struct_type_shallow_by_name_in_module(module_path, &candidate)
                     .or_else(|| {
@@ -3934,19 +3985,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     // Return const false (or true if '!=' requested)
                     return Ok((if is_equal { zero } else { one }).into());
                 }
-                let module_hint = self.current_resolved_var_module_path.clone();
                 let status_ptr = if self.condition_context_active {
                     Some(self.get_or_create_cond_error_global())
                 } else {
                     None
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                let addr = self.variable_read_plan_to_lvalue_address_with_hint(
-                    &var,
-                    pc_address,
-                    status_ptr,
-                    module_hint.as_deref(),
-                )?;
+                let addr =
+                    self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)?;
                 // Read exactly L+1 bytes
                 let (buf_global, status, arr_ty) =
                     self.read_user_bytes_into_buffer(addr, lit_len + 1, "_gs_arrbuf")?;
@@ -4031,19 +4077,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     .map_err(|e| CodeGenError::Builder(e.to_string()))?
             }
             None => {
-                let module_hint = self.current_resolved_var_module_path.clone();
                 let status_ptr = if self.condition_context_active {
                     Some(self.get_or_create_cond_error_global())
                 } else {
                     None
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                let addr = self.variable_read_plan_to_lvalue_address_with_hint(
-                    &var,
-                    pc_address,
-                    status_ptr,
-                    module_hint.as_deref(),
-                )?;
+                let addr =
+                    self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)?;
                 // Fallback using type_name string
                 match parse_type_name(&var.type_name) {
                     ParsedKind::PtrChar => {

--- a/ghostscope-dwarf/src/analyzer/mod.rs
+++ b/ghostscope-dwarf/src/analyzer/mod.rs
@@ -1220,6 +1220,7 @@ mod tests {
             name: name.to_string(),
             type_name: "int".to_string(),
             access_path: crate::VariableAccessPath::default(),
+            module_path: None,
             dwarf_type: Some(crate::TypeInfo::BaseType {
                 name: "int".to_string(),
                 size: 4,

--- a/ghostscope-dwarf/src/analyzer/plan_global.rs
+++ b/ghostscope-dwarf/src/analyzer/plan_global.rs
@@ -166,7 +166,9 @@ impl DwarfAnalyzer {
                     var.dwarf_type = Some(ti);
                 }
             }
-            Ok(Self::read_plan_from_variable(var, provenance))
+            let mut plan = Self::read_plan_from_variable(var, provenance);
+            plan.module_path = Some(path_buf);
+            Ok(plan)
         } else {
             Err(anyhow::anyhow!(
                 "Module {} not loaded",

--- a/ghostscope-dwarf/src/analyzer/plan_pc.rs
+++ b/ghostscope-dwarf/src/analyzer/plan_pc.rs
@@ -141,6 +141,7 @@ impl DwarfAnalyzer {
             end: ctx.normalized_pc,
         });
         plan.inline_context = ctx.inline_chain.last().and_then(|frame| frame.context);
+        plan.module_path = ctx.address_space.module_path.clone();
         plan
     }
 

--- a/ghostscope-dwarf/src/semantics/variable_plan.rs
+++ b/ghostscope-dwarf/src/semantics/variable_plan.rs
@@ -7,6 +7,7 @@ use crate::core::{
 };
 use crate::semantics::{strip_type_aliases, PcRange};
 use crate::TypeInfo;
+use std::path::PathBuf;
 
 /// Owned semantic view returned by PC-context variable queries.
 #[derive(Debug, Clone, PartialEq)]
@@ -174,6 +175,7 @@ pub struct VariableMaterializationPlan {
     pub name: String,
     pub type_name: String,
     pub access_path: VariableAccessPath,
+    pub module_path: Option<PathBuf>,
     pub dwarf_type: Option<TypeInfo>,
     pub availability: Availability,
     pub lowering: VariableLoweringPlan,
@@ -186,6 +188,7 @@ pub struct VariableReadPlan {
     pub name: String,
     pub type_name: String,
     pub access_path: VariableAccessPath,
+    pub module_path: Option<PathBuf>,
     pub dwarf_type: Option<TypeInfo>,
     pub declaration: Option<DieRef>,
     pub type_id: Option<TypeId>,
@@ -297,6 +300,7 @@ impl VariableReadPlan {
             name: variable.name,
             type_name: variable.type_name,
             access_path: VariableAccessPath::default(),
+            module_path: None,
             dwarf_type: variable.dwarf_type,
             declaration: variable.declaration,
             type_id: variable.type_id,
@@ -429,6 +433,7 @@ impl VariableReadPlan {
             name: self.name.clone(),
             type_name: self.type_name.clone(),
             access_path: self.access_path.clone(),
+            module_path: self.module_path.clone(),
             dwarf_type: self.dwarf_type.clone(),
             availability: lowering.availability.clone(),
             lowering,
@@ -1222,6 +1227,7 @@ mod tests {
             name: "value".to_string(),
             type_name: "int".to_string(),
             access_path: VariableAccessPath::default(),
+            module_path: None,
             dwarf_type: None,
             declaration: None,
             type_id: None,
@@ -1399,6 +1405,19 @@ mod tests {
             }
             other => panic!("unexpected materialization: {other:?}"),
         }
+    }
+
+    #[test]
+    fn materialization_plan_preserves_module_path_origin() {
+        let mut plan = read_plan(VariableLocation::Address(AddressExpr::constant(0x1000)));
+        plan.module_path = Some(PathBuf::from("/tmp/libstate.so"));
+
+        let materialized = plan.materialization_plan(&capabilities(true));
+
+        assert_eq!(
+            materialized.module_path,
+            Some(PathBuf::from("/tmp/libstate.so"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Global variable planning returned the resolved module path, but the compiler stored it in mutable context state and consumed it later during lowering. DWARF queries used only for type checks could leave stale hints behind, so later ASLR rebasing could use the wrong module for cross-module globals.

Store the module origin directly on read and materialization plans instead. Populate it in PC and global analyzers, and make compiler lowering use that explicit origin when converting link-time addresses to runtime addresses. Carry the same origin through dynamic array and member lowering so type completion for unknown aggregate targets is scoped to the module that owns the base variable.

Add a globals e2e regression with conflicting same-name struct layouts in the main executable and shared library. The test exercises dynamic member access through a shared-library global pointer and catches fallback to the current probe module.