### PR TITLE
refactor: thread explicit address guards

### DIFF
--- a/ghostscope-compiler/src/ebpf/codegen.rs
+++ b/ghostscope-compiler/src/ebpf/codegen.rs
@@ -3,7 +3,7 @@
 //! This module handles the conversion from statements to compiled instructions
 //! and generates LLVM IR for individual instructions.
 
-use super::context::{CodeGenError, EbpfContext, Result};
+use super::context::{CodeGenError, EbpfContext, Result, RuntimeAddress};
 use crate::script::{PrintStatement, Program, Statement};
 use aya_ebpf_bindings::bindings::bpf_func_id::BPF_FUNC_probe_read_user;
 use ghostscope_protocol::trace_event::{
@@ -35,12 +35,12 @@ enum ComplexArgSource<'ctx> {
     },
     /// Memory dump from a pointer/byte address with a static length
     MemDump {
-        src_addr: inkwell::values::IntValue<'ctx>,
+        address: RuntimeAddress<'ctx>,
         len: usize,
     },
     /// Memory dump with dynamic runtime length; bytes read up to min(len_value, max_len)
     MemDumpDynamic {
-        src_addr: inkwell::values::IntValue<'ctx>,
+        address: RuntimeAddress<'ctx>,
         len_value: inkwell::values::IntValue<'ctx>,
         max_len: usize,
     },
@@ -1741,34 +1741,37 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     fn resolve_memory_format_address(
         &mut self,
         expr: &crate::script::ast::Expr,
-    ) -> Result<IntValue<'ctx>> {
-        let val = self.compile_expr(expr).ok();
-        if let Some(BasicValueEnum::PointerValue(pv)) = val {
-            return self
-                .builder
-                .build_ptr_to_int(pv, self.context.i64_type(), "ptr_to_i64")
-                .map_err(|e| CodeGenError::Builder(e.to_string()));
-        }
-
-        if let Some(BasicValueEnum::IntValue(iv)) = val {
-            if let Some(var) = self.query_dwarf_for_complex_expr(expr)? {
-                if let Some(ref ty) = var.dwarf_type {
-                    if matches!(ty, ghostscope_dwarf::TypeInfo::PointerType { .. }) {
-                        return Ok(iv);
-                    }
-                }
-            }
-        }
-
-        if let Ok(addr) = self.resolve_ptr_i64_from_expr(expr) {
+    ) -> Result<RuntimeAddress<'ctx>> {
+        if let Ok(addr) = self.resolve_runtime_address_from_expr(expr) {
             return Ok(addr);
         }
 
-        let var = self
-            .query_dwarf_for_complex_expr(expr)?
-            .ok_or_else(|| CodeGenError::VariableNotFound(format!("{expr:?}")))?;
-        let pc_address = self.get_compile_time_context()?.pc_address;
-        self.variable_read_plan_to_lvalue_address(&var, pc_address, None)
+        let dwarf_error = match self.query_dwarf_for_complex_expr(expr) {
+            Ok(Some(var)) => {
+                let pc_address = self.get_compile_time_context()?.pc_address;
+                return self.variable_read_plan_to_runtime_address(&var, pc_address, None);
+            }
+            Ok(None) => None,
+            Err(err) => {
+                tracing::debug!(
+                    error = %err,
+                    "DWARF address resolution unavailable for memory format expression; trying script value fallback"
+                );
+                Some(err)
+            }
+        };
+
+        match self.compile_expr(expr)? {
+            BasicValueEnum::PointerValue(pv) => self
+                .builder
+                .build_ptr_to_int(pv, self.context.i64_type(), "ptr_to_i64")
+                .map(|value| RuntimeAddress::available(value, self.context))
+                .map_err(|e| CodeGenError::Builder(e.to_string())),
+            _ => {
+                Err(dwarf_error
+                    .unwrap_or_else(|| CodeGenError::VariableNotFound(format!("{expr:?}"))))
+            }
+        }
     }
 
     fn compile_formatted_print(
@@ -1958,7 +1961,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 access_path: Vec::new(),
                                 data_len: n,
                                 source: ComplexArgSource::MemDump {
-                                    src_addr: addr_iv,
+                                    address: addr_iv,
                                     len: n,
                                 },
                             });
@@ -2018,7 +2021,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 access_path: Vec::new(),
                                 data_len: cap,
                                 source: ComplexArgSource::MemDumpDynamic {
-                                    src_addr: addr_iv,
+                                    address: addr_iv,
                                     len_value: len_iv,
                                     max_len: cap,
                                 },
@@ -2090,7 +2093,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 access_path: Vec::new(),
                                 data_len: cap,
                                 source: ComplexArgSource::MemDumpDynamic {
-                                    src_addr: addr_iv,
+                                    address: addr_iv,
                                     len_value: len_iv,
                                     max_len: cap,
                                 },
@@ -2655,7 +2658,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     }
                     // data_len already set to reserved_len
                 }
-                ComplexArgSource::MemDump { src_addr, len } => {
+                ComplexArgSource::MemDump { address, len } => {
                     // Directly probe-read into payload to avoid byte-wise copies
                     let ptr_ty = self.context.ptr_type(AddressSpace::default());
                     let i64_ty = self.context.i64_type();
@@ -2668,9 +2671,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     let base_src_ptr = self
                         .builder
-                        .build_int_to_ptr(*src_addr, ptr_ty, "md_src_ptr")
+                        .build_int_to_ptr(address.value, ptr_ty, "md_src_ptr")
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                    let offsets_found = self.load_offsets_found_flag()?;
+                    let offsets_found = address.offsets_found;
                     let not_found = self
                         .builder
                         .build_not(offsets_found, "md_offsets_miss")
@@ -2796,7 +2799,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         )
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     self.builder
-                        .build_store(addr_ptr, *src_addr)
+                        .build_store(addr_ptr, address.value)
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     self.mark_any_fail()?;
                     self.builder
@@ -2805,7 +2808,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     self.builder.position_at_end(cont_b);
                 }
                 ComplexArgSource::MemDumpDynamic {
-                    src_addr,
+                    address,
                     len_value,
                     max_len: _,
                 } => {
@@ -2899,9 +2902,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     let ptr_ty = self.context.ptr_type(AddressSpace::default());
                     let base_src_ptr = self
                         .builder
-                        .build_int_to_ptr(*src_addr, ptr_ty, "mdd_src_ptr")
+                        .build_int_to_ptr(address.value, ptr_ty, "mdd_src_ptr")
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                    let offsets_found = self.load_offsets_found_flag()?;
+                    let offsets_found = address.offsets_found;
                     let not_found = self
                         .builder
                         .build_not(offsets_found, "mdd_dyn_offsets_miss")
@@ -3022,7 +3025,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             )
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                         self.builder
-                            .build_store(addr_ptr, *src_addr)
+                            .build_store(addr_ptr, address.value)
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     }
                     self.mark_any_fail()?;
