### PR TITLE
refactor: centralize module resolution in dwarf

### DIFF
--- a/ghostscope-compiler/src/script/compiler.rs
+++ b/ghostscope-compiler/src/script/compiler.rs
@@ -1,6 +1,7 @@
 use crate::script::ast::{Program, Statement, TracePattern};
 use crate::CompileError;
 // BinaryAnalyzer is now internal to ghostscope-binary, use DwarfAnalyzer instead
+use ghostscope_dwarf::ModuleDefaultPolicy;
 use inkwell::context::Context;
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
@@ -360,133 +361,6 @@ impl<'a> AstCompiler<'a> {
             .filter(|path| !path.is_empty())
     }
 
-    fn loaded_module_paths(analyzer: &ghostscope_dwarf::DwarfAnalyzer) -> Vec<String> {
-        let mut modules: Vec<String> = Vec::new();
-        if let Some(main) = analyzer.get_main_executable() {
-            modules.push(main.path);
-        }
-        modules.extend(
-            analyzer
-                .get_shared_library_info()
-                .into_iter()
-                .map(|lib| lib.library_path),
-        );
-        if let Ok(grouped) = analyzer.get_grouped_file_info_by_module() {
-            modules.extend(grouped.into_iter().map(|(module_path, _files)| module_path));
-        }
-        modules.sort();
-        modules.dedup();
-        modules
-    }
-
-    fn paths_equivalent<P: AsRef<Path>, Q: AsRef<Path>>(left: P, right: Q) -> bool {
-        let left = left.as_ref();
-        let right = right.as_ref();
-        if left == right {
-            return true;
-        }
-
-        match (left.canonicalize(), right.canonicalize()) {
-            (Ok(left), Ok(right)) => left == right,
-            _ => false,
-        }
-    }
-
-    fn module_spec_matches_path(module_path: &str, module_spec: &str) -> bool {
-        let spec = module_spec.trim();
-        if spec.is_empty() {
-            return false;
-        }
-
-        Self::paths_equivalent(module_path, spec) || module_path.ends_with(spec)
-    }
-
-    fn module_spec_matches_target(&self, target_module_path: &str, module_spec: &str) -> bool {
-        Self::module_spec_matches_path(target_module_path, module_spec)
-            || self
-                .configured_target_path()
-                .map(|target_path| Self::module_spec_matches_path(target_path, module_spec))
-                .unwrap_or(false)
-    }
-
-    fn resolve_loaded_module_by_spec(
-        analyzer: &ghostscope_dwarf::DwarfAnalyzer,
-        module_spec: &str,
-    ) -> Result<String, CompileError> {
-        let modules = Self::loaded_module_paths(analyzer);
-
-        if let Some(found) = modules
-            .iter()
-            .find(|module_path| Self::paths_equivalent(module_path, module_spec))
-        {
-            return Ok(found.clone());
-        }
-
-        let candidates: Vec<String> = modules
-            .into_iter()
-            .filter(|module_path| module_path.ends_with(module_spec))
-            .collect();
-
-        match candidates.len() {
-            0 => Err(CompileError::Other(format!(
-                "Module '{module_spec}' not found among loaded modules. Use full path or a unique suffix."
-            ))),
-            1 => Ok(candidates[0].clone()),
-            _ => {
-                let mut sample = candidates.clone();
-                sample.truncate(5);
-                Err(CompileError::Other(format!(
-                    "Ambiguous module suffix '{}'. Candidates:\n  - {}\nPlease use a more specific suffix or full path.",
-                    module_spec,
-                    sample.join("\n  - ")
-                )))
-            }
-        }
-    }
-
-    fn resolve_target_module_path(&self) -> Result<Option<String>, CompileError> {
-        let Some(target_path) = self.configured_target_path() else {
-            return Ok(None);
-        };
-        let Some(analyzer) = self.process_analyzer else {
-            return Err(CompileError::Other(
-                "No process analyzer available to resolve -t target".to_string(),
-            ));
-        };
-
-        let matches: Vec<String> = Self::loaded_module_paths(analyzer)
-            .into_iter()
-            .filter(|module_path| Self::paths_equivalent(module_path, target_path))
-            .collect();
-
-        match matches.len() {
-            0 => Err(CompileError::Other(format!(
-                "Target '{target_path}' from -t is not loaded in the analyzed modules. When -t and -p are combined, -t scopes trace target resolution and -p only supplies PID filtering."
-            ))),
-            1 => Ok(Some(matches[0].clone())),
-            _ => Err(CompileError::Other(format!(
-                "Target '{target_path}' from -t matches multiple loaded modules; use a more specific path."
-            ))),
-        }
-    }
-
-    fn filter_module_addresses_to_target(
-        &self,
-        module_addresses: Vec<ghostscope_dwarf::ModuleAddress>,
-        target_module_path: Option<&str>,
-    ) -> Vec<ghostscope_dwarf::ModuleAddress> {
-        let Some(target_module_path) = target_module_path else {
-            return module_addresses;
-        };
-
-        module_addresses
-            .into_iter()
-            .filter(|module_address| {
-                Self::paths_equivalent(&module_address.module_path, target_module_path)
-            })
-            .collect()
-    }
-
     /// Process a trace point: resolve target + generate eBPF in one step
     fn process_trace_point(
         &mut self,
@@ -512,17 +386,19 @@ impl<'a> AstCompiler<'a> {
                     return Err(CompileError::Other(detailed));
                 }
 
-                let target_module_path = self.resolve_target_module_path()?;
                 let original_address_count = module_addresses.len();
-                let module_addresses = self.filter_module_addresses_to_target(
-                    module_addresses,
-                    target_module_path.as_deref(),
-                );
+                let target_path = self.configured_target_path();
+                let module_addresses = self
+                    .process_analyzer
+                    .ok_or_else(|| {
+                        CompileError::Other(
+                            "No process analyzer available to resolve -t target".to_string(),
+                        )
+                    })?
+                    .filter_module_addresses_to_target(module_addresses, target_path)
+                    .map_err(|e| CompileError::Other(e.to_string()))?;
                 if original_address_count > 0 && module_addresses.is_empty() {
-                    let target = target_module_path
-                        .as_deref()
-                        .or_else(|| self.configured_target_path())
-                        .unwrap_or("<unknown>");
+                    let target = target_path.unwrap_or("<unknown>");
                     return Err(CompileError::Other(format!(
                         "No addresses resolved for source line {file_path}:{line_number} in -t target '{target}'. When -t and -p are combined, -t takes precedence for trace target resolution."
                     )));
@@ -628,42 +504,22 @@ impl<'a> AstCompiler<'a> {
                 Ok(())
             }
             TracePattern::Address(addr) => {
-                // Resolve default module path
-                // Prefer the explicit -t target, including combined -t/-p
-                // sessions. Without -t, use the PID main executable; if
-                // unavailable (e.g., -t <lib>.so without a target option in
-                // legacy callers), fall back to a single loaded shared library.
-                let module_path: Option<String> = if let Some(analyzer) = &self.process_analyzer {
-                    if let Some(target_module) = self.resolve_target_module_path()? {
-                        Some(target_module)
-                    } else if let Some(main) = analyzer.get_main_executable() {
-                        Some(main.path)
-                    } else {
-                        let libs = analyzer.get_shared_library_info();
-                        if libs.len() == 1 {
-                            Some(libs[0].library_path.clone())
-                        } else {
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
-
-                let module_path = match module_path {
-                    Some(p) => p,
-                    None => {
-                        return Err(CompileError::Other(
-                            "No module available to resolve address. In PID mode, default module is the main executable. In target mode (-t <binary>), the specified binary is used (including .so).".to_string(),
-                        ));
-                    }
-                };
+                let analyzer = self.process_analyzer.ok_or_else(|| {
+                    CompileError::Other(
+                        "No process analyzer available to resolve address".to_string(),
+                    )
+                })?;
+                let module_path = analyzer
+                    .resolve_address_module(
+                        None,
+                        self.configured_target_path(),
+                        ModuleDefaultPolicy::MainExecutableOrSingleSharedLibrary,
+                    )
+                    .map_err(|e| CompileError::Other(e.to_string()))?;
 
                 // Convert DWARF PC (vaddr) to ELF file offset for uprobe
-                let file_off = self
-                    .process_analyzer
-                    .as_ref()
-                    .and_then(|an| an.vaddr_to_file_offset(&module_path, *addr));
+                let file_off = analyzer.vaddr_to_file_offset(&module_path, *addr);
+                let module_path = module_path.to_string_lossy().to_string();
 
                 if file_off.is_none() {
                     return Err(CompileError::Other(format!(
@@ -701,31 +557,22 @@ impl<'a> AstCompiler<'a> {
                 }
             }
             TracePattern::AddressInModule { module, address } => {
-                // Resolve module path by exact or suffix match across loaded modules.
-                // If -t is configured, keep resolution scoped to that target.
-                let module_path = if let Some(analyzer) = &self.process_analyzer {
-                    if let Some(target_module) = self.resolve_target_module_path()? {
-                        if self.module_spec_matches_target(&target_module, module) {
-                            target_module
-                        } else {
-                            return Err(CompileError::Other(format!(
-                                "Module '{module}' is outside -t target '{target_module}'. When -t and -p are combined, -t takes precedence for trace target resolution."
-                            )));
-                        }
-                    } else {
-                        Self::resolve_loaded_module_by_spec(analyzer, module)?
-                    }
-                } else {
-                    return Err(CompileError::Other(
+                let analyzer = self.process_analyzer.ok_or_else(|| {
+                    CompileError::Other(
                         "No process analyzer available to resolve module".to_string(),
-                    ));
-                };
+                    )
+                })?;
+                let module_path = analyzer
+                    .resolve_address_module(
+                        Some(module),
+                        self.configured_target_path(),
+                        ModuleDefaultPolicy::MainExecutableOrSingleSharedLibrary,
+                    )
+                    .map_err(|e| CompileError::Other(e.to_string()))?;
 
                 // Convert DWARF PC (vaddr) to ELF file offset for uprobe
-                let file_off = self
-                    .process_analyzer
-                    .as_ref()
-                    .and_then(|an| an.vaddr_to_file_offset(&module_path, *address));
+                let file_off = analyzer.vaddr_to_file_offset(&module_path, *address);
+                let module_path = module_path.to_string_lossy().to_string();
 
                 if file_off.is_none() {
                     return Err(CompileError::Other(format!(
@@ -780,17 +627,19 @@ impl<'a> AstCompiler<'a> {
                     )));
                 }
 
-                let target_module_path = self.resolve_target_module_path()?;
                 let original_address_count = module_addresses.len();
-                let module_addresses = self.filter_module_addresses_to_target(
-                    module_addresses,
-                    target_module_path.as_deref(),
-                );
+                let target_path = self.configured_target_path();
+                let module_addresses = self
+                    .process_analyzer
+                    .ok_or_else(|| {
+                        CompileError::Other(
+                            "No process analyzer available to resolve -t target".to_string(),
+                        )
+                    })?
+                    .filter_module_addresses_to_target(module_addresses, target_path)
+                    .map_err(|e| CompileError::Other(e.to_string()))?;
                 if original_address_count > 0 && module_addresses.is_empty() {
-                    let target = target_module_path
-                        .as_deref()
-                        .or_else(|| self.configured_target_path())
-                        .unwrap_or("<unknown>");
+                    let target = target_path.unwrap_or("<unknown>");
                     return Err(CompileError::Other(format!(
                         "No addresses resolved for function '{func_name}' in -t target '{target}'. When -t and -p are combined, -t takes precedence for trace target resolution."
                     )));

--- a/ghostscope-dwarf/src/analyzer/mod.rs
+++ b/ghostscope-dwarf/src/analyzer/mod.rs
@@ -14,9 +14,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+mod module_resolution;
 mod plan_global;
 mod plan_pc;
 mod type_lookup;
+
+pub use module_resolution::ModuleDefaultPolicy;
 
 #[cfg(test)]
 use crate::{

--- a/ghostscope-dwarf/src/analyzer/module_resolution.rs
+++ b/ghostscope-dwarf/src/analyzer/module_resolution.rs
@@ -1,0 +1,272 @@
+use super::{AddressQueryResult, DwarfAnalyzer};
+use crate::core::{ModuleAddress, Result};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleDefaultPolicy {
+    MainExecutableOnly,
+    MainExecutableOrSingleSharedLibrary,
+}
+
+impl DwarfAnalyzer {
+    /// Return loaded module paths in deterministic order.
+    pub fn module_paths(&self) -> Vec<PathBuf> {
+        let mut modules: Vec<PathBuf> = self.modules.keys().cloned().collect();
+        modules.sort();
+        modules
+    }
+
+    /// Treat identical paths and symlink aliases that canonicalize to the same
+    /// file as the same loaded module.
+    pub fn module_paths_equivalent<P: AsRef<Path>, Q: AsRef<Path>>(left: P, right: Q) -> bool {
+        let left = left.as_ref();
+        let right = right.as_ref();
+        if left == right {
+            return true;
+        }
+
+        match (left.canonicalize(), right.canonicalize()) {
+            (Ok(left), Ok(right)) => left == right,
+            _ => false,
+        }
+    }
+
+    /// Match a user-provided module spec against a loaded path by exact path,
+    /// symlink equivalence, or unique suffix.
+    pub fn module_spec_matches_path<P: AsRef<Path>>(module_path: P, module_spec: &str) -> bool {
+        let spec = module_spec.trim();
+        if spec.is_empty() {
+            return false;
+        }
+
+        let module_path = module_path.as_ref();
+        Self::module_paths_equivalent(module_path, Path::new(spec))
+            || module_path.to_string_lossy().ends_with(spec)
+    }
+
+    /// Resolve a module spec against all loaded modules.
+    pub fn resolve_loaded_module_by_spec(&self, module_spec: &str) -> Result<PathBuf> {
+        let module_spec = module_spec.trim();
+        if module_spec.is_empty() {
+            return Err(anyhow::anyhow!("Module spec is empty"));
+        }
+
+        let modules = self.module_paths();
+
+        if let Some(found) = modules
+            .iter()
+            .find(|module_path| Self::module_paths_equivalent(module_path, Path::new(module_spec)))
+        {
+            return Ok(found.clone());
+        }
+
+        let candidates: Vec<PathBuf> = modules
+            .into_iter()
+            .filter(|module_path| module_path.to_string_lossy().ends_with(module_spec))
+            .collect();
+
+        match candidates.len() {
+            0 => Err(anyhow::anyhow!(
+                "Module '{module_spec}' not found among loaded modules. Use full path or a unique suffix."
+            )),
+            1 => Ok(candidates[0].clone()),
+            _ => {
+                let sample: Vec<String> = candidates
+                    .iter()
+                    .take(5)
+                    .map(|path| path.to_string_lossy().to_string())
+                    .collect();
+                Err(anyhow::anyhow!(
+                    "Ambiguous module suffix '{}'. Candidates:\n  - {}\nPlease use a more specific suffix or full path.",
+                    module_spec,
+                    sample.join("\n  - ")
+                ))
+            }
+        }
+    }
+
+    /// Resolve the configured -t path to the corresponding loaded module.
+    pub fn resolve_target_module_path(&self, target_path: &str) -> Result<PathBuf> {
+        let target_path = target_path.trim();
+        if target_path.is_empty() {
+            return Err(anyhow::anyhow!("Target path from -t is empty"));
+        }
+
+        let matches: Vec<PathBuf> = self
+            .module_paths()
+            .into_iter()
+            .filter(|module_path| {
+                Self::module_paths_equivalent(module_path, Path::new(target_path))
+            })
+            .collect();
+
+        match matches.len() {
+            0 => Err(anyhow::anyhow!(
+                "Target '{target_path}' from -t is not loaded in the analyzed modules. When -t and -p are combined, -t scopes trace target resolution and -p only supplies PID filtering."
+            )),
+            1 => Ok(matches[0].clone()),
+            _ => Err(anyhow::anyhow!(
+                "Target '{target_path}' from -t matches multiple loaded modules; use a more specific path."
+            )),
+        }
+    }
+
+    /// Resolve an explicit module spec, respecting -t scoping when configured.
+    pub fn resolve_module_spec(
+        &self,
+        module_spec: &str,
+        target_path: Option<&str>,
+    ) -> Result<PathBuf> {
+        let Some(target_path) = target_path else {
+            return self.resolve_loaded_module_by_spec(module_spec);
+        };
+
+        let target_module = self.resolve_target_module_path(target_path)?;
+        if Self::module_spec_matches_path(&target_module, module_spec)
+            || Self::module_spec_matches_path(target_path, module_spec)
+        {
+            Ok(target_module)
+        } else {
+            Err(anyhow::anyhow!(
+                "Module '{}' is outside -t target '{}'. When -t is configured, module resolution is scoped to the target.",
+                module_spec.trim(),
+                target_module.display()
+            ))
+        }
+    }
+
+    /// Resolve the module to use for a module-relative address query.
+    pub fn resolve_address_module(
+        &self,
+        module_spec: Option<&str>,
+        target_path: Option<&str>,
+        fallback: ModuleDefaultPolicy,
+    ) -> Result<PathBuf> {
+        if let Some(module_spec) = module_spec {
+            return self.resolve_module_spec(module_spec, target_path);
+        }
+
+        if let Some(target_path) = target_path {
+            return self.resolve_target_module_path(target_path);
+        }
+
+        if let Some(main) = self
+            .module_paths()
+            .into_iter()
+            .find(|module_path| self.is_main_executable_module(module_path))
+        {
+            return Ok(main);
+        }
+
+        if fallback == ModuleDefaultPolicy::MainExecutableOrSingleSharedLibrary {
+            let libs: Vec<PathBuf> = self
+                .module_paths()
+                .into_iter()
+                .filter(|module_path| self.is_shared_library(module_path))
+                .collect();
+            if libs.len() == 1 {
+                return Ok(libs[0].clone());
+            }
+        }
+
+        let message = match fallback {
+            ModuleDefaultPolicy::MainExecutableOnly => {
+                "No default module available. Start with -p <pid> or -t <binary>."
+            }
+            ModuleDefaultPolicy::MainExecutableOrSingleSharedLibrary => {
+                "No module available to resolve address. In PID mode, default module is the main executable. In target mode (-t <binary>), the specified binary is used (including .so)."
+            }
+        };
+        Err(anyhow::anyhow!(message))
+    }
+
+    /// Filter module-address matches to the configured -t target.
+    pub fn filter_module_addresses_to_target(
+        &self,
+        module_addresses: Vec<ModuleAddress>,
+        target_path: Option<&str>,
+    ) -> Result<Vec<ModuleAddress>> {
+        let Some(target_path) = target_path else {
+            return Ok(module_addresses);
+        };
+        if module_addresses.is_empty() {
+            return Ok(module_addresses);
+        }
+
+        let target_module = self.resolve_target_module_path(target_path)?;
+        Ok(module_addresses
+            .into_iter()
+            .filter(|module_address| {
+                Self::module_paths_equivalent(&module_address.module_path, &target_module)
+            })
+            .collect())
+    }
+
+    /// Filter address-query matches to the configured -t target.
+    pub fn filter_address_results_to_target(
+        &self,
+        addresses: Vec<AddressQueryResult>,
+        target_path: Option<&str>,
+    ) -> Result<Vec<AddressQueryResult>> {
+        let Some(target_path) = target_path else {
+            return Ok(addresses);
+        };
+        if addresses.is_empty() {
+            return Ok(addresses);
+        }
+
+        let target_module = self.resolve_target_module_path(target_path)?;
+        Ok(addresses
+            .into_iter()
+            .filter(|address| Self::module_paths_equivalent(&address.module_path, &target_module))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_spec_rejects_empty_strings() {
+        assert!(!DwarfAnalyzer::module_spec_matches_path(
+            "/tmp/libfoo.so",
+            ""
+        ));
+        assert!(!DwarfAnalyzer::module_spec_matches_path(
+            "/tmp/libfoo.so",
+            "   "
+        ));
+    }
+
+    #[test]
+    fn module_spec_matches_unique_suffixes() {
+        assert!(DwarfAnalyzer::module_spec_matches_path(
+            "/opt/app/lib/libfoo.so.1",
+            "lib/libfoo.so.1"
+        ));
+        assert!(DwarfAnalyzer::module_spec_matches_path(
+            "/opt/app/lib/libfoo.so.1",
+            "libfoo.so.1"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn module_spec_matches_symlink_alias() -> anyhow::Result<()> {
+        use std::os::unix::fs as unix_fs;
+
+        let temp_dir = tempfile::tempdir()?;
+        let real_path = temp_dir.path().join("libfoo.so.1");
+        let alias_path = temp_dir.path().join("libfoo.so");
+        std::fs::write(&real_path, b"test")?;
+        unix_fs::symlink(&real_path, &alias_path)?;
+
+        assert!(DwarfAnalyzer::module_spec_matches_path(
+            &real_path,
+            alias_path.to_string_lossy().as_ref()
+        ));
+
+        Ok(())
+    }
+}

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -21,8 +21,9 @@ pub mod analyzer;
 
 // Re-export main public API only
 pub use analyzer::{
-    AddressQueryResult, DwarfAnalyzer, FunctionQueryResult, MainExecutableInfo, ModuleLoadingEvent,
-    ModuleLoadingStats, ModuleStats, SharedLibraryInfo, SimpleFileInfo,
+    AddressQueryResult, DwarfAnalyzer, FunctionQueryResult, MainExecutableInfo,
+    ModuleDefaultPolicy, ModuleLoadingEvent, ModuleLoadingStats, ModuleStats, SharedLibraryInfo,
+    SimpleFileInfo,
 };
 
 // Re-export essential core and semantic support types.

--- a/ghostscope/src/tui/info_handlers.rs
+++ b/ghostscope/src/tui/info_handlers.rs
@@ -1,44 +1,7 @@
 use crate::core::GhostSession;
-use ghostscope_dwarf::{AddressQueryResult, FunctionQueryResult};
+use ghostscope_dwarf::{AddressQueryResult, FunctionQueryResult, ModuleDefaultPolicy};
 use ghostscope_ui::{events::*, RuntimeChannels, RuntimeStatus};
-use std::path::Path;
 use tracing::info;
-
-fn paths_equivalent<P: AsRef<Path>, Q: AsRef<Path>>(left: P, right: Q) -> bool {
-    let left = left.as_ref();
-    let right = right.as_ref();
-    if left == right {
-        return true;
-    }
-
-    match (left.canonicalize(), right.canonicalize()) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => false,
-    }
-}
-
-fn module_spec_matches_path(module_path: &str, module_spec: &str) -> bool {
-    let spec = module_spec.trim();
-    if spec.is_empty() {
-        return false;
-    }
-
-    paths_equivalent(module_path, spec) || module_path.ends_with(spec)
-}
-
-fn filter_address_results_to_target(
-    addresses: Vec<AddressQueryResult>,
-    target_path: Option<&str>,
-) -> Vec<AddressQueryResult> {
-    let Some(target_path) = target_path else {
-        return addresses;
-    };
-
-    addresses
-        .into_iter()
-        .filter(|address| paths_equivalent(&address.module_path, target_path))
-        .collect()
-}
 
 /// Handle InfoTrace command
 pub async fn handle_info_trace(
@@ -368,86 +331,6 @@ pub async fn handle_info_address(
         }
     }
 
-    // Helper: resolve module path by exact or suffix match
-    fn resolve_module_path(
-        analyzer: &ghostscope_dwarf::DwarfAnalyzer,
-        sess: &GhostSession,
-        module_spec: Option<&str>,
-    ) -> Result<String, String> {
-        // Build module list: main + shared libraries
-        let mut modules: Vec<String> = Vec::new();
-        if let Some(main) = analyzer.get_main_executable() {
-            modules.push(main.path);
-        }
-        for lib in analyzer.get_shared_library_info() {
-            modules.push(lib.library_path);
-        }
-        if let Ok(grouped) = analyzer.get_grouped_file_info_by_module() {
-            modules.extend(grouped.into_iter().map(|(module_path, _files)| module_path));
-        }
-        modules.sort();
-        modules.dedup();
-
-        if let Some(target_path) = sess.target_binary.as_deref() {
-            let target_module = modules
-                .iter()
-                .find(|module_path| paths_equivalent(module_path, target_path))
-                .cloned()
-                .unwrap_or_else(|| target_path.to_string());
-
-            if let Some(spec) = module_spec {
-                let spec = spec.trim();
-                if !module_spec_matches_path(&target_module, spec)
-                    && !module_spec_matches_path(target_path, spec)
-                {
-                    return Err(format!(
-                        "Module '{spec}' is outside -t target '{target_module}'. When -t and -p are combined, -t takes precedence for address queries."
-                    ));
-                }
-            }
-
-            return Ok(target_module);
-        }
-
-        if let Some(spec) = module_spec {
-            let spec = spec.trim();
-            // Exact match first
-            if let Some(found) = modules
-                .iter()
-                .find(|module_path| paths_equivalent(module_path, spec))
-            {
-                return Ok(found.clone());
-            }
-            // Suffix match
-            let candidates: Vec<String> =
-                modules.into_iter().filter(|p| p.ends_with(spec)).collect();
-            match candidates.len() {
-                0 => Err(format!(
-                    "Module '{spec}' not found among loaded modules. Use full path or a unique suffix."
-                )),
-                1 => Ok(candidates[0].clone()),
-                _ => {
-                    let mut sample = candidates.clone();
-                    sample.truncate(5);
-                    Err(format!(
-                        "Ambiguous module suffix '{}'. Candidates:\n  - {}\nPlease use a more specific suffix or full path.",
-                        spec,
-                        sample.join("\n  - ")
-                    ))
-                }
-            }
-        } else {
-            // No module specified: choose default based on mode
-            // Otherwise use main executable
-            analyzer
-                .get_main_executable()
-                .map(|m| m.path)
-                .ok_or_else(|| {
-                    "No default module available. Start with -p <pid> or -t <binary>.".to_string()
-                })
-        }
-    }
-
     let result = (|| -> Result<TargetDebugInfo, String> {
         let sess = session.as_mut().ok_or_else(|| {
             "No active debugging session. Target process may not be attached or DWARF symbols are unavailable.".to_string()
@@ -466,16 +349,18 @@ pub async fn handle_info_address(
         };
 
         let vaddr = parse_addr(addr_str)?;
-        let module_path = resolve_module_path(analyzer, sess, module_spec)?;
+        let module_path = analyzer
+            .resolve_address_module(
+                module_spec,
+                sess.target_binary.as_deref(),
+                ModuleDefaultPolicy::MainExecutableOnly,
+            )
+            .map_err(|e| e.to_string())?;
+        let module_display = module_path.to_string_lossy().to_string();
 
-        let address_info = sess
-            .process_analyzer
-            .as_mut()
-            .unwrap()
-            .query_address(&module_path, vaddr)
-            .map_err(|e| {
-                format!("Failed to analyze address 0x{vaddr:x} in module '{module_path}': {e}")
-            })?;
+        let address_info = analyzer.query_address(&module_path, vaddr).map_err(|e| {
+            format!("Failed to analyze address 0x{vaddr:x} in module '{module_display}': {e}")
+        })?;
 
         Ok(TargetDebugInfo {
             target: if let Some(ms) = module_spec {
@@ -597,7 +482,9 @@ fn try_get_line_debug_info(
         let query_results = process_analyzer
             .query_source_line_best_effort(cand, line_number)
             .map_err(|e| format!("Failed to analyze {cand}:{line_number}: {e}"))?;
-        let query_results = filter_address_results_to_target(query_results, target_path.as_deref());
+        let query_results = process_analyzer
+            .filter_address_results_to_target(query_results, target_path.as_deref())
+            .map_err(|e| e.to_string())?;
         if !query_results.is_empty() {
             let cand_target = format!("{cand}:{line_number}");
             return Ok(build_source_location_target_debug_info(
@@ -728,11 +615,14 @@ fn build_target_debug_info_from_query_results(
 }
 
 fn handle_function_query_result(
+    process_analyzer: &ghostscope_dwarf::DwarfAnalyzer,
     query_result: FunctionQueryResult,
     target_path: Option<&str>,
 ) -> Result<TargetDebugInfo, String> {
     let raw_address_count = query_result.addresses.len();
-    let addresses = filter_address_results_to_target(query_result.addresses, target_path);
+    let addresses = process_analyzer
+        .filter_address_results_to_target(query_result.addresses, target_path)
+        .map_err(|e| e.to_string())?;
     if raw_address_count == 0 {
         return Err(format!(
             "Function '{}' not found in any loaded module",
@@ -798,7 +688,7 @@ fn handle_function_target(
     let query_result = process_analyzer
         .query_function_best_effort(function_name)
         .map_err(|e| format!("Failed to analyze function '{function_name}': {e}"))?;
-    handle_function_query_result(query_result, target_path)
+    handle_function_query_result(process_analyzer, query_result, target_path)
 }
 
 /// Handle source location target (file:line)
@@ -818,7 +708,9 @@ fn handle_source_location_target(
         .query_source_line_best_effort(file_path, line_number)
         .map_err(|e| format!("Failed to analyze {file_path}:{line_number}: {e}"))?;
     let raw_address_count = query_results.len();
-    let query_results = filter_address_results_to_target(query_results, target_path);
+    let query_results = process_analyzer
+        .filter_address_results_to_target(query_results, target_path)
+        .map_err(|e| e.to_string())?;
 
     if query_results.is_empty() {
         if raw_address_count > 0 {


### PR DESCRIPTION
Move target, suffix, and symlink-aware module resolution into the DWARF analyzer so compiler and TUI callers share the same behavior.

Keep -t scoped filtering and address module fallback behind shared analyzer APIs.