### PR TITLE
fix: use aya maps for sysmon pinned map operations

### DIFF
--- a/ghostscope-process/src/pinned_bpf_maps.rs
+++ b/ghostscope-process/src/pinned_bpf_maps.rs
@@ -1,14 +1,12 @@
 use crate::pid::{
     host_pid_for_proc_pid, read_nspid_chain, read_pid_ns_inode, INITIAL_PID_NAMESPACE_INO,
 };
-use aya::maps::MapData;
+use aya::maps::{HashMap as AyaHashMap, Map, MapData};
 use aya_obj::maps::bpf_map_def;
 use aya_obj::{
     generated::bpf_map_type::BPF_MAP_TYPE_HASH, maps::LegacyMap, EbpfSectionKind, Map as ObjMap,
 };
-use libc as c;
 use std::io;
-use std::os::fd::{AsFd, AsRawFd};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
@@ -351,80 +349,14 @@ pub fn ensure_pinned_proc_offsets_exists(max_entries: u32) -> anyhow::Result<()>
     }
 }
 
-// Low-level bpf syscall wrapper for map update (avoids tight coupling to aya map wrappers)
-#[repr(C)]
-struct BpfMapUpdateAttr {
-    map_fd: u32,
-    _pad: u32, // align to 64-bit for following fields
-    key: u64,
-    value: u64,
-    flags: u64,
-}
-
-const BPF_MAP_UPDATE_ELEM: c::c_long = 2; // from linux/bpf.h
-const BPF_MAP_DELETE_ELEM: c::c_long = 1; // from linux/bpf.h
-const BPF_MAP_GET_NEXT_KEY: c::c_long = 4; // from linux/bpf.h
-
-fn bpf_map_update_elem(
-    fd: i32,
-    key: *const c::c_void,
-    value: *const c::c_void,
-    flags: u64,
-) -> io::Result<()> {
-    let attr = BpfMapUpdateAttr {
-        map_fd: fd as u32,
-        _pad: 0,
-        key: key as usize as u64,
-        value: value as usize as u64,
-        flags,
-    };
-    let ret = unsafe {
-        c::syscall(
-            c::SYS_bpf,
-            BPF_MAP_UPDATE_ELEM,
-            &attr,
-            std::mem::size_of::<BpfMapUpdateAttr>(),
-        )
-    };
-    if ret < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
-
-#[repr(C)]
-struct BpfMapKeyAttr {
-    map_fd: u32,
-    _pad: u32, // align to 64-bit for following fields
-    key: u64,
-    next_key: u64,
-}
-
-fn bpf_map_get_next_key(
-    fd: i32,
-    key: *const c::c_void,
-    next_key: *mut c::c_void,
-) -> io::Result<()> {
-    let attr = BpfMapKeyAttr {
-        map_fd: fd as u32,
-        _pad: 0,
-        key: key as usize as u64,
-        next_key: next_key as usize as u64,
-    };
-    let ret = unsafe {
-        c::syscall(
-            c::SYS_bpf,
-            BPF_MAP_GET_NEXT_KEY,
-            &attr,
-            std::mem::size_of::<BpfMapKeyAttr>(),
-        )
-    };
-    if ret < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
+fn open_pinned_hash_map<K, V>(path: PathBuf) -> anyhow::Result<AyaHashMap<MapData, K, V>>
+where
+    K: aya::Pod,
+    V: aya::Pod,
+{
+    let map_data = MapData::from_pin(path)?;
+    let map = Map::from_map_data(map_data)?;
+    Ok(AyaHashMap::try_from(map)?)
 }
 
 /// Compute the bpffs pin path for the allowed_pids map for current process
@@ -607,40 +539,23 @@ pub fn ensure_pinned_pid_aliases_exists(max_entries: u32) -> anyhow::Result<()> 
 
 /// Insert a PID into the allowed_pids pinned map.
 pub fn insert_allowed_pid(pid: u32) -> anyhow::Result<()> {
-    let map_data = MapData::from_pin(allowed_pids_pin_path()?)?;
-    let fd = map_data.fd().as_fd().as_raw_fd();
-    let key = pid;
-    let val: u8 = 1;
-    bpf_map_update_elem(
-        fd,
-        &key as *const _ as *const _,
-        &val as *const _ as *const _,
-        0,
-    )
-    .map_err(|e| anyhow::anyhow!("allowed_pids update failed for {}: {}", pid, e))
+    let mut map = open_pinned_hash_map::<u32, u8>(allowed_pids_pin_path()?)?;
+    map.insert(pid, 1, 0)
+        .map_err(|e| anyhow::anyhow!("allowed_pids update failed for {}: {}", pid, e))
 }
 
 /// Remove a PID from the allowed_pids pinned map.
 pub fn remove_allowed_pid(pid: u32) -> anyhow::Result<()> {
-    let map_data = MapData::from_pin(allowed_pids_pin_path()?)?;
-    let fd = map_data.fd().as_fd().as_raw_fd();
-    bpf_map_delete_elem(fd, &pid as *const _ as *const _)
+    let mut map = open_pinned_hash_map::<u32, u8>(allowed_pids_pin_path()?)?;
+    map.remove(&pid)
         .map_err(|e| anyhow::anyhow!("allowed_pids delete failed for {}: {}", pid, e))
 }
 
 /// Insert a runtime-pid -> proc-pid alias into the pinned pid_aliases map.
 pub fn insert_pid_alias(runtime_pid: u32, proc_pid: u32) -> anyhow::Result<()> {
-    let map_data = MapData::from_pin(pid_aliases_pin_path()?)?;
-    let fd = map_data.fd().as_fd().as_raw_fd();
-    let key = runtime_pid;
+    let mut map = open_pinned_hash_map::<u32, PidAliasValue>(pid_aliases_pin_path()?)?;
     let val = PidAliasValue { proc_pid };
-    bpf_map_update_elem(
-        fd,
-        &key as *const _ as *const _,
-        &val as *const _ as *const _,
-        0,
-    )
-    .map_err(|e| {
+    map.insert(runtime_pid, val, 0).map_err(|e| {
         anyhow::anyhow!(
             "pid_aliases update failed for runtime_pid={} proc_pid={}: {}",
             runtime_pid,
@@ -652,9 +567,8 @@ pub fn insert_pid_alias(runtime_pid: u32, proc_pid: u32) -> anyhow::Result<()> {
 
 /// Remove a runtime-pid alias from the pinned pid_aliases map.
 pub fn remove_pid_alias(runtime_pid: u32) -> anyhow::Result<()> {
-    let map_data = MapData::from_pin(pid_aliases_pin_path()?)?;
-    let fd = map_data.fd().as_fd().as_raw_fd();
-    bpf_map_delete_elem(fd, &runtime_pid as *const _ as *const _).map_err(|e| {
+    let mut map = open_pinned_hash_map::<u32, PidAliasValue>(pid_aliases_pin_path()?)?;
+    map.remove(&runtime_pid).map_err(|e| {
         anyhow::anyhow!(
             "pid_aliases delete failed for runtime_pid={}: {}",
             runtime_pid,
@@ -663,82 +577,38 @@ pub fn remove_pid_alias(runtime_pid: u32) -> anyhow::Result<()> {
     })
 }
 
-fn bpf_map_delete_elem(fd: i32, key: *const c::c_void) -> io::Result<()> {
-    let attr = BpfMapUpdateAttr {
-        map_fd: fd as u32,
-        _pad: 0,
-        key: key as usize as u64,
-        value: 0,
-        flags: 0,
-    };
-    let ret = unsafe {
-        c::syscall(
-            c::SYS_bpf,
-            BPF_MAP_DELETE_ELEM,
-            &attr,
-            std::mem::size_of::<BpfMapUpdateAttr>(),
-        )
-    };
-    if ret < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
-
 /// Purge all entries for a given pid in the pinned proc_module_offsets map.
 pub fn purge_offsets_for_pid(pid: u32) -> anyhow::Result<usize> {
-    let map_data = MapData::from_pin(proc_offsets_pin_path()?)?;
-    let fd = map_data.fd().as_fd().as_raw_fd();
+    let mut map =
+        open_pinned_hash_map::<ProcModuleKey, ProcModuleOffsetsValue>(proc_offsets_pin_path()?)?;
     let mut deleted = 0usize;
 
-    // Iterate keys with GET_NEXT_KEY
-    let mut prev: Option<ProcModuleKey> = None;
-    loop {
-        let mut next: ProcModuleKey = ProcModuleKey {
-            pid: 0,
-            pad: 0,
-            cookie_lo: 0,
-            cookie_hi: 0,
-        };
-        let key_ptr = prev
-            .as_ref()
-            .map(|k| k as *const _ as *const c::c_void)
-            .unwrap_or(std::ptr::null());
-        let res = bpf_map_get_next_key(fd, key_ptr, &mut next as *mut _ as *mut _);
-        match res {
-            Ok(()) => {
-                // Check pid match
-                if next.pid == pid {
-                    // Delete and continue iteration from the same prev (do not advance prev)
-                    let _ = bpf_map_delete_elem(fd, &next as *const _ as *const _);
-                    deleted += 1;
-                    // Do not set prev = Some(next) to avoid skipping following keys
-                    continue;
-                } else {
-                    prev = Some(next);
-                }
-            }
-            Err(e) => {
-                // ENOENT means end of iteration
-                if e.raw_os_error() == Some(libc::ENOENT) {
-                    break;
-                } else {
-                    return Err(anyhow::anyhow!("bpf_map_get_next_key failed: {}", e));
-                }
-            }
+    let keys: Vec<ProcModuleKey> = map.keys().collect::<Result<_, _>>()?;
+    for key in keys {
+        if key.pid == pid {
+            map.remove(&key).map_err(|e| {
+                anyhow::anyhow!(
+                    "proc_module_offsets delete failed for pid={} cookie=0x{:08x}{:08x}: {}",
+                    pid,
+                    key.cookie_hi,
+                    key.cookie_lo,
+                    e
+                )
+            })?;
+            deleted += 1;
         }
     }
+
     Ok(deleted)
 }
 
-/// Open the pinned global proc_module_offsets map and insert entries via raw bpf syscall.
+/// Open the pinned global proc_module_offsets map and insert entries.
 pub fn insert_offsets_for_pid(
     pid: u32,
     items: &[(u64, ProcModuleOffsetsValue)],
 ) -> anyhow::Result<usize> {
-    let map_data = MapData::from_pin(proc_offsets_pin_path()?)?;
-    let fd = map_data.fd().as_fd().as_raw_fd();
+    let mut map =
+        open_pinned_hash_map::<ProcModuleKey, ProcModuleOffsetsValue>(proc_offsets_pin_path()?)?;
     let mut inserted = 0usize;
     for (cookie, off) in items {
         let key = ProcModuleKey {
@@ -747,12 +617,7 @@ pub fn insert_offsets_for_pid(
             cookie_lo: (*cookie & 0xffff_ffff) as u32,
             cookie_hi: (*cookie >> 32) as u32,
         };
-        match bpf_map_update_elem(
-            fd,
-            &key as *const _ as *const _,
-            off as *const _ as *const _,
-            0,
-        ) {
+        match map.insert(key, *off, 0) {
             Ok(()) => {
                 tracing::debug!(
                     "proc_module_offsets insert ok: pid={} cookie=0x{:08x}{:08x} text=0x{:x} rodata=0x{:x} data=0x{:x} bss=0x{:x}",
@@ -761,7 +626,7 @@ pub fn insert_offsets_for_pid(
                 inserted += 1
             }
             Err(e) => warn!(
-                "bpf_map_update_elem failed for pid={} cookie=0x{:08x}{:08x}: {}",
+                "proc_module_offsets insert failed for pid={} cookie=0x{:08x}{:08x}: {}",
                 pid, key.cookie_hi, key.cookie_lo, e
             ),
         }


### PR DESCRIPTION
Replace the local bpf(2) wrappers with Aya typed hash maps because the manual wrappers encoded map commands and iteration state by hand. That made the sysmon cleanup path vulnerable to syscall ABI mistakes, including repeated first-key iteration and invalid lookup buffers.

The tradeoff is that pinned map access is now coupled to Aya's map wrappers instead of a tiny local syscall shim. That is preferable for runtime code because Aya owns the BPF ABI details and returns typed errors. Purge now snapshots keys before deleting matching entries, which may allocate one vector proportional to the map size but avoids mutating during iteration.