@@ -3216,12 +3219,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         .build_bit_cast(var_data_ptr, ptr_type, "dst_ptr")
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     let size_val = i32_type.const_int(a.data_len as u64, false);
-                    let src_addr = self.planned_address_to_llvm_address(
+                    let src_addr = self.resolve_planned_address(
                         address,
                         Some(apl_ptr),
                         module_for_offsets.as_deref(),
                     )?;
-                    let offsets_found = self.load_offsets_found_flag()?;
+                    let offsets_found = src_addr.offsets_found;
                     let current_block = self.builder.get_insert_block().unwrap();
                     let current_fn = current_block.get_parent().unwrap();
                     let cont2_block = self.context.append_basic_block(current_fn, "after_read");
@@ -3242,7 +3245,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     self.builder.position_at_end(found_block);
                     let src_ptr = self
                         .builder
-                        .build_int_to_ptr(src_addr, ptr_type, "src_ptr")
+                        .build_int_to_ptr(src_addr.value, ptr_type, "src_ptr")
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
 
                     // status_ptr was stored in apl_ptr earlier (we named it status_ptr)
@@ -3250,7 +3253,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     let zero64 = i64_type.const_zero();
                     let is_null = self
                         .builder
-                        .build_int_compare(inkwell::IntPredicate::EQ, src_addr, zero64, "is_null")
+                        .build_int_compare(
+                            inkwell::IntPredicate::EQ,
+                            src_addr.value,
+                            zero64,
+                            "is_null",
+                        )
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     let null_block = self.context.append_basic_block(current_fn, "null_deref");
                     let read_block = self.context.append_basic_block(current_fn, "read_user");
@@ -3345,7 +3353,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         .map_err(|e| {
                             CodeGenError::LLVMError(format!("Failed to cast addr ptr: {e}"))
                         })?;
-                    let src_as_i64 = src_addr;
+                    let src_as_i64 = src_addr.value;
                     self.builder
                         .build_store(addr_ptr, src_as_i64)
                         .map_err(|e| {
@@ -3382,7 +3390,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     address,
                     module_for_offsets,
                 } => {
-                    let addr = self.planned_address_to_llvm_address(
+                    let addr = self.resolve_planned_address(
                         address,
                         Some(apl_ptr),
                         module_for_offsets.as_deref(),
@@ -3396,7 +3404,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         )
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     self.builder
-                        .build_store(cast_ptr, addr)
+                        .build_store(cast_ptr, addr.value)
                         .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                     // header already set to reserved_len (8)
                 }
@@ -4612,9 +4620,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
         // Compute source address with ASLR-aware helper, honoring module hint
         // Prefer a previously recorded module path for offsets; fall back handled in helper
-        let src_addr =
-            self.planned_address_to_llvm_address(address, Some(status_ptr), module_hint)?;
-        tracing::trace!(src_addr = %{src_addr}, "generate_print_complex_variable_runtime: computed src_addr");
+        let src_addr = self.resolve_planned_address(address, Some(status_ptr), module_hint)?;
+        tracing::trace!(src_addr = %src_addr.value, "generate_print_complex_variable_runtime: computed src_addr");
 
         // Setup common types and casts
         let ptr_type = self.context.ptr_type(AddressSpace::default());
@@ -4627,9 +4634,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let size_val = i32_type.const_int(data_len as u64, false);
         let src_ptr = self
             .builder
-            .build_int_to_ptr(src_addr, ptr_type, "src_ptr")
+            .build_int_to_ptr(src_addr.value, ptr_type, "src_ptr")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-        let offsets_found = self.load_offsets_found_flag()?;
+        let offsets_found = src_addr.offsets_found;
         let current_block = self.builder.get_insert_block().unwrap();
         let current_fn = current_block.get_parent().unwrap();
         let cont_block = self.context.append_basic_block(current_fn, "after_read");
@@ -4652,7 +4659,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let zero64 = i64_type.const_zero();
         let is_null = self
             .builder
-            .build_int_compare(inkwell::IntPredicate::EQ, src_addr, zero64, "is_null")
+            .build_int_compare(inkwell::IntPredicate::EQ, src_addr.value, zero64, "is_null")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         let null_block = self.context.append_basic_block(current_fn, "null_deref");
         let read_block = self.context.append_basic_block(current_fn, "read_user");
@@ -4773,7 +4780,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             )
             .map_err(|e| CodeGenError::LLVMError(format!("Failed to cast addr ptr: {e}")))?;
         self.builder
-            .build_store(addr_ptr, src_addr)
+            .build_store(addr_ptr, src_addr.value)
             .map_err(|e| CodeGenError::LLVMError(format!("Failed to store addr: {e}")))?;
         // mark fail
         self.mark_any_fail()?;

--- a/ghostscope-compiler/src/ebpf/context.rs
+++ b/ghostscope-compiler/src/ebpf/context.rs
@@ -57,6 +57,38 @@ pub enum CodeGenError {
 
 pub type Result<T> = std::result::Result<T, CodeGenError>;
 
+/// Runtime address produced by lowering a DWARF `PlannedAddress`.
+///
+/// `value` is the address to use in generated eBPF code. `offsets_found` is an
+/// i1 guard that is false when a link-time address could not be rebased through
+/// `proc_module_offsets`. Runtime-derived addresses do not need that lookup, so
+/// their guard is always true.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RuntimeAddress<'ctx> {
+    pub value: IntValue<'ctx>,
+    pub offsets_found: IntValue<'ctx>,
+}
+
+impl<'ctx> RuntimeAddress<'ctx> {
+    pub(crate) fn available(value: IntValue<'ctx>, context: &'ctx Context) -> Self {
+        Self {
+            value,
+            offsets_found: context.bool_type().const_int(1, false),
+        }
+    }
+
+    pub(crate) fn with_offsets_found(value: IntValue<'ctx>, offsets_found: IntValue<'ctx>) -> Self {
+        Self {
+            value,
+            offsets_found,
+        }
+    }
+
+    pub(crate) fn with_value(self, value: IntValue<'ctx>) -> Self {
+        Self { value, ..self }
+    }
+}
+
 /// eBPF LLVM code generation context
 pub struct EbpfContext<'ctx, 'dw> {
     pub context: &'ctx Context,
@@ -95,9 +127,6 @@ pub struct EbpfContext<'ctx, 'dw> {
     // This is maintained across structured control flow so later instructions can budget against
     // the worst-case path without double-counting sibling branches.
     pub compile_time_event_bytes_upper_bound: usize,
-    // Tracks whether the last proc_module_offsets lookup succeeded (used to skip reads)
-    pub offsets_found_flag: Option<inkwell::values::PointerValue<'ctx>>,
-
     // Compilation options (includes eBPF map configuration)
     pub compile_options: crate::CompileOptions,
 
@@ -206,7 +235,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             pm_key_alloca: None,
             event_offset_alloca: None,
             compile_time_event_bytes_upper_bound: 0,
-            offsets_found_flag: None,
             compile_options: compile_options.clone(),
 
             // Control-flow expression context
@@ -846,71 +874,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     /// Mark that at least one variable failed (status!=0)
     pub fn mark_any_fail(&mut self) -> Result<()> {
         self.store_flag_value("_gs_any_fail", 1)
-    }
-
-    /// Get (and create if needed) the global flag tracking the last proc_module_offsets lookup.
-    /// Stored as i8 where 0 = miss, 1 = found.
-    pub fn get_or_create_offsets_found_flag(&mut self) -> inkwell::values::PointerValue<'ctx> {
-        if let Some(ptr) = self.offsets_found_flag {
-            return ptr;
-        }
-        let i8_type = self.context.i8_type();
-        // TODO: Replace this global flag with explicit control-flow checks when memory-read emission is refactored.
-        let global =
-            self.module
-                .add_global(i8_type, Some(AddressSpace::default()), "_gs_offsets_found");
-        global.set_initializer(&i8_type.const_int(1, false));
-        let ptr = global.as_pointer_value();
-        self.offsets_found_flag = Some(ptr);
-        ptr
-    }
-
-    /// Store a boolean into the offsets-found flag (true => found, false => miss).
-    pub fn store_offsets_found_flag(
-        &mut self,
-        flag: inkwell::values::IntValue<'ctx>,
-    ) -> Result<()> {
-        let ptr = self.get_or_create_offsets_found_flag();
-        let i8_type = self.context.i8_type();
-        let flag_i8 = self
-            .builder
-            .build_int_z_extend(flag, i8_type, "offset_flag_i8")
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-        self.builder
-            .build_store(ptr, flag_i8)
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-        Ok(())
-    }
-
-    /// Store a constant boolean value into the offsets-found flag.
-    pub fn store_offsets_found_const(&mut self, value: bool) -> Result<()> {
-        let ptr = self.get_or_create_offsets_found_flag();
-        let i8_type = self.context.i8_type();
-        self.builder
-            .build_store(ptr, i8_type.const_int(value as u64, false))
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-        Ok(())
-    }
-
-    /// Load the current offsets-found flag as i1 (true => found, false => miss).
-    pub fn load_offsets_found_flag(&mut self) -> Result<inkwell::values::IntValue<'ctx>> {
-        let ptr = self.get_or_create_offsets_found_flag();
-        let i8_type = self.context.i8_type();
-        let raw = self
-            .builder
-            .build_load(i8_type, ptr, "offsets_found_raw")
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
-            .into_int_value();
-        let is_non_zero = self
-            .builder
-            .build_int_compare(
-                inkwell::IntPredicate::NE,
-                raw,
-                i8_type.const_zero(),
-                "offsets_found_bool",
-            )
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-        Ok(is_non_zero)
     }
 
     /// Get or create global for condition error code (i8). Name: _gs_cond_error

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -3,7 +3,7 @@
 //! This module handles integration with DWARF debug information for
 //! variable type resolution and read-plan lowering.
 
-use super::context::{CodeGenError, EbpfContext, Result};
+use super::context::{CodeGenError, EbpfContext, Result, RuntimeAddress};
 use ghostscope_dwarf::{
     AddressOrigin, Availability, EntryValueCase, LvalueAddressPlan, MemoryAccessSize, PlanExprOp,
     PlannedAddress, PlannedAddressKind, RuntimeComputedExpr, SectionType, TypeInfo,
@@ -79,6 +79,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     None,
                     module_hint,
                 )
+                .map(|value| value.value.into())
             }
             ghostscope_dwarf::PlannedValue::ImplicitBytes(bytes) => {
                 debug!("Generating implicit value: {} bytes", bytes.len());
@@ -95,20 +96,19 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 } else {
                     status_ptr
                 };
-                self.planned_address_to_llvm_address(address, runtime_status_ptr, module_hint)
-                    .map(Into::into)
+                self.resolve_planned_address(address, runtime_status_ptr, module_hint)
+                    .map(|address| address.value.into())
             }
         }
     }
 
