### PR TITLE
refactor: centralize source line resolution

### DIFF
--- a/ghostscope-compiler/src/script/compiler.rs
+++ b/ghostscope-compiler/src/script/compiler.rs
@@ -7,7 +7,6 @@ use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::Write as _;
 use std::hash::{Hash, Hasher};
-use std::path::Path;
 use tracing::{debug, error, info, warn};
 
 /// Resolved target information from DWARF queries
@@ -256,103 +255,6 @@ impl<'a> AstCompiler<'a> {
         message
     }
 
-    /// Build a detailed error message for SourceLine resolution failures
-    fn describe_source_line_failure(&mut self, file_path: &str, line_number: u32) -> String {
-        let default_msg =
-            format!("No addresses resolved for source line {file_path}:{line_number}");
-
-        let analyzer = match self.process_analyzer {
-            Some(a) => a,
-            None => return default_msg,
-        };
-
-        let grouped = match analyzer.get_grouped_file_info_by_module() {
-            Ok(g) => g,
-            Err(_) => return default_msg,
-        };
-
-        // Collect all full paths and those sharing the basename
-        let mut all_full_paths: Vec<String> = Vec::new();
-        let mut same_basename_paths: Vec<String> = Vec::new();
-        let has_sep = file_path.contains('/') || file_path.contains('\\');
-        let basename = Path::new(file_path)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or(file_path);
-
-        for (_module, files) in &grouped {
-            for f in files {
-                all_full_paths.push(f.full_path.clone());
-                if f.basename == basename {
-                    same_basename_paths.push(f.full_path.clone());
-                }
-            }
-        }
-
-        if all_full_paths.is_empty() {
-            return default_msg;
-        }
-
-        let exact_match = all_full_paths.iter().any(|p| p == file_path);
-        let suffix_matches: Vec<String> = all_full_paths
-            .iter()
-            .filter(|p| p.ends_with(file_path) || file_path.ends_with(p.as_str()))
-            .cloned()
-            .collect();
-
-        if same_basename_paths.is_empty() {
-            return format!(
-                "Source file not found in DWARF: {file_path}.\n- Tips: use 'srcpath map <dwf_comp_dir> <local_dir>' or pass full DWARF path.\n- List files with: dwarf-tool source-files or 'info source-files'"
-            );
-        }
-
-        if !exact_match && suffix_matches.is_empty() && has_sep && same_basename_paths.len() > 1 {
-            let mut samples = same_basename_paths.clone();
-            samples.sort();
-            samples.dedup();
-            if samples.len() > 3 {
-                samples.truncate(3);
-            }
-            let sample_list = samples.join("\n  - ");
-            return format!(
-                "Multiple files named '{basename}' found; the given path '{file_path}' did not uniquely match by suffix.\nTry a more specific path or add a path mapping (srcpath map).\nExamples:\n  - {sample_list}"
-            );
-        }
-
-        // Probe a few candidate paths to see if any has addresses on this line
-        let mut hit_candidates: Vec<String> = Vec::new();
-        let probe_list: Vec<String> = if !suffix_matches.is_empty() {
-            suffix_matches
-        } else {
-            let mut v = same_basename_paths.clone();
-            v.sort();
-            v.dedup();
-            v.truncate(20);
-            v
-        };
-
-        for cand in &probe_list {
-            let addrs = analyzer.lookup_addresses_by_source_line(cand, line_number);
-            if !addrs.is_empty() {
-                hit_candidates.push(cand.clone());
-                if hit_candidates.len() >= 3 {
-                    break;
-                }
-            }
-        }
-
-        if !hit_candidates.is_empty() {
-            let list = hit_candidates.join("\n  - ");
-            return format!(
-                "Ambiguous path: '{file_path}' did not resolve, but found addresses for the same line in:\n  - {list}\nPlease use a more specific path (full DWARF path) or add a mapping (srcpath map)."
-            );
-        }
-
-        format!(
-            "No executable addresses for {file_path}:{line_number} (file exists in DWARF but this line has no statement).\nTry a nearby line, or rebuild with debug info and lower optimization (e.g., -g -O0)."
-        )
-    }
-
     fn configured_target_path(&self) -> Option<&str> {
         self.compile_options
             .target_binary_path
@@ -374,34 +276,30 @@ impl<'a> AstCompiler<'a> {
                 file_path,
                 line_number,
             } => {
-                // Obtain addresses first in a separate scope to avoid holding a mutable borrow of self
-                let module_addresses = if let Some(analyzer) = self.process_analyzer {
-                    analyzer.lookup_addresses_by_source_line(file_path, *line_number)
-                } else {
-                    Vec::new()
-                };
-
-                if module_addresses.is_empty() {
-                    let detailed = self.describe_source_line_failure(file_path, *line_number);
-                    return Err(CompileError::Other(detailed));
-                }
-
-                let original_address_count = module_addresses.len();
+                let analyzer = self.process_analyzer.ok_or_else(|| {
+                    CompileError::Other(
+                        "No process analyzer available to resolve source line".to_string(),
+                    )
+                })?;
                 let target_path = self.configured_target_path();
-                let module_addresses = self
-                    .process_analyzer
-                    .ok_or_else(|| {
-                        CompileError::Other(
-                            "No process analyzer available to resolve -t target".to_string(),
-                        )
-                    })?
-                    .filter_module_addresses_to_target(module_addresses, target_path)
+                let source_line = analyzer
+                    .resolve_source_line_addresses_best_effort(
+                        analyzer.source_line_candidates(file_path),
+                        *line_number,
+                        target_path,
+                    )
                     .map_err(|e| CompileError::Other(e.to_string()))?;
-                if original_address_count > 0 && module_addresses.is_empty() {
+                let module_addresses = source_line.addresses;
+
+                if source_line.raw_address_count > 0 && module_addresses.is_empty() {
                     let target = target_path.unwrap_or("<unknown>");
                     return Err(CompileError::Other(format!(
                         "No addresses resolved for source line {file_path}:{line_number} in -t target '{target}'. When -t and -p are combined, -t takes precedence for trace target resolution."
                     )));
+                }
+                if module_addresses.is_empty() {
+                    let detailed = analyzer.describe_source_line_failure(file_path, *line_number);
+                    return Err(CompileError::Other(detailed));
                 }
 
                 debug!(

--- a/ghostscope-dwarf/src/analyzer/mod.rs
+++ b/ghostscope-dwarf/src/analyzer/mod.rs
@@ -17,9 +17,11 @@ use std::sync::Arc;
 mod module_resolution;
 mod plan_global;
 mod plan_pc;
+mod source_resolution;
 mod type_lookup;
 
 pub use module_resolution::ModuleDefaultPolicy;
+pub use source_resolution::{SourceLineAddressSearch, SourceLineQuerySearch};
 
 #[cfg(test)]
 use crate::{

--- a/ghostscope-dwarf/src/analyzer/source_resolution.rs
+++ b/ghostscope-dwarf/src/analyzer/source_resolution.rs
@@ -1,0 +1,278 @@
+use super::{AddressQueryResult, DwarfAnalyzer};
+use crate::{
+    core::{ModuleAddress, Result},
+    path_match,
+};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone)]
+pub struct SourceLineAddressSearch {
+    pub file_path: Option<String>,
+    pub line_number: u32,
+    pub raw_address_count: usize,
+    pub addresses: Vec<ModuleAddress>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceLineQuerySearch {
+    pub file_path: Option<String>,
+    pub line_number: u32,
+    pub raw_address_count: usize,
+    pub addresses: Vec<AddressQueryResult>,
+}
+
+impl DwarfAnalyzer {
+    /// Build DWARF source path candidates for a user-provided file path.
+    ///
+    /// This keeps DWARF path matching rules in the analyzer: exact paths first,
+    /// then component-boundary suffix matches, then unique basename matches
+    /// for bare filenames, and finally the original query.
+    pub fn source_line_candidates(&self, file_path: &str) -> Vec<String> {
+        let Ok(grouped) = self.get_grouped_file_info_by_module() else {
+            return vec![file_path.to_string()];
+        };
+
+        let mut exact = Vec::new();
+        let mut suffix_matches = Vec::new();
+        let mut basename_matches = Vec::new();
+        let mut seen_paths = HashSet::new();
+        let has_separator = path_match::has_path_separator(file_path);
+        let basename = path_match::file_name(file_path);
+
+        for (_module_path, files) in grouped {
+            for file in files {
+                if !seen_paths.insert(file.full_path.clone()) {
+                    continue;
+                }
+
+                if file.full_path == file_path {
+                    exact.push(file.full_path);
+                } else if has_separator
+                    && (path_match::path_component_suffix_matches(&file.full_path, file_path)
+                        || path_match::path_component_suffix_matches(file_path, &file.full_path))
+                {
+                    suffix_matches.push(file.full_path);
+                } else if !has_separator && file.basename == basename {
+                    basename_matches.push(file.full_path);
+                }
+            }
+        }
+
+        exact.sort();
+        suffix_matches.sort();
+        basename_matches.sort();
+        let basename_candidate = if basename_matches.len() == 1 {
+            basename_matches.pop()
+        } else {
+            None
+        };
+
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::new();
+        for candidate in exact
+            .into_iter()
+            .chain(suffix_matches)
+            .chain(basename_candidate)
+            .chain([file_path.to_string()])
+        {
+            if !candidate.trim().is_empty() && seen.insert(candidate.clone()) {
+                candidates.push(candidate);
+            }
+        }
+        candidates
+    }
+
+    /// Probe source-line candidates until a candidate resolves to addresses.
+    ///
+    /// If a candidate resolves before target filtering but all addresses are
+    /// filtered out, the first filtered match is returned with an empty address
+    /// list so callers can produce a target-scoped error.
+    pub fn resolve_source_line_addresses_best_effort<I, S>(
+        &self,
+        candidates: I,
+        line_number: u32,
+        target_path: Option<&str>,
+    ) -> Result<SourceLineAddressSearch>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut seen = HashSet::new();
+        let mut first_target_filtered: Option<SourceLineAddressSearch> = None;
+
+        for candidate in candidates {
+            let candidate = candidate.as_ref().trim();
+            if candidate.is_empty() || !seen.insert(candidate.to_string()) {
+                continue;
+            }
+
+            let module_addresses = self.lookup_addresses_by_source_line(candidate, line_number);
+            let raw_address_count = module_addresses.len();
+            if raw_address_count == 0 {
+                continue;
+            }
+
+            let addresses =
+                self.filter_module_addresses_to_target(module_addresses, target_path)?;
+            let search = SourceLineAddressSearch {
+                file_path: Some(candidate.to_string()),
+                line_number,
+                raw_address_count,
+                addresses,
+            };
+
+            if !search.addresses.is_empty() {
+                return Ok(search);
+            }
+            if first_target_filtered.is_none() {
+                first_target_filtered = Some(search);
+            }
+        }
+
+        Ok(first_target_filtered.unwrap_or(SourceLineAddressSearch {
+            file_path: None,
+            line_number,
+            raw_address_count: 0,
+            addresses: Vec::new(),
+        }))
+    }
+
+    /// Probe source-line candidates and return rich debug information for the
+    /// first candidate with address results.
+    pub fn resolve_source_line_query_best_effort<I, S>(
+        &self,
+        candidates: I,
+        line_number: u32,
+        target_path: Option<&str>,
+    ) -> Result<SourceLineQuerySearch>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let address_search =
+            self.resolve_source_line_addresses_best_effort(candidates, line_number, target_path)?;
+        let Some(file_path) = address_search.file_path.clone() else {
+            return Ok(SourceLineQuerySearch {
+                file_path: None,
+                line_number,
+                raw_address_count: 0,
+                addresses: Vec::new(),
+            });
+        };
+
+        if address_search.addresses.is_empty() {
+            return Ok(SourceLineQuerySearch {
+                file_path: Some(file_path),
+                line_number,
+                raw_address_count: address_search.raw_address_count,
+                addresses: Vec::new(),
+            });
+        }
+
+        let addresses = self.query_module_addresses_for_source_line_best_effort(
+            address_search.addresses,
+            &file_path,
+            line_number,
+            &format!("source line '{file_path}:{line_number}'"),
+        )?;
+
+        Ok(SourceLineQuerySearch {
+            file_path: Some(file_path),
+            line_number,
+            raw_address_count: address_search.raw_address_count,
+            addresses,
+        })
+    }
+
+    /// Explain why a source-line lookup did not resolve to executable addresses.
+    pub fn describe_source_line_failure(&self, file_path: &str, line_number: u32) -> String {
+        let default_msg =
+            format!("No addresses resolved for source line {file_path}:{line_number}");
+
+        let grouped = match self.get_grouped_file_info_by_module() {
+            Ok(grouped) => grouped,
+            Err(_) => return default_msg,
+        };
+
+        let mut all_full_paths = Vec::new();
+        let mut same_basename_paths = Vec::new();
+        let has_sep = path_match::has_path_separator(file_path);
+        let basename = path_match::file_name(file_path);
+
+        for (_module, files) in &grouped {
+            for file in files {
+                all_full_paths.push(file.full_path.clone());
+                if file.basename == basename {
+                    same_basename_paths.push(file.full_path.clone());
+                }
+            }
+        }
+
+        if all_full_paths.is_empty() {
+            return default_msg;
+        }
+
+        let exact_match = all_full_paths.iter().any(|path| path == file_path);
+        let suffix_matches: Vec<String> = all_full_paths
+            .iter()
+            .filter(|path| {
+                path_match::path_component_suffix_matches(path, file_path)
+                    || path_match::path_component_suffix_matches(file_path, path)
+            })
+            .cloned()
+            .collect();
+
+        if same_basename_paths.is_empty() {
+            return format!(
+                "Source file not found in DWARF: {file_path}.\n- Tips: use 'srcpath map <dwarf_comp_dir> <local_dir>' or pass full DWARF path.\n- List files with: dwarf-tool source-files or 'info source-files'"
+            );
+        }
+
+        if !exact_match && suffix_matches.is_empty() && has_sep && same_basename_paths.len() > 1 {
+            let mut samples = same_basename_paths.clone();
+            samples.sort();
+            samples.dedup();
+            if samples.len() > 3 {
+                samples.truncate(3);
+            }
+            let sample_list = samples.join("\n  - ");
+            return format!(
+                "Multiple files named '{basename}' found; the given path '{file_path}' did not uniquely match by suffix.\nTry a more specific path or add a path mapping (srcpath map).\nExamples:\n  - {sample_list}"
+            );
+        }
+
+        let mut hit_candidates = Vec::new();
+        let probe_list = if !suffix_matches.is_empty() {
+            suffix_matches
+        } else {
+            let mut paths = same_basename_paths.clone();
+            paths.sort();
+            paths.dedup();
+            paths.truncate(20);
+            paths
+        };
+
+        for candidate in &probe_list {
+            if !self
+                .lookup_addresses_by_source_line(candidate, line_number)
+                .is_empty()
+            {
+                hit_candidates.push(candidate.clone());
+                if hit_candidates.len() >= 3 {
+                    break;
+                }
+            }
+        }
+
+        if !hit_candidates.is_empty() {
+            let list = hit_candidates.join("\n  - ");
+            return format!(
+                "Ambiguous path: '{file_path}' did not resolve, but found addresses for the same line in:\n  - {list}\nPlease use a more specific path (full DWARF path) or add a mapping (srcpath map)."
+            );
+        }
+
+        format!(
+            "No executable addresses for {file_path}:{line_number} (file exists in DWARF but this line has no statement).\nTry a nearby line, or rebuild with debug info and lower optimization (e.g., -g -O0)."
+        )
+    }
+}

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -23,7 +23,7 @@ pub mod analyzer;
 pub use analyzer::{
     AddressQueryResult, DwarfAnalyzer, FunctionQueryResult, MainExecutableInfo,
     ModuleDefaultPolicy, ModuleLoadingEvent, ModuleLoadingStats, ModuleStats, SharedLibraryInfo,
-    SimpleFileInfo,
+    SimpleFileInfo, SourceLineAddressSearch, SourceLineQuerySearch,
 };
 
 // Re-export essential core and semantic support types.

--- a/ghostscope/src/source_path.rs
+++ b/ghostscope/src/source_path.rs
@@ -1,5 +1,6 @@
 use crate::config::settings::SourceConfig;
 use ghostscope_ui::events::{PathSubstitution, SourcePathInfo};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
@@ -227,13 +228,73 @@ impl SourcePathResolver {
         }
         None
     }
+
+    /// Build source-line query candidates for a user-provided path.
+    ///
+    /// SourcePathResolver owns local filesystem to DWARF path mapping, while
+    /// DwarfAnalyzer owns DWARF path matching and basename/suffix expansion.
+    pub fn source_line_candidates(
+        &self,
+        input_path: &str,
+        analyzer: &ghostscope_dwarf::DwarfAnalyzer,
+    ) -> Vec<String> {
+        let mut candidates = Vec::new();
+
+        if let Some(dwarf_path) = self.reverse_map_to_dwarf(input_path) {
+            candidates.push(dwarf_path);
+        }
+
+        if !Path::new(input_path).is_absolute() {
+            for sub in self
+                .runtime_substitutions
+                .iter()
+                .chain(self.config_substitutions.iter())
+            {
+                let joined = PathBuf::from(&sub.from).join(input_path);
+                candidates.push(joined.to_string_lossy().to_string());
+            }
+        }
+
+        candidates.extend(analyzer.source_line_candidates(input_path));
+        candidates.push(input_path.to_string());
+
+        let mut seen = HashSet::new();
+        candidates
+            .retain(|candidate| !candidate.trim().is_empty() && seen.insert(candidate.clone()));
+        candidates
+    }
+
+    /// Resolve a DWARF source path for UI display.
+    pub fn resolve_dwarf_path_for_display(
+        &self,
+        dwarf_full_path: &str,
+        fallback_directory: &str,
+        fallback_basename: &str,
+    ) -> (String, String) {
+        if let Some(resolved_path) = self.resolve(dwarf_full_path) {
+            return split_display_path(&resolved_path);
+        }
+
+        (
+            self.try_substitute_path(fallback_directory)
+                .unwrap_or_else(|| fallback_directory.to_string()),
+            fallback_basename.to_string(),
+        )
+    }
 }
 