-    pub fn planned_address_to_llvm_address(
+    pub(crate) fn resolve_planned_address(
         &mut self,
         address: &PlannedAddress,
         status_ptr: Option<PointerValue<'ctx>>,
         module_hint: Option<&str>,
-    ) -> Result<IntValue<'ctx>> {
+    ) -> Result<RuntimeAddress<'ctx>> {
         let pt_regs_ptr = self.get_pt_regs_parameter()?;
-        self.store_offsets_found_const(true)?;
 
         match address.origin {
             AddressOrigin::LinkTime => {
@@ -141,12 +141,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     Some(runtime_base),
                     module_hint,
                 )?;
-                match value {
-                    BasicValueEnum::IntValue(value) => Ok(value),
-                    _ => Err(CodeGenError::LLVMError(
-                        "Computed address did not produce integer".to_string(),
-                    )),
-                }
+                Ok(value)
             }
             AddressOrigin::RuntimeDerived | AddressOrigin::Unknown => {
                 self.planned_address_without_rebase(address, pt_regs_ptr, status_ptr, module_hint)
@@ -160,22 +155,24 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         pt_regs_ptr: PointerValue<'ctx>,
         status_ptr: Option<PointerValue<'ctx>>,
         module_hint: Option<&str>,
-    ) -> Result<IntValue<'ctx>> {
+    ) -> Result<RuntimeAddress<'ctx>> {
         match &address.kind {
-            PlannedAddressKind::Constant { address } => {
-                Ok(self.context.i64_type().const_int(*address, false))
-            }
+            PlannedAddressKind::Constant { address } => Ok(RuntimeAddress::available(
+                self.context.i64_type().const_int(*address, false),
+                self.context,
+            )),
             PlannedAddressKind::RegisterOffset { dwarf_reg, offset } => {
                 let reg_val = self.load_register_value(*dwarf_reg, pt_regs_ptr)?;
                 if let BasicValueEnum::IntValue(reg_i) = reg_val {
-                    if *offset != 0 {
+                    let value = if *offset != 0 {
                         let ofs_val = self.context.i64_type().const_int(*offset as u64, true);
                         self.builder
                             .build_int_add(reg_i, ofs_val, "addr_with_offset")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))
                     } else {
                         Ok(reg_i)
-                    }
+                    }?;
+                    Ok(RuntimeAddress::available(value, self.context))
                 } else {
                     Err(CodeGenError::RegisterMappingError(
                         "Register value is not integer".to_string(),
@@ -197,21 +194,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         pt_regs_ptr: PointerValue<'ctx>,
         status_ptr: Option<PointerValue<'ctx>>,
         module_hint: Option<&str>,
-    ) -> Result<IntValue<'ctx>> {
-        let val = self.generate_runtime_expr_ops(
-            expr.ops(),
-            pt_regs_ptr,
-            None,
-            status_ptr,
-            None,
-            module_hint,
-        )?;
-        match val {
-            BasicValueEnum::IntValue(value) => Ok(value),
-            _ => Err(CodeGenError::LLVMError(
-                "Computed address did not produce integer".to_string(),
-            )),
-        }
+    ) -> Result<RuntimeAddress<'ctx>> {
+        self.generate_runtime_expr_ops(expr.ops(), pt_regs_ptr, None, status_ptr, None, module_hint)
     }
 
     fn runtime_address_from_link_time_address(
@@ -219,7 +203,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         link_addr: u64,
         status_ptr: Option<PointerValue<'ctx>>,
         module_hint: Option<&str>,
-    ) -> Result<IntValue<'ctx>> {
+    ) -> Result<RuntimeAddress<'ctx>> {
         let ctx = self.get_compile_time_context()?;
         let module_for_offsets = module_hint
             .map(|s| s.to_string())
@@ -230,8 +214,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let (rt_addr, found_flag) =
             self.generate_runtime_address_from_offsets(link_val, st_code, cookie)?;
         self.store_offsets_unavailable_status(status_ptr, found_flag)?;
-        self.store_offsets_found_flag(found_flag)?;
-        Ok(rt_addr)
+        Ok(RuntimeAddress::with_offsets_found(rt_addr, found_flag))
     }
 
     fn store_offsets_unavailable_status(
@@ -469,16 +452,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         self.variable_materialization_to_llvm_value(&materialized, pc_address, status_ptr)
     }
 
-    pub(super) fn variable_read_plan_to_lvalue_address(
+    pub(super) fn variable_read_plan_to_runtime_address(
         &mut self,
         plan: &VariableReadPlan,
         pc_address: u64,
         status_ptr: Option<PointerValue<'ctx>>,
-    ) -> Result<IntValue<'ctx>> {
+    ) -> Result<RuntimeAddress<'ctx>> {
         let module_hint = Self::module_path_for_offsets(plan.module_path.as_deref());
         match plan.lvalue_address_plan() {
             LvalueAddressPlan::Address { address } => {
-                self.planned_address_to_llvm_address(&address, status_ptr, module_hint.as_deref())
+                self.resolve_planned_address(&address, status_ptr, module_hint.as_deref())
             }
             LvalueAddressPlan::Unavailable { availability } => Err(
                 Self::dwarf_lvalue_address_unavailable_error(&plan.name, &availability, pc_address),
@@ -498,14 +481,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         } else {
             status_ptr
         };
-        let addr =
-            self.planned_address_to_llvm_address(address, runtime_status_ptr, module_hint)?;
+        let addr = self.resolve_planned_address(address, runtime_status_ptr, module_hint)?;
 
         if ghostscope_dwarf::is_c_aggregate_type(dwarf_type) {
             let ptr_ty = self.context.ptr_type(inkwell::AddressSpace::default());
             let as_ptr = self
                 .builder
-                .build_int_to_ptr(addr, ptr_ty, "aggregate_addr_as_ptr")
+                .build_int_to_ptr(addr.value, ptr_ty, "aggregate_addr_as_ptr")
                 .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
             return Ok(as_ptr.into());
         }
@@ -628,11 +610,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         pt_regs_ptr: PointerValue<'ctx>,
         _result_size: Option<MemoryAccessSize>,
         status_ptr: Option<PointerValue<'ctx>>,
-        initial_top: Option<IntValue<'ctx>>,
+        initial_top: Option<RuntimeAddress<'ctx>>,
         module_hint: Option<&str>,
-    ) -> Result<BasicValueEnum<'ctx>> {
+    ) -> Result<RuntimeAddress<'ctx>> {
         // Implement stack-based computation
-        let mut stack: Vec<IntValue<'ctx>> = Vec::new();
+        let mut stack: Vec<RuntimeAddress<'ctx>> = Vec::new();
         // Track a runtime null-pointer flag from dereference steps; when true, subsequent
         // arithmetic will be masked to zero to avoid reads at small offsets from NULL.
         let mut deref_null_flag: Option<inkwell::values::IntValue> = None;