-/// Apply substitutions to directory path only (for info source)
-pub fn apply_substitutions_to_directory(resolver: &SourcePathResolver, directory: &str) -> String {
-    resolver
-        .try_substitute_path(directory)
-        .unwrap_or_else(|| directory.to_string())
+fn split_display_path(path: &Path) -> (String, String) {
+    let basename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+    let directory = path
+        .parent()
+        .map(|parent| parent.to_string_lossy().to_string())
+        .filter(|parent| !parent.is_empty())
+        .unwrap_or_else(|| ".".to_string());
+    (directory, basename)
 }
 
 #[cfg(test)]
@@ -292,20 +353,32 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_substitutions_to_directory() {
+    fn test_resolve_dwarf_path_for_display_substitutes_directory() {
         let resolver = create_test_resolver(vec![("/usr/src/debug", "/home/user/sources")], vec![]);
 
         // Should substitute
-        let result = apply_substitutions_to_directory(&resolver, "/usr/src/debug/myproject");
-        assert_eq!(result, "/home/user/sources/myproject");
+        let (dir, basename) = resolver.resolve_dwarf_path_for_display(
+            "/usr/src/debug/myproject/main.c",
+            "/usr/src/debug/myproject",
+            "main.c",
+        );
+        assert_eq!(dir, "/home/user/sources/myproject");
+        assert_eq!(basename, "main.c");
 
         // Should not substitute (no boundary)
-        let result2 = apply_substitutions_to_directory(&resolver, "/usr/src/debug-backup");
-        assert_eq!(result2, "/usr/src/debug-backup");
+        let (dir, basename) = resolver.resolve_dwarf_path_for_display(
+            "/usr/src/debug-backup/main.c",
+            "/usr/src/debug-backup",
+            "main.c",
+        );
+        assert_eq!(dir, "/usr/src/debug-backup");
+        assert_eq!(basename, "main.c");
 
         // Should not substitute (no match)
-        let result3 = apply_substitutions_to_directory(&resolver, "/other/path");
-        assert_eq!(result3, "/other/path");
+        let (dir, basename) =
+            resolver.resolve_dwarf_path_for_display("/other/path/main.c", "/other/path", "main.c");
+        assert_eq!(dir, "/other/path");
+        assert_eq!(basename, "main.c");
     }
 
     #[test]

--- a/ghostscope/src/tui/info_handlers.rs
+++ b/ghostscope/src/tui/info_handlers.rs
@@ -432,9 +432,6 @@ fn try_get_line_debug_info(
         .as_mut()
         .ok_or_else(|| "Debug information not available. DWARF symbols may not be loaded or initialization failed.".to_string())?;
 
-    use std::collections::HashSet;
-    use std::path::PathBuf;
-
     // Parse original input once
     let (orig_file, line_part) = target
         .rsplit_once(':')
@@ -443,67 +440,38 @@ fn try_get_line_debug_info(
         .parse::<u32>()
         .map_err(|_| format!("Invalid line number '{line_part}' in target '{target}'"))?;
 
-    // Build candidate DWARF file paths in priority order
-    let mut candidates: Vec<String> = Vec::new();
+    let source_line = process_analyzer
+        .resolve_source_line_query_best_effort(
+            session
+                .source_path_resolver
+                .source_line_candidates(orig_file, process_analyzer),
+            line_number,
+            target_path.as_deref(),
+        )
+        .map_err(|e| format!("Failed to analyze {orig_file}:{line_number}: {e}"))?;
 
-    // 1) Reverse-map absolute local paths to DWARF paths (if applicable)
-    if let Some(dwarf_path) = session.source_path_resolver.reverse_map_to_dwarf(orig_file) {
-        candidates.push(dwarf_path);
+    if !source_line.addresses.is_empty() {
+        let file_path = source_line
+            .file_path
+            .clone()
+            .unwrap_or_else(|| orig_file.to_string());
+        let cand_target = format!("{file_path}:{line_number}");
+        return Ok(build_source_location_target_debug_info(
+            cand_target,
+            file_path,
+            line_number,
+            source_line.addresses,
+        ));
     }
 
-    // 2) If user provided a relative path, combine with each substitution's 'from' (DWARF comp_dir)
-    if !orig_file.starts_with('/') {
-        let rules = session.source_path_resolver.get_all_rules();
-        for sub in rules.substitutions {
-            let joined = PathBuf::from(&sub.from).join(orig_file);
-            candidates.push(joined.to_string_lossy().to_string());
-        }
-
-        // 2b) Also combine with all DWARF-reported directories (comp_dir) from analyzer's file index
-        if let Ok(grouped) = process_analyzer.get_grouped_file_info_by_module() {
-            for (_module_path, files) in grouped {
-                for f in files {
-                    let joined = PathBuf::from(&f.directory).join(orig_file);
-                    candidates.push(joined.to_string_lossy().to_string());
-                }
-            }
-        }
+    if source_line.raw_address_count > 0 {
+        let target_path = target_path.as_deref().unwrap_or("<unknown>");
+        return Err(format!(
+            "Cannot resolve any address for {orig_file}:{line_number} in -t target '{target_path}'"
+        ));
     }
 
-    // 3) Always try original input (might already be full DWARF path)
-    candidates.push(orig_file.to_string());
-
-    // Deduplicate while preserving order
-    let mut seen = HashSet::new();
-    candidates.retain(|c| seen.insert(c.clone()));
-
-    // Probe candidates until we find addresses
-    for cand in &candidates {
-        let query_results = process_analyzer
-            .query_source_line_best_effort(cand, line_number)
-            .map_err(|e| format!("Failed to analyze {cand}:{line_number}: {e}"))?;
-        let query_results = process_analyzer
-            .filter_address_results_to_target(query_results, target_path.as_deref())
-            .map_err(|e| e.to_string())?;
-        if !query_results.is_empty() {
-            let cand_target = format!("{cand}:{line_number}");
-            return Ok(build_source_location_target_debug_info(
-                cand_target,
-                cand.to_string(),
-                line_number,
-                query_results,
-            ));
-        }
-    }
-
-    // Fallback to previous behavior (with reverse-map if available)
-    let final_target =
-        if let Some(dwarf_path) = session.source_path_resolver.reverse_map_to_dwarf(orig_file) {
-            format!("{dwarf_path}:{line_number}")
-        } else {
-            target.to_string()
-        };
-    handle_source_location_target(process_analyzer, &final_target, target_path.as_deref())
+    Err(process_analyzer.describe_source_line_failure(orig_file, line_number))
 }
 
 fn unique_module_count(addresses: &[AddressQueryResult]) -> usize {
@@ -689,45 +657,4 @@ fn handle_function_target(
         .query_function_best_effort(function_name)
         .map_err(|e| format!("Failed to analyze function '{function_name}': {e}"))?;
     handle_function_query_result(process_analyzer, query_result, target_path)
-}
-
-/// Handle source location target (file:line)
-fn handle_source_location_target(
-    process_analyzer: &mut ghostscope_dwarf::DwarfAnalyzer,
-    target: &str,
-    target_path: Option<&str>,
-) -> Result<TargetDebugInfo, String> {
-    let (file_path, line_part) = target
-        .rsplit_once(':')
-        .ok_or_else(|| format!("Invalid target format '{target}'. Expected format: file:line"))?;
-    let line_number = line_part
-        .parse::<u32>()
-        .map_err(|_| format!("Invalid line number '{line_part}' in target '{target}'"))?;
-
-    let query_results = process_analyzer
-        .query_source_line_best_effort(file_path, line_number)
-        .map_err(|e| format!("Failed to analyze {file_path}:{line_number}: {e}"))?;
-    let raw_address_count = query_results.len();
-    let query_results = process_analyzer
-        .filter_address_results_to_target(query_results, target_path)
-        .map_err(|e| e.to_string())?;
-
-    if query_results.is_empty() {
-        if raw_address_count > 0 {
-            let target_path = target_path.unwrap_or("<unknown>");
-            return Err(format!(
-                "Cannot resolve any address for {file_path}:{line_number} in -t target '{target_path}'"
-            ));
-        }
-        return Err(format!(
-            "Cannot resolve any address for {file_path}:{line_number}"
-        ));
-    }
-
-    Ok(build_source_location_target_debug_info(
-        target.to_string(),
-        file_path.to_string(),
-        line_number,
-        query_results,
-    ))
 }

--- a/ghostscope/src/tui/source_handlers.rs
+++ b/ghostscope/src/tui/source_handlers.rs
@@ -1,5 +1,4 @@
 use crate::core::GhostSession;
-use crate::source_path::apply_substitutions_to_directory;
 use ghostscope_ui::{events::*, RuntimeChannels, RuntimeStatus};
 use std::collections::HashSet;
 use tracing::info;
@@ -227,28 +226,12 @@ fn get_grouped_source_files_info(session: &GhostSession) -> anyhow::Result<Vec<S
                 // 3. Search directories by basename (srcpath add)
                 let dwarf_full_path = format!("{}/{}", file.directory, file.basename);
 
-                let (resolved_dir, resolved_basename) = if let Some(resolved_path) =
-                    session.source_path_resolver.resolve(&dwarf_full_path)
-                {
-                    // Successfully resolved - extract directory and basename from resolved path
-                    let resolved_str = resolved_path.to_string_lossy().to_string();
-                    if let Some(last_slash) = resolved_str.rfind('/') {
-                        let dir = resolved_str[..last_slash].to_string();
-                        let basename = resolved_str[last_slash + 1..].to_string();
-                        (dir, basename)
-                    } else {
-                        // No directory separator - use current dir
-                        (".".to_string(), resolved_str)
-                    }
-                } else {
-                    // Resolution failed - use substitution-only fallback for directory
-                    // This maintains backward compatibility with pure substitution approach
-                    let resolved_dir = apply_substitutions_to_directory(
-                        &session.source_path_resolver,
+                let (resolved_dir, resolved_basename) =
+                    session.source_path_resolver.resolve_dwarf_path_for_display(
+                        &dwarf_full_path,
                         &file.directory,
+                        &file.basename,
                     );
-                    (resolved_dir, file.basename.clone())
-                };
 
                 let key = format!("{resolved_dir}:{resolved_basename}");
                 if seen.insert(key) {


### PR DESCRIPTION
Move DWARF source path candidate generation, source-line search, and failure diagnostics into shared analyzer APIs.

Keep local source path remapping in the TUI layer while compiler and info commands consume the common lookup behavior.