@@ -645,7 +627,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 PlanExprOp::LoadRegister(dwarf_reg) => {
                     let reg_value = self.load_register_value(*dwarf_reg, pt_regs_ptr)?;
                     if let BasicValueEnum::IntValue(int_val) = reg_value {
-                        stack.push(int_val);
+                        stack.push(RuntimeAddress::available(int_val, self.context));
                     } else {
                         return Err(CodeGenError::RegisterMappingError(format!(
                             "Register {dwarf_reg} did not return integer value"
@@ -655,14 +637,18 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                 PlanExprOp::PushConstant(value) => {
                     let const_val = self.context.i64_type().const_int(*value as u64, true);
-                    stack.push(const_val);
+                    stack.push(RuntimeAddress::available(const_val, self.context));
                 }
 
                 PlanExprOp::Add => {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let sum_val = self
                             .builder
-                            .build_int_add(a, b, "add")
+                            .build_int_add(a.value, b.value, "add")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "add_guard")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                         if let Some(nf) = deref_null_flag {
                             let masked_bv = self
@@ -674,9 +660,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     "add_masked",
                                 )
                                 .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                            stack.push(masked_bv.into_int_value());
+                            stack.push(RuntimeAddress::with_offsets_found(
+                                masked_bv.into_int_value(),
+                                guard,
+                            ));
                         } else {
-                            stack.push(sum_val);
+                            stack.push(RuntimeAddress::with_offsets_found(sum_val, guard));
                         }
                     } else {
                         return Err(CodeGenError::LLVMError(
@@ -689,9 +678,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_int_sub(a, b, "sub")
+                            .build_int_sub(a.value, b.value, "sub")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "sub_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Sub".to_string(),
@@ -703,9 +696,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_int_mul(a, b, "mul")
+                            .build_int_mul(a.value, b.value, "mul")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "mul_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Mul".to_string(),
@@ -715,8 +712,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                 PlanExprOp::Div => {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
-                        let result = self.build_signed_int_div_via_udiv(a, b, "div")?;
-                        stack.push(result);
+                        let result = self.build_signed_int_div_via_udiv(a.value, b.value, "div")?;
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "div_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Div".to_string(),
@@ -726,8 +727,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                 PlanExprOp::Mod => {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
-                        let result = self.build_signed_int_rem_via_urem(a, b, "mod")?;
-                        stack.push(result);
+                        let result = self.build_signed_int_rem_via_urem(a.value, b.value, "mod")?;
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "mod_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Mod".to_string(),
@@ -739,9 +744,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_and(a, b, "and")
+                            .build_and(a.value, b.value, "and")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "and_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in BitwiseAnd".to_string(),
@@ -753,9 +762,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_or(a, b, "or")
+                            .build_or(a.value, b.value, "or")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "or_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in BitwiseOr".to_string(),
@@ -767,9 +780,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_xor(a, b, "xor")
+                            .build_xor(a.value, b.value, "xor")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "xor_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in BitwiseXor".to_string(),
@@ -781,9 +798,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_left_shift(a, b, "shl")
+                            .build_left_shift(a.value, b.value, "shl")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "shl_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in ShiftLeft".to_string(),
@@ -795,9 +816,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_right_shift(a, b, false, "shr")
+                            .build_right_shift(a.value, b.value, false, "shr")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "shr_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in ShiftRight".to_string(),
@@ -809,9 +834,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let (Some(b), Some(a)) = (stack.pop(), stack.pop()) {
                         let result = self
                             .builder
-                            .build_right_shift(a, b, true, "shra")
+                            .build_right_shift(a.value, b.value, true, "shra")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "shra_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in ShiftRightArithmetic".to_string(),
@@ -823,9 +852,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let Some(a) = stack.pop() {
                         let result = self
                             .builder
-                            .build_not(a, "not")
+                            .build_not(a.value, "not")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        stack.push(a.with_value(result));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Not".to_string(),
@@ -837,9 +866,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     if let Some(a) = stack.pop() {
                         let result = self
                             .builder
-                            .build_int_sub(self.context.i64_type().const_zero(), a, "neg")
+                            .build_int_sub(self.context.i64_type().const_zero(), a.value, "neg")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        stack.push(a.with_value(result));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Neg".to_string(),
@@ -852,23 +881,23 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         let zero = self.context.i64_type().const_zero();
                         let is_neg = self
                             .builder
-                            .build_int_compare(inkwell::IntPredicate::SLT, a, zero, "abs_neg")
+                            .build_int_compare(inkwell::IntPredicate::SLT, a.value, zero, "abs_neg")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                         let negated = self
                             .builder
-                            .build_int_sub(zero, a, "abs_negated")
+                            .build_int_sub(zero, a.value, "abs_negated")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                         let result = self
                             .builder
                             .build_select::<BasicValueEnum<'ctx>, _>(
                                 is_neg,
                                 negated.into(),
-                                a.into(),
+                                a.value.into(),
                                 "abs",
                             )
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
                             .into_int_value();
-                        stack.push(result);
+                        stack.push(a.with_value(result));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in Abs".to_string(),
@@ -894,13 +923,17 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         };
                         let cmp = self
                             .builder
-                            .build_int_compare(predicate, a, b, "cmp")
+                            .build_int_compare(predicate, a.value, b.value, "cmp")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                         let result = self
                             .builder
                             .build_int_z_extend(cmp, self.context.i64_type(), "cmp_i64")
                             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-                        stack.push(result);
+                        let guard = self
+                            .builder
+                            .build_and(a.offsets_found, b.offsets_found, "cmp_guard")
+                            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+                        stack.push(RuntimeAddress::with_offsets_found(result, guard));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in comparison".to_string(),
@@ -916,7 +949,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             .builder
                             .build_int_compare(
                                 inkwell::IntPredicate::EQ,
-                                addr,
+                                addr.value,
                                 zero64,
                                 "is_null_deref",
                             )
@@ -1060,7 +1093,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 .build_store(sp, new_status_bv)
                                 .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
                         }
-                        stack.push(merged);
+                        stack.push(RuntimeAddress::with_offsets_found(
+                            merged,
+                            addr.offsets_found,
+                        ));
                     } else {
                         return Err(CodeGenError::LLVMError(
                             "Stack underflow in LoadMemory".to_string(),
@@ -1080,7 +1116,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         status_ptr,
                         module_hint,
                     )?;
-                    stack.push(value);
+                    stack.push(RuntimeAddress::available(value, self.context));
                 }
 
                 // Add catch-all for unimplemented operations
@@ -1094,7 +1130,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
 
         if stack.len() == 1 {
-            Ok(stack.pop().unwrap().into())
+            Ok(stack.pop().unwrap())
         } else {
             Err(CodeGenError::LLVMError(format!(
                 "Invalid stack state after computation: {} elements remaining",
@@ -1127,7 +1163,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 None,
                 module_hint,
             )?
-            .into_int_value();
+            .value;
 
         let current_block = self.builder.get_insert_block().ok_or_else(|| {
             CodeGenError::LLVMError("No insertion block for EntryValueLookup".to_string())
@@ -1185,6 +1221,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     &format!("entry_value_match_{index}"),
                 )
                 .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+            let is_match = self
+                .builder
+                .build_and(
+                    is_match,
+                    found_flag,
+                    &format!("entry_value_match_ready_{index}"),
+                )
+                .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
             let case_bb = self
                 .context
                 .append_basic_block(current_fn, &format!("entry_value_case_{index}"));
@@ -1208,7 +1252,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     None,
                     module_hint,
                 )?
-                .into_int_value();
+                .value;
             let case_value_block = self.builder.get_insert_block().ok_or_else(|| {
                 CodeGenError::LLVMError(
                     "No insertion block after EntryValueLookup case".to_string(),
@@ -2268,9 +2312,46 @@ mod tests {
         let address = PlannedAddress::from_location(location)
             .expect("computed location should materialize as a planned address");
         let addr = ctx
-            .planned_address_to_llvm_address(&address, None, None)
+            .resolve_planned_address(&address, None, None)
             .expect("computed address with mid-stream dereference should compile");
-        assert_eq!(addr.get_type().get_bit_width(), 64);
+        assert_eq!(addr.value.get_type().get_bit_width(), 64);
+        assert_eq!(addr.offsets_found.get_type().get_bit_width(), 1);
+        assert!(
+            ctx.module
+                .print_to_string()
+                .to_string()
+                .contains("add_guard"),
+            "trailing arithmetic should preserve the address availability guard"
+        );
+    }
+
+    #[test]
+    fn planned_address_lowering_does_not_emit_offsets_global() {
+        let llctx = LlvmContext::create();
+        let opts = crate::CompileOptions::default();
+        let mut ctx = EbpfContext::new(&llctx, "explicit_addr_guard", Some(0), &opts).expect("ctx");
+        ctx.create_basic_ebpf_function("f").expect("fn");
+        ctx.__test_ensure_proc_offsets_map().expect("map");
+        ctx.__test_alloc_pm_key().expect("pm_key");
+        ctx.set_compile_time_context(0x1234, "/nonexistent/module".to_string());
+
+        let address =
+            PlannedAddress::from_location(VariableLocation::Address(AddressExpr::constant(0x1000)))
+                .expect("constant address should materialize as a planned address");
+
+        let addr = ctx
+            .resolve_planned_address(&address, None, None)
+            .expect("link-time address should lower with an explicit guard");
+
+        assert_eq!(addr.value.get_type().get_bit_width(), 64);
+        assert_eq!(addr.offsets_found.get_type().get_bit_width(), 1);
+        assert!(
+            !ctx.module
+                .print_to_string()
+                .to_string()
+                .contains("_gs_offsets_found"),
+            "address availability should be threaded explicitly instead of using a module global"
+        );
     }
 
     #[test]
@@ -2292,10 +2373,10 @@ mod tests {
         );
 
         let addr = ctx
-            .variable_read_plan_to_lvalue_address(&plan, 0x1234, None)
+            .variable_read_plan_to_runtime_address(&plan, 0x1234, None)
             .expect("address-only read plan should not require DWARF type info");
 
-        assert_eq!(addr.get_type().get_bit_width(), 64);
+        assert_eq!(addr.value.get_type().get_bit_width(), 64);
     }
 
     #[test]
@@ -2314,7 +2395,7 @@ mod tests {
         );
 
         let err = ctx
-            .variable_read_plan_to_lvalue_address(&plan, 0x1234, None)
+            .variable_read_plan_to_runtime_address(&plan, 0x1234, None)
             .expect_err("unavailable lvalue plans should be rejected");
 
         assert!(matches!(err, CodeGenError::VariableUnavailable(_)));

--- a/ghostscope-compiler/src/ebpf/expression.rs
+++ b/ghostscope-compiler/src/ebpf/expression.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles compilation of various expression types to LLVM IR.
 
-use super::context::{CodeGenError, EbpfContext, Result};
+use super::context::{CodeGenError, EbpfContext, Result, RuntimeAddress};
 use crate::script::{BinaryOp, Expr};
 use aya_ebpf_bindings::bindings::bpf_func_id::BPF_FUNC_probe_read_user;
 use ghostscope_dwarf::{
@@ -23,7 +23,7 @@ struct DynamicTypeInfo {
 }
 
 struct DynamicLvalue<'ctx> {
-    address: IntValue<'ctx>,
+    address: RuntimeAddress<'ctx>,
     type_info: DynamicTypeInfo,
 }
 
@@ -561,16 +561,24 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         &mut self,
         e: &Expr,
     ) -> Result<inkwell::values::IntValue<'ctx>> {
-        let mut visited = std::collections::HashSet::new();
-        self.resolve_ptr_i64_from_expr_internal(e, &mut visited, 0)
+        self.resolve_runtime_address_from_expr(e)
+            .map(|address| address.value)
     }
 
-    fn resolve_ptr_i64_from_expr_internal(
+    pub(crate) fn resolve_runtime_address_from_expr(
+        &mut self,
+        e: &Expr,
+    ) -> Result<RuntimeAddress<'ctx>> {
+        let mut visited = std::collections::HashSet::new();
+        self.resolve_runtime_address_from_expr_internal(e, &mut visited, 0)
+    }
+
+    fn resolve_runtime_address_from_expr_internal(
         &mut self,
         e: &Expr,
         visited: &mut std::collections::HashSet<String>,
         depth: usize,
-    ) -> Result<inkwell::values::IntValue<'ctx>> {
+    ) -> Result<RuntimeAddress<'ctx>> {
         use crate::script::ast::BinaryOp as BO;
         use crate::script::ast::Expr as E;
         use inkwell::values::BasicValueEnum::*;
@@ -589,7 +597,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     )));
                 }
                 if let Some(target) = self.get_alias_variable(name) {
-                    let r = self.resolve_ptr_i64_from_expr_internal(&target, visited, depth + 1);
+                    let r = self.resolve_runtime_address_from_expr_internal(
+                        &target,
+                        visited,
+                        depth + 1,
+                    );
                     visited.remove(name);
                     return r;
                 }
@@ -609,7 +621,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 None
                             };
                             let pc_address = self.get_compile_time_context()?.pc_address;
-                            return self.variable_read_plan_to_lvalue_address(
+                            return self.variable_read_plan_to_runtime_address(
                                 &var, pc_address, status_ptr,
                             );
                         } else {
@@ -644,7 +656,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     None
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                return self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr);
+                return self.variable_read_plan_to_runtime_address(&var, pc_address, status_ptr);
             } else {
                 return Err(CodeGenError::TypeError(
                     "cannot take address of unresolved expression".into(),
@@ -659,12 +671,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         if let Some((ptr_side, index)) = self.pointer_arithmetic_parts_expanding_aliases(e)? {
             if matches!(&ptr_side, E::AddressOf(_)) {
                 let base =
-                    self.resolve_ptr_i64_from_expr_internal(&ptr_side, visited, depth + 1)?;
+                    self.resolve_runtime_address_from_expr_internal(&ptr_side, visited, depth + 1)?;
                 let off = self.context.i64_type().const_int(index as u64, false);
-                return self
+                let value = self
                     .builder
-                    .build_int_add(base, off, "ptr_add")
-                    .map_err(|err| CodeGenError::Builder(err.to_string()));
+                    .build_int_add(base.value, off, "ptr_add")
+                    .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+                return Ok(base.with_value(value));
             } else if let Some(var) = self.query_dwarf_for_complex_expr(&ptr_side)? {
                 if var.dwarf_type.is_some() {
                     let pointed_plan = var
@@ -676,7 +689,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         None
                     };
                     let pc_address = self.get_compile_time_context()?.pc_address;
-                    return self.variable_read_plan_to_lvalue_address(
+                    return self.variable_read_plan_to_runtime_address(
                         &pointed_plan,
                         pc_address,
                         status_ptr,
@@ -691,40 +704,43 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 // alias + K
                 if let Some(k) = Self::integer_literal_value(right) {
                     if let Ok(base) =
-                        self.resolve_ptr_i64_from_expr_internal(left, visited, depth + 1)
+                        self.resolve_runtime_address_from_expr_internal(left, visited, depth + 1)
                     {
                         let off = self.context.i64_type().const_int(k as u64, false);
-                        return self
+                        let value = self
                             .builder
-                            .build_int_add(base, off, "ptr_add")
-                            .map_err(|e| CodeGenError::Builder(e.to_string()));
+                            .build_int_add(base.value, off, "ptr_add")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+                        return Ok(base.with_value(value));
                     }
                 }
                 // K + alias
                 if let Some(k) = Self::integer_literal_value(left) {
                     if let Ok(base) =
-                        self.resolve_ptr_i64_from_expr_internal(right, visited, depth + 1)
+                        self.resolve_runtime_address_from_expr_internal(right, visited, depth + 1)
                     {
                         let off = self.context.i64_type().const_int(k as u64, false);
-                        return self
+                        let value = self
                             .builder
-                            .build_int_add(base, off, "ptr_add")
-                            .map_err(|e| CodeGenError::Builder(e.to_string()));
+                            .build_int_add(base.value, off, "ptr_add")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+                        return Ok(base.with_value(value));
                     }
                 }
             } else if matches!(op, BO::Subtract) {
                 if let Some(k) = Self::integer_literal_value(right) {
                     if let Ok(base) =
-                        self.resolve_ptr_i64_from_expr_internal(left, visited, depth + 1)
+                        self.resolve_runtime_address_from_expr_internal(left, visited, depth + 1)
                     {
                         let off = self
                             .context
                             .i64_type()
                             .const_int(k.wrapping_neg() as u64, false);
-                        return self
+                        let value = self
                             .builder
-                            .build_int_add(base, off, "ptr_sub")
-                            .map_err(|e| CodeGenError::Builder(e.to_string()));
+                            .build_int_add(base.value, off, "ptr_sub")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+                        return Ok(base.with_value(value));
                     }
                 }
             }
@@ -740,10 +756,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         let val_any =
                             self.variable_read_plan_to_llvm_value(&var, pc_address, None)?;
                         match val_any {
-                            IntValue(iv) => Ok(iv),
+                            IntValue(iv) => Ok(RuntimeAddress::available(iv, self.context)),
                             PointerValue(pv) => self
                                 .builder
                                 .build_ptr_to_int(pv, self.context.i64_type(), "ptr_as_i64")
+                                .map(|value| RuntimeAddress::available(value, self.context))
                                 .map_err(|e| CodeGenError::Builder(e.to_string())),
                             _ => Err(CodeGenError::TypeError(
                                 "DWARF value is not pointer/integer".into(),
@@ -758,7 +775,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             None
                         };
                         let pc_address = self.get_compile_time_context()?.pc_address;
-                        self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)
+                        self.variable_read_plan_to_runtime_address(&var, pc_address, status_ptr)
                     }
                     _ => Err(CodeGenError::TypeError(
                         "DWARF value is not pointer/array".into(),
@@ -771,7 +788,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     None
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)
+                self.variable_read_plan_to_runtime_address(&var, pc_address, status_ptr)
             }
         } else {
             // No DWARF-backed address and not an address-of/alias+const: reject script-level pointers.
@@ -784,7 +801,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     fn dynamic_pointer_arithmetic_address(
         &mut self,
         expr: &Expr,
-    ) -> Result<Option<IntValue<'ctx>>> {
+    ) -> Result<Option<RuntimeAddress<'ctx>>> {
         use crate::script::ast::BinaryOp as BO;
         use crate::script::ast::Expr as E;
 
@@ -825,7 +842,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         base_expr: &Expr,
         offset_expr: &Expr,
         subtract: bool,
-    ) -> Result<Option<IntValue<'ctx>>> {
+    ) -> Result<Option<RuntimeAddress<'ctx>>> {
         if Self::integer_literal_value(offset_expr).is_some() {
             return Ok(None);
         }
@@ -835,7 +852,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             return Ok(None);
         }
 
-        let base_address = self.resolve_ptr_i64_from_expr(&expanded_base)?;
+        let base_address = self.resolve_runtime_address_from_expr(&expanded_base)?;
         let offset = match self.compile_expr(offset_expr)? {
             BasicValueEnum::IntValue(value) => {
                 self.normalize_int_to_i64(value, "dynamic_raw_offset_i64")?
@@ -855,16 +872,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         };
         let address = self
             .builder
-            .build_int_add(base_address, offset, "dynamic_raw_address")
+            .build_int_add(base_address.value, offset, "dynamic_raw_address")
             .map_err(|err| CodeGenError::Builder(err.to_string()))?;
-        Ok(Some(address))
+        Ok(Some(base_address.with_value(address)))
     }
 
     fn dynamic_index_address_candidate(
         &mut self,
         base_expr: &Expr,
         index_expr: &Expr,
-    ) -> Result<Option<IntValue<'ctx>>> {
+    ) -> Result<Option<RuntimeAddress<'ctx>>> {
         match self.compile_dynamic_array_element_address(base_expr, index_expr) {
             Ok(Some(element_lvalue)) => Ok(Some(element_lvalue.address)),
             Ok(None) => Ok(None),
@@ -1023,15 +1040,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.context.bool_type().const_int(1, false)
         } else {
             // Resolve pointer for A and read from user memory
-            let ptr_a = self.resolve_ptr_i64_from_expr(a_expr)?;
-            let offsets_found_a = self.load_offsets_found_flag()?;
+            let ptr_a = self.resolve_runtime_address_from_expr(a_expr)?;
+            let offsets_found_a = ptr_a.offsets_found;
             let dst_a = self
                 .builder
                 .build_bit_cast(buf_a, ptr_ty, "memcmp_dst_a")
                 .map_err(|e| CodeGenError::Builder(e.to_string()))?;
             let base_src_a = self
                 .builder
-                .build_int_to_ptr(ptr_a, ptr_ty, "memcmp_src_a")
+                .build_int_to_ptr(ptr_a.value, ptr_ty, "memcmp_src_a")
                 .map_err(|e| CodeGenError::Builder(e.to_string()))?;
             let null_ptr = ptr_ty.const_null();
             let src_a = self
@@ -1101,15 +1118,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.context.bool_type().const_int(1, false)
         } else {
             // Resolve pointer for B and read from user memory
-            let ptr_b = self.resolve_ptr_i64_from_expr(b_expr)?;
-            let offsets_found_b = self.load_offsets_found_flag()?;
+            let ptr_b = self.resolve_runtime_address_from_expr(b_expr)?;
+            let offsets_found_b = ptr_b.offsets_found;
             let dst_b = self
                 .builder
                 .build_bit_cast(buf_b, ptr_ty, "memcmp_dst_b")
                 .map_err(|e| CodeGenError::Builder(e.to_string()))?;
             let base_src_b = self
                 .builder
-                .build_int_to_ptr(ptr_b, ptr_ty, "memcmp_src_b")
+                .build_int_to_ptr(ptr_b.value, ptr_ty, "memcmp_src_b")
                 .map_err(|e| CodeGenError::Builder(e.to_string()))?;
             let null_ptr = ptr_ty.const_null();
             let src_b = self
@@ -1565,10 +1582,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             let val_any =
                                 self.variable_read_plan_to_llvm_value(&var, pc_address, None)?;
                             match val_any {
-                                BasicValueEnum::IntValue(iv) => iv,
+                                BasicValueEnum::IntValue(iv) => {
+                                    RuntimeAddress::available(iv, self.context)
+                                }
                                 BasicValueEnum::PointerValue(pv) => self
                                     .builder
                                     .build_ptr_to_int(pv, self.context.i64_type(), "ptr_as_i64")
+                                    .map(|value| RuntimeAddress::available(value, self.context))
                                     .map_err(|e| CodeGenError::Builder(e.to_string()))?,
                                 _ => {
                                     return Err(CodeGenError::TypeError(
@@ -1584,7 +1604,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 None
                             };
                             let pc_address = self.get_compile_time_context()?.pc_address;
-                            self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)?
+                            self.variable_read_plan_to_runtime_address(
+                                &var, pc_address, status_ptr,
+                            )?
                         }
                         _ => {
                             // Not a pointer/array -> treat as error
@@ -1601,7 +1623,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
             None => {
                 // Generic pointer expr (e.g., alias); resolve to i64
-                self.resolve_ptr_i64_from_expr(dwarf_expr).map_err(|_| {
+                self.resolve_runtime_address_from_expr(dwarf_expr).map_err(|_| {
                     CodeGenError::TypeError(
                         "strncmp requires at least one string argument, and the other side must be an address expression (DWARF pointer/array or alias)".to_string(),
                     )
@@ -1641,19 +1663,39 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .builder
             .build_bit_cast(buf_global, ptr_ty, "strncmp_dst_ptr")
             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let base_src_ptr = self
+            .builder
+            .build_int_to_ptr(ptr_i64.value, ptr_ty, "strncmp_src_ptr")
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
         let src_ptr = self
             .builder
-            .build_int_to_ptr(ptr_i64, ptr_ty, "strncmp_src_ptr")
-            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                ptr_i64.offsets_found,
+                base_src_ptr.into(),
+                ptr_ty.const_null().into(),
+                "strncmp_src_or_null",
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_pointer_value();
+        let effective_len = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                ptr_i64.offsets_found,
+                bounded_len.into(),
+                self.context.i32_type().const_zero().into(),
+                "strncmp_len_or_zero",
+            )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?
+            .into_int_value();
         let ret = self
             .create_bpf_helper_call(
                 BPF_FUNC_probe_read_user as u64,
-                &[dst_ptr, bounded_len.into(), src_ptr.into()],
+                &[dst_ptr, effective_len.into(), src_ptr.into()],
                 self.context.i64_type().into(),
                 "probe_read_user_strncmp",
             )?
             .into_int_value();
-        let status_ok = self
+        let read_ok = self
             .builder
             .build_int_compare(
                 inkwell::IntPredicate::EQ,
@@ -1661,6 +1703,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 self.context.i64_type().const_zero(),
                 "rd_ok",
             )
+            .map_err(|e| CodeGenError::Builder(e.to_string()))?;
+        let status_ok = self
+            .builder
+            .build_and(read_ok, ptr_i64.offsets_found, "strncmp_ok_with_offsets")
             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
 
         // If in condition context and read failed, set condition error code = 1 (ProbeReadFailed)
@@ -1679,7 +1725,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             self.builder.position_at_end(set_b);
             // VariableStatus::ReadError = 2
             let _ = self.set_condition_error_if_unset(2u8);
-            let _ = self.set_condition_error_addr_if_unset(ptr_i64);
+            let _ = self.set_condition_error_addr_if_unset(ptr_i64.value);
             // flags: bit0 = read failure for strncmp
             let one = self.context.i8_type().const_int(1, false);
             let _ = self.or_condition_error_flags(one);
@@ -2249,12 +2295,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     )
                                 })?;
                         let pc_address = self.get_compile_time_context()?.pc_address;
-                        match self.variable_read_plan_to_lvalue_address(&var, pc_address, None) {
-                            Ok(addr_i64) => {
+                        match self.variable_read_plan_to_runtime_address(&var, pc_address, None) {
+                            Ok(address) => {
                                 let ptr_ty = self.context.ptr_type(AddressSpace::default());
                                 let as_ptr = self
                                     .builder
-                                    .build_int_to_ptr(addr_i64, ptr_ty, "addr_as_ptr")
+                                    .build_int_to_ptr(address.value, ptr_ty, "addr_as_ptr")
                                     .map_err(|e| CodeGenError::Builder(e.to_string()))?;
                                 return Ok(as_ptr.into());
                             }
@@ -2279,12 +2325,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         )
                     })?;
                 let pc_address = self.get_compile_time_context()?.pc_address;
-                match self.variable_read_plan_to_lvalue_address(&var, pc_address, None) {
-                    Ok(addr_i64) => {
+                match self.variable_read_plan_to_runtime_address(&var, pc_address, None) {
+                    Ok(address) => {
                         let ptr_ty = self.context.ptr_type(AddressSpace::default());
                         let as_ptr = self
                             .builder
-                            .build_int_to_ptr(addr_i64, ptr_ty, "addr_as_ptr")
+                            .build_int_to_ptr(address.value, ptr_ty, "addr_as_ptr")
                             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
                         Ok(as_ptr.into())
                     }
@@ -3031,12 +3077,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let member_address = self
             .builder
             .build_int_add(
-                element_lvalue.address,
+                element_lvalue.address.value,
                 member_offset,
                 "dynamic_member_address",
             )
             .map_err(|err| CodeGenError::Builder(err.to_string()))?;
-        let value = self.read_dynamic_address_value(member_address, &member_type)?;
+        let value = self.read_dynamic_address_value(
+            element_lvalue.address.with_value(member_address),
+            &member_type,
+        )?;
         Ok(Some((value, member_type)))
     }
 
@@ -3052,7 +3101,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             let Some(element_info) = self.indexable_element_type_and_stride(expr)? else {
                 return Ok(None);
             };
-            let element_address = self.resolve_ptr_i64_from_expr(expr)?;
+            let element_address = self.resolve_runtime_address_from_expr(expr)?;
             return Ok(Some(DynamicLvalue {
                 address: element_address,
                 type_info: DynamicTypeInfo {
@@ -3076,13 +3125,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             let member_address = self
                 .builder
                 .build_int_add(
-                    base_lvalue.address,
+                    base_lvalue.address.value,
                     member_offset,
                     "dynamic_member_lvalue_address",
                 )
                 .map_err(|err| CodeGenError::Builder(err.to_string()))?;
             return Ok(Some(DynamicLvalue {
-                address: member_address,
+                address: base_lvalue.address.with_value(member_address),
                 type_info: DynamicTypeInfo {
                     dwarf_type: member_type,
                     module_path: base_lvalue.type_info.module_path,
@@ -3136,7 +3185,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     module_path.as_deref(),
                 );
                 Ok(Some(DynamicLvalue {
-                    address: pointer_value,
+                    address: RuntimeAddress::available(pointer_value, self.context),
                     type_info: DynamicTypeInfo {
                         dwarf_type: target_type,
                         module_path,
@@ -3206,7 +3255,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 })?;
                 match ghostscope_dwarf::strip_type_aliases(&array_type) {
                     DwarfType::ArrayType { element_type, .. } => {
-                        let base_address = self.variable_read_plan_to_lvalue_address(
+                        let base_address = self.variable_read_plan_to_runtime_address(
                             &array_plan,
                             compile_context.pc_address,
                             status_ptr,
@@ -3228,9 +3277,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             status_ptr,
                         )?;
                         let base_address = match pointer_value {
-                            BasicValueEnum::IntValue(value) => {
-                                self.normalize_int_to_i64(value, "dynamic_array_base_i64")?
-                            }
+                            BasicValueEnum::IntValue(value) => RuntimeAddress::available(
+                                self.normalize_int_to_i64(value, "dynamic_array_base_i64")?,
+                                self.context,
+                            ),
                             BasicValueEnum::PointerValue(value) => self
                                 .builder
                                 .build_ptr_to_int(
@@ -3238,6 +3288,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     self.context.i64_type(),
                                     "dynamic_array_base_ptr",
                                 )
+                                .map(|value| RuntimeAddress::available(value, self.context))
                                 .map_err(|err| CodeGenError::Builder(err.to_string()))?,
                             _ => {
                                 return Err(CodeGenError::TypeError(
@@ -3282,7 +3333,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     })?;
                     match ghostscope_dwarf::strip_type_aliases(&array_type) {
                         DwarfType::ArrayType { element_type, .. } => {
-                            let base_address = self.variable_read_plan_to_lvalue_address(
+                            let base_address = self.variable_read_plan_to_runtime_address(
                                 &array_plan,
                                 compile_context.pc_address,
                                 status_ptr,
@@ -3304,9 +3355,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 status_ptr,
                             )?;
                             let base_address = match pointer_value {
-                                BasicValueEnum::IntValue(value) => {
-                                    self.normalize_int_to_i64(value, "dynamic_array_base_i64")?
-                                }
+                                BasicValueEnum::IntValue(value) => RuntimeAddress::available(
+                                    self.normalize_int_to_i64(value, "dynamic_array_base_i64")?,
+                                    self.context,
+                                ),
                                 BasicValueEnum::PointerValue(value) => self
                                     .builder
                                     .build_ptr_to_int(
@@ -3314,6 +3366,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                         self.context.i64_type(),
                                         "dynamic_array_base_ptr",
                                     )
+                                    .map(|value| RuntimeAddress::available(value, self.context))
                                     .map_err(|err| CodeGenError::Builder(err.to_string()))?,
                                 _ => {
                                     return Err(CodeGenError::TypeError(
@@ -3345,7 +3398,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         .ok_or_else(|| {
                             CodeGenError::VariableNotFound(Self::expr_to_debug_string(array_expr))
                         })?;
-                    let base_address = self.resolve_ptr_i64_from_expr(&expanded_array_expr)?;
+                    let base_address =
+                        self.resolve_runtime_address_from_expr(&expanded_array_expr)?;
                     (element_info, base_address, 0)
                 } else if let Some(array_lvalue) =
                     self.dynamic_lvalue_address_and_type(&expanded_array_expr)?
@@ -3367,8 +3421,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                 &array_lvalue.type_info.dwarf_type,
                             )?;
                             let base_address = match pointer_value {
-                                BasicValueEnum::IntValue(value) => self
-                                    .normalize_int_to_i64(value, "dynamic_array_member_ptr_i64")?,
+                                BasicValueEnum::IntValue(value) => RuntimeAddress::available(
+                                    self.normalize_int_to_i64(
+                                        value,
+                                        "dynamic_array_member_ptr_i64",
+                                    )?,
+                                    self.context,
+                                ),
                                 BasicValueEnum::PointerValue(value) => self
                                     .builder
                                     .build_ptr_to_int(
@@ -3376,6 +3435,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                         self.context.i64_type(),
                                         "dynamic_array_member_ptr",
                                     )
+                                    .map(|value| RuntimeAddress::available(value, self.context))
                                     .map_err(|err| CodeGenError::Builder(err.to_string()))?,
                                 _ => {
                                     return Err(CodeGenError::TypeError(
@@ -3445,11 +3505,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|err| CodeGenError::Builder(err.to_string()))?;
         let element_address = self
             .builder
-            .build_int_add(base_address, byte_offset, "dynamic_array_element_address")
+            .build_int_add(
+                base_address.value,
+                byte_offset,
+                "dynamic_array_element_address",
+            )
             .map_err(|err| CodeGenError::Builder(err.to_string()))?;
 
         Ok(Some(DynamicLvalue {
-            address: element_address,
+            address: base_address.with_value(element_address),
             type_info: DynamicTypeInfo {
                 dwarf_type: element_info.element_type,
                 module_path: element_info.module_path,
@@ -3623,14 +3687,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     fn read_dynamic_address_value(
         &mut self,
-        address: IntValue<'ctx>,
+        address: RuntimeAddress<'ctx>,
         dwarf_type: &DwarfType,
     ) -> Result<BasicValueEnum<'ctx>> {
         if ghostscope_dwarf::is_c_aggregate_type(dwarf_type) {
             let ptr_ty = self.context.ptr_type(AddressSpace::default());
             let as_ptr = self
                 .builder
-                .build_int_to_ptr(address, ptr_ty, "dynamic_aggregate_ptr")
+                .build_int_to_ptr(address.value, ptr_ty, "dynamic_aggregate_ptr")
                 .map_err(|err| CodeGenError::Builder(err.to_string()))?;
             return Ok(as_ptr.into());
         }
@@ -3879,8 +3943,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     }
                 };
                 let need = lit_len + 1;
-                let (buf_global, ret_len, arr_ty) =
-                    self.read_user_cstr_into_buffer(ptr_i64, need, "_gs_strbuf")?;
+                let (buf_global, ret_len, arr_ty) = self.read_user_cstr_into_buffer(
+                    RuntimeAddress::available(ptr_i64, self.context),
+                    need,
+                    "_gs_strbuf",
+                )?;
 
                 // ret_len must equal L+1
                 let i64_ty = self.context.i64_type();
@@ -3994,7 +4061,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
                 let addr =
-                    self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)?;
+                    self.variable_read_plan_to_runtime_address(&var, pc_address, status_ptr)?;
                 // Read exactly L+1 bytes
                 let (buf_global, status, arr_ty) =
                     self.read_user_bytes_into_buffer(addr, lit_len + 1, "_gs_arrbuf")?;
@@ -4086,7 +4153,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 };
                 let pc_address = self.get_compile_time_context()?.pc_address;
                 let addr =
-                    self.variable_read_plan_to_lvalue_address(&var, pc_address, status_ptr)?;
+                    self.variable_read_plan_to_runtime_address(&var, pc_address, status_ptr)?;
                 // Fallback using type_name string
                 match parse_type_name(&var.type_name) {
                     ParsedKind::PtrChar => {
@@ -4105,8 +4172,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             }
                         };
                         let need = lit_len + 1;
-                        let (buf_global, ret_len, arr_ty) =
-                            self.read_user_cstr_into_buffer(ptr_i64, need, "_gs_strbuf")?;
+                        let (buf_global, ret_len, arr_ty) = self.read_user_cstr_into_buffer(
+                            RuntimeAddress::available(ptr_i64, self.context),
+                            need,
+                            "_gs_strbuf",
+                        )?;
 
                         let i64_ty = self.context.i64_type();
                         let expect_len = i64_ty.const_int(need as u64, false);

--- a/ghostscope-compiler/src/ebpf/helper_functions.rs
+++ b/ghostscope-compiler/src/ebpf/helper_functions.rs
@@ -3,7 +3,7 @@
 //! This module handles eBPF helper function calls, register mapping, and pt_regs
 //! access for different target architectures.
 
-use super::context::{CodeGenError, EbpfContext, Result};
+use super::context::{CodeGenError, EbpfContext, Result, RuntimeAddress};
 use aya_ebpf_bindings::bindings::bpf_func_id::{
     BPF_FUNC_get_current_pid_tgid, BPF_FUNC_ktime_get_ns, BPF_FUNC_map_lookup_elem,
     BPF_FUNC_perf_event_output, BPF_FUNC_probe_read_user, BPF_FUNC_probe_read_user_str,
@@ -237,9 +237,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     /// Read a user C-string into a static buffer using bpf_probe_read_user_str.
     /// Returns (buffer_ptr, len_including_nul).
-    pub fn read_user_cstr_into_buffer(
+    pub(crate) fn read_user_cstr_into_buffer(
         &mut self,
-        src_addr: inkwell::values::IntValue<'ctx>,
+        src_addr: RuntimeAddress<'ctx>,
         size: u32,
         name_prefix: &str,
     ) -> Result<(
@@ -257,15 +257,35 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         let src_ptr = self
             .builder
-            .build_int_to_ptr(src_addr, ptr_ty, "src_ptr")
+            .build_int_to_ptr(src_addr.value, ptr_ty, "src_ptr")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        let src_ptr = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                src_addr.offsets_found,
+                src_ptr.into(),
+                ptr_ty.const_null().into(),
+                "cstr_src_or_null",
+            )
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            .into_pointer_value();
 
         // Helper signature: long fn(void *dst, u32 size, const void *src)
         let i64_ty = self.context.i64_type();
         let i32_ty = self.context.i32_type();
+        let effective_size = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                src_addr.offsets_found,
+                i32_ty.const_int(size as u64, false).into(),
+                i32_ty.const_zero().into(),
+                "cstr_size_or_zero",
+            )
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            .into_int_value();
         let args: [inkwell::values::BasicValueEnum; 3] = [
             dst_ptr,
-            i32_ty.const_int(size as u64, false).into(),
+            effective_size.into(),
             inkwell::values::BasicValueEnum::PointerValue(src_ptr),
         ];
         let ret = self.create_bpf_helper_call(
@@ -281,14 +301,24 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 "probe_read_user_str did not return integer".to_string(),
             ));
         };
+        let len = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                src_addr.offsets_found,
+                len.into(),
+                i64_ty.const_zero().into(),
+                "cstr_len_or_zero",
+            )
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            .into_int_value();
         Ok((buf_global, len, arr_ty))
     }
 
     /// Read raw user bytes into a static buffer using bpf_probe_read_user.
     /// Returns (buffer_ptr, status==0?).
-    pub fn read_user_bytes_into_buffer(
+    pub(crate) fn read_user_bytes_into_buffer(
         &mut self,
-        src_addr: inkwell::values::IntValue<'ctx>,
+        src_addr: RuntimeAddress<'ctx>,
         size: u32,
         name_prefix: &str,
     ) -> Result<(
@@ -307,12 +337,32 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         let src_ptr = self
             .builder
-            .build_int_to_ptr(src_addr, ptr_ty, "src_ptr")
+            .build_int_to_ptr(src_addr.value, ptr_ty, "src_ptr")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        let src_ptr = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                src_addr.offsets_found,
+                src_ptr.into(),
+                ptr_ty.const_null().into(),
+                "bytes_src_or_null",
+            )
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            .into_pointer_value();
+        let effective_size = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                src_addr.offsets_found,
+                i32_ty.const_int(size as u64, false).into(),
+                i32_ty.const_zero().into(),
+                "bytes_size_or_zero",
+            )
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            .into_int_value();
 
         let args: [inkwell::values::BasicValueEnum; 3] = [
             dst_ptr,
-            i32_ty.const_int(size as u64, false).into(),
+            effective_size.into(),
             inkwell::values::BasicValueEnum::PointerValue(src_ptr),
         ];
         // Helper returns long (0 on success, -errno on failure)
@@ -329,6 +379,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 "probe_read_user did not return integer".to_string(),
             ));
         };
+        let status = self
+            .builder
+            .build_select::<BasicValueEnum<'ctx>, _>(
+                src_addr.offsets_found,
+                status.into(),
+                i64_ty.const_int(u64::MAX, true).into(),
+                "bytes_status_or_missing_offsets",
+            )
+            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?
+            .into_int_value();
         Ok((buf_global, status, arr_ty))
     }
     /// Compute runtime address from link-time address using proc_module_offsets map
@@ -712,7 +772,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         flag_phi.add_incoming(&[(&one, found_block), (&zero, miss_block)]);
         let found_flag = flag_phi.as_basic_value().into_int_value();
 
-        self.store_offsets_found_flag(found_flag)?;
         Ok((final_addr, found_flag))
     }
     /// Load a register value from pt_regs
@@ -756,13 +815,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     fn probe_read_user_core(
         &mut self,
-        addr: IntValue<'ctx>,
+        address: RuntimeAddress<'ctx>,
         size: MemoryAccessSize,
         name_suffix: &str,
     ) -> Result<ProbeReadResult<'ctx>> {
         let i64_type = self.context.i64_type();
         let ptr_type = self.context.ptr_type(AddressSpace::default());
-        let offsets_found = self.load_offsets_found_flag()?;
+        let offsets_found = address.offsets_found;
         let not_found = self
             .builder
             .build_not(offsets_found, "offsets_miss")
@@ -776,7 +835,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         let base_src_ptr = self
             .builder
-            .build_int_to_ptr(addr, ptr_type, "src_ptr")
+            .build_int_to_ptr(address.value, ptr_type, "src_ptr")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         let null_ptr = ptr_type.const_null();
         let src_ptr = self
@@ -969,9 +1028,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     }
 
     /// Generate memory read using bpf_probe_read_user
-    pub fn generate_memory_read(
+    pub(crate) fn generate_memory_read(
         &mut self,
-        addr: IntValue<'ctx>,
+        address: RuntimeAddress<'ctx>,
         size: MemoryAccessSize,
         status_ptr: Option<PointerValue<'ctx>>,
     ) -> Result<BasicValueEnum<'ctx>> {
@@ -980,7 +1039,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             loaded_i64,
             combined_fail,
             not_found,
-        } = self.probe_read_user_core(addr, size, "probe_read_user")?;
+        } = self.probe_read_user_core(address, size, "probe_read_user")?;
 
         if let Some(status_ptr) = status_ptr {
             self.store_variable_read_status(
@@ -1006,9 +1065,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     /// Generate memory read with runtime status capture (for control-flow conditions).
     /// On helper failure, sets condition error code (if active) and returns zero value.
-    pub fn generate_memory_read_with_status(
+    pub(crate) fn generate_memory_read_with_status(
         &mut self,
-        addr: IntValue<'ctx>,
+        address: RuntimeAddress<'ctx>,
         size: MemoryAccessSize,
     ) -> Result<BasicValueEnum<'ctx>> {
         let zero_const = self.context.i64_type().const_zero();
@@ -1016,7 +1075,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             loaded_i64,
             combined_fail,
             ..
-        } = self.probe_read_user_core(addr, size, "probe_read_user_cf")?;
+        } = self.probe_read_user_core(address, size, "probe_read_user_cf")?;
 
         let cur_block = self.builder.get_insert_block().unwrap();
         let func = cur_block.get_parent().unwrap();
@@ -1027,7 +1086,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         self.builder.position_at_end(set_block);
         let _ = self.set_condition_error_if_unset(2u8);
-        let _ = self.set_condition_error_addr_if_unset(addr);
+        let _ = self.set_condition_error_addr_if_unset(address.value);
         self.builder
             .build_unconditional_branch(cont_block)
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;


### PR DESCRIPTION
Replace the implicit offsets-found module global with RuntimeAddress guards produced by DWARF address lowering.

Propagate the guard through memory reads, expression address planning, formatted memdump paths, and builtin string comparisons so unavailable proc offsets report consistently.