### PR TITLE
feat: support DWARF-backed casts

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -233,6 +233,26 @@ Tips:
 - Auto‑dereference is supported for locals/params/globals. You don’t need to write `*ptr` or `->`; when safe, pointers are read and dereferenced automatically.
 - Array access: supported for top‑level `arr[<int literal>]` and chain‑tail `a.b.c[<int literal>]`. Not supported: chain‑middle indices (`a.b[2].c`), variable/expression indices (`arr[i]`, `arr[i + 1]`), and multi‑dim arrays.
 
+#### Explicit Casts
+
+Use `cast(expr, "TYPE")` to force GhostScope to interpret an expression as a different type. This is most useful when a value is an address, `void*`, or otherwise lacks the precise DWARF type you want to inspect.
+
+```ghostscope
+trace handle_request {
+    let req = cast(ctx, "struct request *");
+    print req.id;
+    print req.headers[0];
+}
+```
+
+Cast type names are resolved from DWARF type names. Treat the DWARF `DW_AT_name` value as the source of truth: C-style prefixes such as `struct`, `union`, `enum`, and `class` are accepted as convenience hints, but they are not usually part of the stored DWARF name. For example, a C `struct request` normally appears in DWARF as a structure DIE named `request`, while a typedef appears under the typedef name.
+
+Base types such as `int`, `unsigned int`, `bool`, `float`, and `double` also commonly exist in DWARF as base-type DIEs. GhostScope accepts common builtin spellings for convenience, and scalar casts can still be useful for width, signedness, and boolean normalization. The main value of `cast`, however, is user-defined and layout-bearing types: structs, classes, unions, enums, typedefs, pointers, and arrays. Those types let GhostScope use DWARF member offsets and element layout to read meaningful fields from memory.
+
+Type lookup is scoped by module. A module is the runtime-loaded ELF object that owns the trace point: the main executable or a shared library, not a source file, package, namespace, or Rust crate. Resolution first checks the current trace module, then falls back to other loaded modules that have DWARF information.
+
+Name collisions are possible when different modules define the same type name, for example a main executable and a shared library both defining `struct request`. In that case, the type in the current trace module wins. If the type exists in exactly one other loaded module, GhostScope may resolve that fallback match; if multiple fallback modules match, `cast` reports an ambiguity instead of picking one arbitrarily. There is no explicit `module=` or module-qualified cast syntax yet; future versions may add it for cross-module disambiguation.
+
 ## Special Variables
 
 Start with `$` and expose runtime info:
@@ -302,7 +322,7 @@ Extended specifiers and dynamic length:
 
 ```ghostscope
 // Hex / pointer / ASCII bytes
-print "A={:x} B={:08X}", a, b;
+print "A={:x} B={:X}", a, b;
 print "p={:p}", ptr;
 print "s={:s}", cstr;            // for char*/char[N], `{}` prints quoted C string
 
@@ -319,14 +339,28 @@ print "tail={:s.n$}", p;
 ```
 
 Notes:
-- `{}` default; `{:x}`/`{:X}` for integers; `{:p}` pointer; `{:s}` ASCII bytes.
+- `{}` default; `{:x}`/`{:X}` render the captured value payload as hex bytes; `{:p}` renders an address; `{:s}` renders ASCII bytes.
+- Length suffixes change `{:x}`/`{:s}` into memory-dump forms. `{:x}` formats the value already captured for the argument; `{:x.4}` treats the argument as an addressable memory source and reads 4 bytes from that address/source.
 - Length suffixes:
   - `.{N}`: static length (decimal/`0x..`/`0o..`/`0b..`).
   - `.*`: dynamic (consumes two args: len then value).
   - `.name$`: capture script variable `name` as length; does not consume an extra value arg.
-- Kernel performs bounded reads; user space renders hex/ASCII. For `{:s}` ASCII, rendering stops at first NUL; non‑printables show as `\xNN`.
+- Reads are type-sensitive. For `{:x}`, the DWARF/script type controls the captured value size and how the value is materialized. For `{:x.N}`/`{:s.N}`, pointers use the pointer value as the read address, arrays/aggregates use their base address, and addressable scalar DWARF variables use their storage address. A pure script integer is not addressable and will be rejected unless you explicitly cast it to a pointer type.
+- Kernel performs bounded reads for memory-dump forms; user space renders hex/ASCII. For `{:s}` ASCII, rendering stops at first NUL; non‑printables show as `\xNN`.
 - Per‑argument read cap is controlled by `ebpf.mem_dump_cap` (default 256 bytes). Requests beyond cap are truncated; if event payload is exceeded, output may also truncate with `…`.
 - On read failure (e.g., null deref, offsets unavailable, permission), extended specifiers print `<MISSING_ARG>`.
+
+Example:
+
+```ghostscope
+trace foo.c:42 {
+    // int a = 10;
+    print "value-hex={:x}", a;     // hex view of the captured int value, e.g. 0a 00 00 00
+    print "mem-hex={:x.4}", a;     // read 4 bytes from a's DWARF storage address
+    print "bad={:x.4}", 10;        // rejected: script integer literal is not an address
+    print "forced={:x.4}", cast(10, "u8 *"); // tries to read 4 bytes at address 0xa
+}
+```
 
 **Note**: Format strings use Rust‑style placeholders, not `%d`/`%s`.
 

--- a/docs/zh/scripting.md
+++ b/docs/zh/scripting.md
@@ -229,7 +229,25 @@ print arr[0].name;
 - 目前“局部变量、参数、全局变量”均已支持自动解引用（无需显式 `*ptr`，也不需要 `->`，统一使用 `.`，在安全范围内会自动加载并解引用指针值，类似于 Rust 的自动解引用）。
 - 数组访问：已支持顶层 `arr[整数字面量]` 与“链尾”`a.b.c[整数字面量]`。暂不支持：链中间索引（如 `a.b[2].c`）、变量/表达式下标（`arr[i]`、`arr[i + 1]`）和多维数组。
 
- 
+#### 显式类型转换
+
+使用 `cast(expr, "TYPE")` 可以强制 GhostScope 将表达式解释成另一种类型。这个能力最适合用于地址、`void*`，或者当前 DWARF 类型不够精确但用户明确知道内存真实布局的场景。
+
+```ghostscope
+trace handle_request {
+    let req = cast(ctx, "struct request *");
+    print req.id;
+    print req.headers[0];
+}
+```
+
+`cast` 的类型字符串会按 DWARF 类型名解析。应把 DWARF 的 `DW_AT_name` 当作最真实的类型名称来源：`struct`、`union`、`enum`、`class` 这类 C 风格前缀只是为了方便书写和表达 tag hint，通常不是 DWARF 里保存的名字。例如 C 里的 `struct request`，在 DWARF 的结构体 DIE 上通常叫 `request`；`typedef` 则通常以 typedef 自己的名字出现。
+
+`int`、`unsigned int`、`bool`、`float`、`double` 这类普通基础类型在 DWARF 里通常也会以 base type DIE 的形式存在。GhostScope 也接受常见 builtin 写法作为便利入口，标量 cast 在宽度、符号和布尔归一化这类场景仍然有用。不过 `cast` 的主要价值是用户自定义且带布局信息的类型：结构体、类、联合体、枚举、typedef、指针和数组。只有这些类型才能让 GhostScope 依据 DWARF 的成员偏移和元素布局，从内存中读出有意义的字段。
+
+类型解析按模块作用域进行。这里的“模块”指运行时加载的 ELF object：主可执行文件或共享库；不是源码文件、包名、namespace 或 Rust crate。解析会先查当前 trace 命中的模块，再回退到其他带 DWARF 信息的已加载模块。
+
+不同模块可能定义同名类型，例如主可执行文件和某个共享库都定义了 `struct request`。这种碰撞场景下，当前 trace 模块里的类型优先。如果该类型只存在于另一个已加载模块，GhostScope 可能解析到那个 fallback 结果；如果多个 fallback 模块同时命中，`cast` 会报告歧义，而不是随意选择一个。目前还没有显式 `module=` 或模块限定的 cast 语法；后续版本可能会加入，用于跨模块消歧。
 
 ### 特殊变量
 
@@ -306,7 +324,7 @@ print "姓名: {}, 年龄: {}", person.name, person.age;
 
 ```ghostscope
 // 十六进制 / 指针 / ASCII 字符串
-print "A={:x} B={:08X}", a, b;   // 十六进制（宽度/填充二阶段）
+print "A={:x} B={:X}", a, b;     // 十六进制字节视图
 print "p={:p}", ptr;             // 指针地址 0x...
 print "s={:s}", cstr;            // ASCII 字节视图；char*/char[N] 的 `{}` 仍打印带引号 C 字符串
 
@@ -323,14 +341,28 @@ print "tail={:s.n$}", p;          // 长度来自变量 n
 ```
 
 说明
-- `{}` 默认；`{:x}`/`{:X}` 用于整数；`{:p}` 指针；`{:s}` ASCII 字节。
+- `{}` 默认；`{:x}`/`{:X}` 将已经捕获到的参数 payload 按十六进制字节渲染；`{:p}` 渲染地址；`{:s}` 渲染 ASCII 字节。
+- 长度后缀会把 `{:x}`/`{:s}` 变成内存转储语义。`{:x}` 格式化参数已经捕获到的值；`{:x.4}` 会把参数当成可寻址的内存来源，并从该地址/来源读取 4 字节。
 - 长度后缀：
   - `.{N}`：静态长度（读取 N 字节）。`N` 支持十进制、十六进制（`0x..`）、八进制（`0o..`）和二进制（`0b..`）。
   - `.*`：动态长度，占位符会消费两个实参（先长度、后值）
   - `.name$`：捕获脚本变量 `name` 作为长度，不额外消费实参
-- 内核侧做有界读取；用户态十六进制/ASCII 渲染。`{:s}` 的 ASCII 渲染遇到首个 NUL 字节即停止；不可打印字节显示为 `\xNN`。
+- 读取方式会受类型影响。对于 `{:x}`，DWARF/脚本类型决定捕获值的大小，以及这个值如何被 materialize。对于 `{:x.N}`/`{:s.N}`，指针使用指针值作为读取地址，数组/聚合使用基地址，可取地址的 DWARF 标量变量使用自己的存储地址。纯脚本整数不是地址，除非显式 cast 成指针类型，否则会被拒绝。
+- 内核侧会为内存转储形式做有界读取；用户态负责十六进制/ASCII 渲染。`{:s}` 的 ASCII 渲染遇到首个 NUL 字节即停止；不可打印字节显示为 `\xNN`。
 - 内存转储的单参数上限由配置项 `ebpf.mem_dump_cap` 控制（默认 256 字节）。若请求长度超过该上限，将被截断；若超过事件负载上限，输出也可能被截断并以 `…` 表示。
 - 读取失败（如空指针、偏移不可用、权限等）时，扩展占位符会输出 `<MISSING_ARG>`。
+
+示例：
+
+```ghostscope
+trace foo.c:42 {
+    // int a = 10;
+    print "value-hex={:x}", a;     // a 这个 int 值的十六进制字节视图，如 0a 00 00 00
+    print "mem-hex={:x.4}", a;     // 从 a 的 DWARF 存储地址读取 4 字节
+    print "bad={:x.4}", 10;        // 会被拒绝：脚本整数字面量不是地址
+    print "forced={:x.4}", cast(10, "u8 *"); // 强制从地址 0xa 读 4 字节
+}
+```
 
 **注意**：格式字符串遵循 Rust 风格，不支持 `%d`/`%s`（C 风格）。
 
@@ -508,7 +540,7 @@ trace log_activity {
 - 支持：脚本变量（整数/布尔） 与上述 DWARF 整数类标量。
 - 有序比较 `< <= > >=` 的语义：
   - 脚本整数始终是有符号 `i64`；布尔按 `0`/`1` 参与比较。
-  - GhostScope 目前不支持显式类型转换，例如 `(uint32_t)x` 或 `x as u32`。
+  - 显式类型转换使用 `cast(expr, "TYPE")`，详见上文“显式类型转换”。不支持 C/Rust 原生写法，例如 `(uint32_t)x` 或 `x as u32`。
   - 对 DWARF 侧 C 整数类标量，有序比较会先按 C 的 integer promotions 与 usual arithmetic conversions 选择比较宽度和有符号/无符号语义。
   - `char`、`unsigned char`、`short`、`unsigned short` 等窄整数会先提升。按当前支持的 C 目标模型，`int8_t(-5) < uint8_t(250)` 会按有符号 `int` 比较，结果为真。
   - 对有符号/无符号混合比较，GhostScope 会选择转换后的比较宽度和符号。例如 `int32_t(-1) > uint32_t(4000000000)` 按 `uint32_t` 比较；`uint32_t(4000000000) > -10000000000` 则把脚本侧视为有符号 `i64` 参与比较。

--- a/e2e-tests/compile-fixtures.sh
+++ b/e2e-tests/compile-fixtures.sh
@@ -70,6 +70,9 @@ run_make_fixture c_multithread_program all
 run_make_fixture scalar_types_program clean
 run_make_fixture scalar_types_program all
 
+run_make_fixture cast_types_program clean
+run_make_fixture cast_types_program all
+
 run_cargo_fixture "$RUST_FIXTURE_DIR" clean
 run_cargo_fixture "$RUST_FIXTURE_DIR" build --locked
 

--- a/e2e-tests/tests/cast_types_execution.rs
+++ b/e2e-tests/tests/cast_types_execution.rs
@@ -1,0 +1,165 @@
+//! Cast-focused script execution tests.
+
+mod common;
+
+use common::{init, OptimizationLevel, FIXTURES};
+use std::path::Path;
+use std::time::Duration;
+
+async fn spawn_cast_types_binary(
+    binary_path: &Path,
+) -> anyhow::Result<common::targets::TargetHandle> {
+    let target = common::targets::TargetLauncher::binary(binary_path)
+        .spawn()
+        .await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(target)
+}
+
+async fn run_ghostscope_with_script_for_target(
+    script_content: &str,
+    timeout_secs: u64,
+    target: &common::targets::TargetHandle,
+) -> anyhow::Result<(i32, String, String)> {
+    common::runner::GhostscopeRunner::new()
+        .with_script(script_content)
+        .attach_to(target)
+        .timeout_secs(timeout_secs)
+        .enable_sysmon_for_target(false)
+        .run()
+        .await
+}
+
+#[tokio::test]
+async fn test_cast_type_matrix_and_module_local_duplicate_names() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("cast_types_program", OptimizationLevel::Debug)?;
+    let target = spawn_cast_types_binary(&binary_path).await?;
+
+    let script = r#"
+	trace cast_types_program.c:64 {
+	    let idx = seq - (seq / 4) * 4;
+	    let typed = cast(&node, "struct CastNode *");
+	    let wordp = cast(&node.words, "uint32_t *");
+	    let nested = cast(cast(cast(&node, "void *"), "const volatile CastNode *"), "CastNode *");
+	    let nested_scalar = cast(cast(cast(&node, "CastNode *").negative, "u8"), "i32");
+	    if typed.payload.signed_value == 700 + seq { print "CAST_ALIAS_OK"; }
+	    if *wordp == seq * 10 { print "CAST_ALIAS_DEREF_OK"; }
+	    if cast(&node, "CastNode *").words[idx] == seq * 10 + idx { print "CAST_TYPEDEF_PTR_OK"; }
+	    if cast(&node.words, "uint32_t *")[idx] == seq * 10 + idx { print "CAST_U32_PTR_INDEX_OK"; }
+	    if cast(&node.words, "uint32_t[4]")[idx] == seq * 10 + idx { print "CAST_U32_ARRAY_INDEX_OK"; }
+	    if *(cast(&node.words, "uint32_t *") + idx) == seq * 10 + idx { print "CAST_PTR_ARITH_DEREF_OK"; }
+	    print "CAST_PTR_ARITH_PRINT_OK {}", cast(&node.words, "uint32_t *") + 1;
+	    if cast(cast(&node, "CastNode *").negative, "u8") == 255 { print "CAST_U8_WRAP_OK"; }
+	    if cast(cast(&node, "CastNode *").negative, "i8") == -1 { print "CAST_I8_SIGN_OK"; }
+	    if cast(cast(&node, "CastNode *").wide, "bool") == true { print "CAST_BOOL_OK"; }
+	    if nested.words[idx] == seq * 10 + idx { print "CAST_NESTED_PTR_OK"; }
+	    if nested_scalar == 255 { print "CAST_NESTED_SCALAR_OK"; }
+	    if cast(true, "i32") == 1 { print "CAST_TRUE_I32_OK"; }
+	    if cast(cast(&node, "CastNode *").wide == cast(&node, "CastNode *").wide, "i32") == 1 { print "CAST_COMPARE_I32_OK"; }
+	    if cast(cast(&node, "CastNode *").kind, "enum CastKind") == 1 { print "CAST_ENUM_OK"; }
+	    if cast(&cast(&node, "CastNode *").payload, "union CastPayload").signed_value == 700 + seq { print "CAST_UNION_OK"; }
+	    if cast(&node, "const volatile CastNode *").qualified_next.payload.signed_value == 700 + seq { print "CAST_QUALIFIED_OK"; }
+	    if cast(&dup, "struct Duplicate *").main_marker == 1000 + seq { print "CAST_MAIN_DUP_OK"; }
+	}
+
+trace cast_lib_duplicate_probe {
+    if cast(dup, "struct Duplicate *").lib_marker == 2000 + seq { print "CAST_LIB_DUP_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 5, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    for marker in [
+        "CAST_ALIAS_OK",
+        "CAST_ALIAS_DEREF_OK",
+        "CAST_TYPEDEF_PTR_OK",
+        "CAST_U32_PTR_INDEX_OK",
+        "CAST_U32_ARRAY_INDEX_OK",
+        "CAST_PTR_ARITH_DEREF_OK",
+        "CAST_PTR_ARITH_PRINT_OK",
+        "CAST_U8_WRAP_OK",
+        "CAST_I8_SIGN_OK",
+        "CAST_BOOL_OK",
+        "CAST_NESTED_PTR_OK",
+        "CAST_NESTED_SCALAR_OK",
+        "CAST_TRUE_I32_OK",
+        "CAST_COMPARE_I32_OK",
+        "CAST_ENUM_OK",
+        "CAST_UNION_OK",
+        "CAST_QUALIFIED_OK",
+        "CAST_MAIN_DUP_OK",
+        "CAST_LIB_DUP_OK",
+    ] {
+        assert!(
+            stdout.contains(marker),
+            "Expected marker {marker}. STDOUT: {stdout}\nSTDERR: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_fallback_duplicate_type_reports_ambiguity() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("cast_types_program", OptimizationLevel::Debug)?;
+    let target = spawn_cast_types_binary(&binary_path).await?;
+
+    let script = r#"
+	trace cast_types_program.c:64 {
+	    print cast(&node, "struct FallbackDuplicate *").lib_a_marker;
+	}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 3, &target).await?;
+    target.terminate().await?;
+    assert_ne!(
+        exit_code, 0,
+        "expected ambiguous type failure. STDOUT: {stdout}"
+    );
+    assert!(
+        (stdout.contains("FallbackDuplicate") || stderr.contains("FallbackDuplicate"))
+            && (stdout.contains("ambiguous") || stderr.contains("ambiguous")),
+        "Expected ambiguous cast target diagnostic. STDOUT: {stdout}\nSTDERR: {stderr}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_unknown_type_reports_compile_error() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("cast_types_program", OptimizationLevel::Debug)?;
+    let target = spawn_cast_types_binary(&binary_path).await?;
+
+    let script = r#"
+	trace cast_types_program.c:64 {
+	    print cast(&node, "struct MissingCastType *").field;
+	}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 3, &target).await?;
+    target.terminate().await?;
+    assert_ne!(exit_code, 0, "expected compile failure. STDOUT: {stdout}");
+    assert!(
+        stdout.contains("MissingCastType")
+            || stderr.contains("MissingCastType")
+            || stdout.contains("was not found")
+            || stderr.contains("was not found"),
+        "Expected missing cast target diagnostic. STDOUT: {stdout}\nSTDERR: {stderr}"
+    );
+
+    Ok(())
+}

--- a/e2e-tests/tests/common/mod.rs
+++ b/e2e-tests/tests/common/mod.rs
@@ -36,6 +36,7 @@ lazy_static! {
     static ref COMPILE_SCALAR_TYPES_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_SCALAR_TYPES_OPTIMIZED_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
+    static ref COMPILE_CAST_TYPES_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_RUST_GLOBAL_RESULT: Mutex<Option<anyhow::Result<()>>> = Mutex::new(None);
     static ref COMPILE_INLINE_CALLSITE_DEFAULT_RESULT: Mutex<Option<anyhow::Result<()>>> =
         Mutex::new(None);
@@ -76,6 +77,7 @@ enum RegisteredFixtureKind {
     ShortLivedLongComm,
     CMultithread,
     ScalarTypes,
+    CastTypes,
     RustGlobal,
     InlineCallsite,
     InlineCallValue,
@@ -149,6 +151,12 @@ const REGISTERED_FIXTURES: &[RegisteredFixture] = &[
         directory: "scalar_types_program",
         cleanup: CleanupCommand::Make,
         kind: RegisteredFixtureKind::ScalarTypes,
+    },
+    RegisteredFixture {
+        name: "cast_types_program",
+        directory: "cast_types_program",
+        cleanup: CleanupCommand::Make,
+        kind: RegisteredFixtureKind::CastTypes,
     },
     RegisteredFixture {
         name: "rust_global_program",
@@ -478,6 +486,16 @@ impl RegisteredFixture {
                     }
                 };
                 Ok(dir.join(bin_name))
+            }
+            RegisteredFixtureKind::CastTypes => {
+                if !matches!(opt_level, OptimizationLevel::Debug) {
+                    anyhow::bail!(
+                        "{} optimization level not supported for cast_types_program",
+                        opt_level.description()
+                    );
+                }
+                ensure_cast_types_program_compiled()?;
+                Ok(dir.join("cast_types_program"))
             }
             RegisteredFixtureKind::RustGlobal => {
                 ensure_rust_global_program_compiled()?;
@@ -1238,6 +1256,7 @@ static COMPILE_SHORT_LIVED_LONG_COMM: Once = Once::new();
 static COMPILE_C_MULTITHREAD: Once = Once::new();
 static COMPILE_SCALAR_TYPES: Once = Once::new();
 static COMPILE_SCALAR_TYPES_OPTIMIZED: Once = Once::new();
+static COMPILE_CAST_TYPES: Once = Once::new();
 static COMPILE_RUST_GLOBAL: Once = Once::new();
 static COMPILE_INLINE_CALLSITE_DEFAULT: Once = Once::new();
 static COMPILE_INLINE_CALLSITE_CLANG_DWARF5: Once = Once::new();
@@ -1516,6 +1535,50 @@ fn ensure_scalar_types_program_optimized_variants_compiled() -> anyhow::Result<(
         .unwrap()
         .as_ref()
     {
+        Some(Ok(())) => Ok(()),
+        Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+        None => panic!("Compilation result should be set after call_once"),
+    }
+}
+
+fn ensure_cast_types_program_compiled() -> anyhow::Result<()> {
+    COMPILE_CAST_TYPES.call_once(|| {
+        let compile_result = (|| -> anyhow::Result<()> {
+            let base =
+                PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cast_types_program");
+            if let Some(result) = use_precompiled_outputs(
+                "cast_types_program",
+                &[
+                    base.join("cast_types_program"),
+                    base.join("libcast_types.so"),
+                    base.join("libcast_types_extra.so"),
+                ],
+            ) {
+                return result;
+            }
+
+            println!("Compiling cast_types_program (Debug) in {base:?}");
+            let _ = Command::new("make")
+                .arg("clean")
+                .current_dir(base.clone())
+                .status()
+                .is_ok();
+            let out = Command::new("make").arg("all").current_dir(base).output()?;
+            if out.status.success() {
+                println!("✓ Successfully compiled cast_types_program and libcast_types.so");
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                Err(anyhow::anyhow!(
+                    "Failed to compile cast_types_program: {}",
+                    stderr
+                ))
+            }
+        })();
+        *COMPILE_CAST_TYPES_RESULT.lock().unwrap() = Some(compile_result);
+    });
+
+    match COMPILE_CAST_TYPES_RESULT.lock().unwrap().as_ref() {
         Some(Ok(())) => Ok(()),
         Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
         None => panic!("Compilation result should be set after call_once"),

--- a/e2e-tests/tests/complex_types_execution.rs
+++ b/e2e-tests/tests/complex_types_execution.rs
@@ -75,6 +75,60 @@ trace update_complex {
 }
 
 #[tokio::test]
+async fn test_cast_pointer_members_array_and_scalar() -> anyhow::Result<()> {
+    init();
+
+    let binary_path =
+        FIXTURES.get_test_binary_with_opt("complex_types_program", OptimizationLevel::Debug)?;
+    let target = spawn_complex_types_binary(&binary_path).await?;
+
+    let script = r#"
+trace complex_types_program.c:15 {
+    let idx = i - (i / 8) * 8;
+    print cast(c, "struct Complex");
+    print *cast(c, "struct Complex *");
+    print "CAST_PTR I={} AGE={} DATA={} ARR={} U8={}",
+        i,
+        cast(c, "struct Complex *").age,
+        cast(c, "struct Complex *").data.i,
+        cast(c, "struct Complex *").arr[idx],
+        cast(i, "u8");
+    if (*cast(c, "struct Complex *")).data.i == i { print "CAST_DEREF_OK"; }
+    if cast(c, "struct Complex *").data.i == i { print "CAST_DATA_OK"; }
+    if cast(c, "struct Complex *").arr[idx] == i * 2 { print "CAST_ARR_OK"; }
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 4, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout.contains("arr: [") && stdout.contains("friend_ref:"),
+        "Expected aggregate cast to render struct fields. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("CAST_DATA_OK"),
+        "Expected pointer cast member access to match i. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("CAST_DEREF_OK"),
+        "Expected pointer deref cast member access to match i. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("CAST_ARR_OK"),
+        "Expected pointer cast array access to scale by element size. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("CAST_PTR I=") && stdout.contains(" U8="),
+        "Expected formatted scalar cast output. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_complex_o3_pointer_members_after_volatile_path() -> anyhow::Result<()> {
     init();
 

--- a/e2e-tests/tests/fixtures/cast_types_program/Makefile
+++ b/e2e-tests/tests/fixtures/cast_types_program/Makefile
@@ -1,0 +1,34 @@
+CC ?= gcc
+BASE_CFLAGS ?= -Wall -Wextra -g -fPIC
+CFLAGS ?= $(BASE_CFLAGS) -O0
+BINARY ?= cast_types_program
+OBJ ?= $(BINARY).o
+SHARED_LIB ?= libcast_types.so
+SHARED_OBJ ?= cast_types_lib.o
+EXTRA_SHARED_LIB ?= libcast_types_extra.so
+EXTRA_SHARED_OBJ ?= cast_types_extra_lib.o
+
+all: $(BINARY) $(SHARED_LIB) $(EXTRA_SHARED_LIB)
+
+$(BINARY): $(OBJ) $(SHARED_LIB) $(EXTRA_SHARED_LIB)
+	$(CC) $(BASE_CFLAGS) -O0 -o $@ $(OBJ) -L. -lcast_types -lcast_types_extra -Wl,-rpath,'$$ORIGIN'
+
+$(OBJ): cast_types_program.c cast_types_program.h
+	$(CC) $(CFLAGS) -c -o $@ cast_types_program.c
+
+$(SHARED_LIB): $(SHARED_OBJ)
+	$(CC) -shared -o $@ $(SHARED_OBJ)
+
+$(SHARED_OBJ): cast_types_lib.c cast_types_program.h
+	$(CC) $(CFLAGS) -c -o $@ cast_types_lib.c
+
+$(EXTRA_SHARED_LIB): $(EXTRA_SHARED_OBJ)
+	$(CC) -shared -o $@ $(EXTRA_SHARED_OBJ)
+
+$(EXTRA_SHARED_OBJ): cast_types_extra_lib.c cast_types_program.h
+	$(CC) $(CFLAGS) -c -o $@ cast_types_extra_lib.c
+
+clean:
+	rm -f *.o cast_types_program libcast_types.so libcast_types_extra.so
+
+.PHONY: all clean

--- a/e2e-tests/tests/fixtures/cast_types_program/cast_types_extra_lib.c
+++ b/e2e-tests/tests/fixtures/cast_types_program/cast_types_extra_lib.c
@@ -1,0 +1,21 @@
+#include "cast_types_program.h"
+
+extern volatile unsigned long long cast_types_shared_sink;
+
+struct FallbackDuplicate {
+    int lib_b_marker;
+    int lib_b_value;
+};
+
+__attribute__((noinline)) void cast_extra_fallback_probe(struct FallbackDuplicate *dup, int seq) {
+    dup->lib_b_value += seq & 1;
+    cast_types_shared_sink += (unsigned long long)dup->lib_b_marker + (unsigned long long)dup->lib_b_value;
+}
+
+void cast_call_extra_lib(int seq) {
+    struct FallbackDuplicate fallback = {
+        .lib_b_marker = 6000 + seq,
+        .lib_b_value = 7000 + seq,
+    };
+    cast_extra_fallback_probe(&fallback, seq);
+}

--- a/e2e-tests/tests/fixtures/cast_types_program/cast_types_lib.c
+++ b/e2e-tests/tests/fixtures/cast_types_program/cast_types_lib.c
@@ -1,0 +1,36 @@
+#include "cast_types_program.h"
+
+extern volatile unsigned long long cast_types_shared_sink;
+
+struct Duplicate {
+    int lib_marker;
+    int lib_value;
+};
+
+struct FallbackDuplicate {
+    int lib_a_marker;
+    int lib_a_value;
+};
+
+__attribute__((noinline)) void cast_lib_duplicate_probe(struct Duplicate *dup, int seq) {
+    dup->lib_value += seq & 1;
+    cast_types_shared_sink += (unsigned long long)dup->lib_marker + (unsigned long long)dup->lib_value;
+}
+
+__attribute__((noinline)) void cast_lib_fallback_probe(struct FallbackDuplicate *dup, int seq) {
+    dup->lib_a_value += seq & 1;
+    cast_types_shared_sink += (unsigned long long)dup->lib_a_marker + (unsigned long long)dup->lib_a_value;
+}
+
+void cast_call_lib(int seq) {
+    struct Duplicate dup = {
+        .lib_marker = 2000 + seq,
+        .lib_value = 3000 + seq,
+    };
+    struct FallbackDuplicate fallback = {
+        .lib_a_marker = 4000 + seq,
+        .lib_a_value = 5000 + seq,
+    };
+    cast_lib_duplicate_probe(&dup, seq);
+    cast_lib_fallback_probe(&fallback, seq);
+}

--- a/e2e-tests/tests/fixtures/cast_types_program/cast_types_program.c
+++ b/e2e-tests/tests/fixtures/cast_types_program/cast_types_program.c
@@ -1,0 +1,71 @@
+#include <stdint.h>
+#include <unistd.h>
+
+#include "cast_types_program.h"
+
+enum CastKind {
+    CAST_KIND_ZERO = 0,
+    CAST_KIND_ONE = 1,
+    CAST_KIND_NEG = -1,
+};
+
+union CastPayload {
+    int signed_value;
+    uint32_t unsigned_value;
+    char bytes[4];
+};
+
+typedef struct CastNode {
+    uint32_t words[4];
+    union CastPayload payload;
+    enum CastKind kind;
+    int negative;
+    unsigned long long wide;
+    void *opaque;
+    const volatile struct CastNode *qualified_next;
+} CastNode;
+
+struct Duplicate {
+    int main_marker;
+    int main_value;
+};
+
+volatile unsigned long long cast_types_shared_sink;
+
+__attribute__((noinline)) void cast_main_duplicate_probe(struct Duplicate *dup, CastNode *node, void *raw_words,
+                                                         int seq) {
+    dup->main_value += seq & 1;
+    cast_types_shared_sink +=
+        (unsigned long long)dup->main_marker +
+        (unsigned long long)dup->main_value +
+        (unsigned long long)node->words[seq & 3] +
+        (unsigned long long)node->payload.unsigned_value +
+        (unsigned long long)(uintptr_t)raw_words;
+}
+
+int main(void) {
+    CastNode node = {0};
+    struct Duplicate dup = {0};
+
+    for (int seq = 0; seq < 20000; seq++) {
+        for (int i = 0; i < 4; i++) {
+            node.words[i] = (uint32_t)(seq * 10 + i);
+        }
+        node.payload.signed_value = 700 + seq;
+        node.kind = CAST_KIND_ONE;
+        node.negative = -1;
+        node.wide = 0xff00ULL + (unsigned long long)seq;
+        node.opaque = node.words;
+        node.qualified_next = &node;
+
+        dup.main_marker = 1000 + seq;
+        dup.main_value = 1100 + seq;
+
+        cast_main_duplicate_probe(&dup, &node, node.words, seq);
+        cast_call_lib(seq);
+        cast_call_extra_lib(seq);
+        usleep(200000);
+    }
+
+    return (int)(cast_types_shared_sink == 0);
+}

--- a/e2e-tests/tests/fixtures/cast_types_program/cast_types_program.h
+++ b/e2e-tests/tests/fixtures/cast_types_program/cast_types_program.h
@@ -1,0 +1,7 @@
+#ifndef CAST_TYPES_PROGRAM_H
+#define CAST_TYPES_PROGRAM_H
+
+void cast_call_lib(int seq);
+void cast_call_extra_lib(int seq);
+
+#endif

--- a/ghostscope-compiler/src/ebpf/codegen/args.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/args.rs
@@ -96,6 +96,103 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
     }
 
+    fn complex_arg_from_dynamic_lvalue(
+        &mut self,
+        expr: &crate::script::ast::Expr,
+        lvalue: crate::ebpf::expression::DynamicLvalue<'ctx>,
+    ) -> Result<ComplexArg<'ctx>> {
+        let dwarf_type = lvalue.type_info.dwarf_type;
+        let data_len = Self::compute_read_size_for_type(&dwarf_type);
+        if data_len == 0 {
+            return Err(CodeGenError::TypeSizeNotAvailable(self.expr_to_name(expr)));
+        }
+
+        Ok(ComplexArg {
+            var_name_index: self
+                .trace_context
+                .add_variable_name(self.expr_to_name(expr)),
+            type_index: self.trace_context.add_type(dwarf_type),
+            access_path: Vec::new(),
+            data_len,
+            source: ComplexArgSource::MemDump {
+                address: lvalue.address,
+                len: data_len,
+            },
+        })
+    }
+
+    fn complex_arg_from_cast_expr(
+        &mut self,
+        source_expr: &crate::script::ast::Expr,
+        target_type: &str,
+    ) -> Result<ComplexArg<'ctx>> {
+        let dwarf_type = self.resolve_cast_target_type(target_type)?;
+        let display_name = format!(
+            "cast({}, \"{}\")",
+            self.expr_to_name(source_expr),
+            target_type
+        );
+        let var_name_index = self.trace_context.add_variable_name(display_name.clone());
+        let type_index = self.trace_context.add_type(dwarf_type.clone());
+
+        if matches!(
+            ghostscope_dwarf::strip_type_aliases(&dwarf_type),
+            ghostscope_dwarf::TypeInfo::PointerType { .. }
+        ) {
+            let value = self.cast_source_pointer_value(source_expr)?.value;
+            return Ok(ComplexArg {
+                var_name_index,
+                type_index,
+                access_path: Vec::new(),
+                data_len: 8,
+                source: ComplexArgSource::ComputedInt { value, byte_len: 8 },
+            });
+        }
+
+        if ghostscope_dwarf::c_integer_comparison_type(&dwarf_type).is_some() {
+            let cast_expr = crate::script::ast::Expr::Cast {
+                expr: Box::new(source_expr.clone()),
+                target_type: target_type.to_string(),
+            };
+            let value = match self.compile_expr(&cast_expr)? {
+                BasicValueEnum::IntValue(value) => value,
+                BasicValueEnum::PointerValue(value) => self
+                    .builder
+                    .build_ptr_to_int(value, self.context.i64_type(), "cast_arg_ptr_to_i64")
+                    .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                _ => {
+                    return Err(CodeGenError::TypeError(
+                        "cast expression did not produce an integer value".to_string(),
+                    ))
+                }
+            };
+            let byte_len = Self::cast_value_byte_len(&dwarf_type).unwrap_or(8);
+            return Ok(ComplexArg {
+                var_name_index,
+                type_index,
+                access_path: Vec::new(),
+                data_len: byte_len,
+                source: ComplexArgSource::ComputedInt { value, byte_len },
+            });
+        }
+
+        let address = self.cast_source_memory_address(source_expr)?;
+        let data_len = Self::compute_read_size_for_type(&dwarf_type);
+        if data_len == 0 {
+            return Err(CodeGenError::TypeSizeNotAvailable(display_name));
+        }
+        Ok(ComplexArg {
+            var_name_index,
+            type_index,
+            access_path: Vec::new(),
+            data_len,
+            source: ComplexArgSource::MemDump {
+                address,
+                len: data_len,
+            },
+        })
+    }
+
     /// Unified expression resolver: returns a ComplexArg carrying
     /// a consistent var_name_index/type_index/access_path/data_len/source
     /// with strict priority: script variables -> DWARF (locals/params/globals).
@@ -246,6 +343,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 })
             }
 
+            // 3b) Explicit forced cast/reinterpret view.
+            E::Cast { expr, target_type } => self.complex_arg_from_cast_expr(expr, target_type),
+
             // 4) AddressOf: return AddressValue (pointer payload will be produced)
             E::AddressOf(inner) => {
                 let var = self
@@ -299,6 +399,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             | E::ArrayAccess(_, _)
             | E::PointerDeref(_)
             | E::ChainAccess(_)) => {
+                if let Some(lvalue) = self.dynamic_lvalue_address_and_type(expr)? {
+                    return self.complex_arg_from_dynamic_lvalue(expr, lvalue);
+                }
+
                 if let E::ArrayAccess(array_expr, index_expr) = expr {
                     if let Some((BasicValueEnum::IntValue(value), _element_type)) =
                         self.compile_dynamic_array_access_value(array_expr, index_expr)?
@@ -376,6 +480,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
             // 7) Pointer arithmetic (ptr +/- K) → typed runtime read at computed address
             E::BinaryOp { .. } => {
+                if let Some(lvalue) = self.dynamic_lvalue_address_and_type(expr)? {
+                    return self.complex_arg_from_dynamic_lvalue(expr, lvalue);
+                }
+
                 // Support: ptr + int, int + ptr, ptr - int (int may be negative)
                 // Only allow when ptr side resolves to DWARF pointer/array; the offset must be an integer literal for now.
                 // We emit a RuntimeRead with computed location, preserving the pointed-to DWARF type.
@@ -668,6 +776,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 E::ArrayAccess(arr, idx) => format!("{}[{}]", inner(arr), inner(idx)),
                 E::PointerDeref(p) => format!("*{}", inner(p)),
                 E::AddressOf(p) => format!("&{}", inner(p)),
+                E::Cast { expr, target_type } => {
+                    format!("cast({}, \"{}\")", inner(expr), target_type)
+                }
                 E::ChainAccess(v) => v.join("."),
                 E::Int(v) => v.to_string(),
                 E::String(s) => format!("\"{s}\""),
@@ -726,6 +837,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             | E::PointerDeref(inner)
             | E::AddressOf(inner)
             | E::MemberAccess(inner, _) => Self::expr_contains_builtin(inner),
+            E::Cast { expr, .. } => Self::expr_contains_builtin(expr),
             E::ArrayAccess(base, index) => {
                 Self::expr_contains_builtin(base) || Self::expr_contains_builtin(index)
             }
@@ -867,6 +979,18 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             E::Variable(name) if self.alias_variable_exists(name) => true,
             // Explicit address-of is always an alias
             E::AddressOf(_) => true,
+            E::Cast { target_type, .. } => self
+                .resolve_cast_target_type(target_type)
+                .ok()
+                .is_some_and(|ty| {
+                    matches!(
+                        ghostscope_dwarf::strip_type_aliases(&ty),
+                        ghostscope_dwarf::TypeInfo::PointerType { .. }
+                            | ghostscope_dwarf::TypeInfo::ArrayType { .. }
+                            | ghostscope_dwarf::TypeInfo::StructType { .. }
+                            | ghostscope_dwarf::TypeInfo::UnionType { .. }
+                    )
+                }),
             // Constant offset on top of an alias-eligible expression
             E::BinaryOp {
                 left,

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -1358,6 +1358,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     let in2 = expand_aliases(ctx, inner, visited, depth + 1)?;
                     E::AddressOf(Box::new(in2))
                 }
+                E::Cast { expr, target_type } => {
+                    let expr = expand_aliases(ctx, expr, visited, depth + 1)?;
+                    E::Cast {
+                        expr: Box::new(expr),
+                        target_type: target_type.clone(),
+                    }
+                }
                 E::ChainAccess(chain) => {
                     if chain.is_empty() {
                         return Ok(e.clone());

--- a/ghostscope-compiler/src/ebpf/expression.rs
+++ b/ghostscope-compiler/src/ebpf/expression.rs
@@ -17,14 +17,14 @@ use tracing::debug;
 // compare cap is provided via compile_options.compare_cap (config: ebpf.compare_cap)
 
 #[derive(Clone)]
-struct DynamicTypeInfo {
-    dwarf_type: DwarfType,
-    module_path: Option<PathBuf>,
+pub(super) struct DynamicTypeInfo {
+    pub(super) dwarf_type: DwarfType,
+    pub(super) module_path: Option<PathBuf>,
 }
 
-struct DynamicLvalue<'ctx> {
-    address: RuntimeAddress<'ctx>,
-    type_info: DynamicTypeInfo,
+pub(super) struct DynamicLvalue<'ctx> {
+    pub(super) address: RuntimeAddress<'ctx>,
+    pub(super) type_info: DynamicTypeInfo,
 }
 
 struct IndexableElementInfo {
@@ -207,6 +207,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     }
 
     fn is_dwarf_aggregate_expr(&mut self, expr: &Expr) -> bool {
+        if let Expr::Cast { target_type, .. } = expr {
+            return self
+                .resolve_cast_target_type(target_type)
+                .ok()
+                .is_some_and(|ty| ghostscope_dwarf::is_c_aggregate_type(&ty));
+        }
+
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
                 return ghostscope_dwarf::is_c_aggregate_type(ty);
@@ -226,6 +233,20 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         match expr {
             E::AddressOf(_) => return true,
             E::String(_) => return true,
+            E::Cast { target_type, .. } => {
+                if self
+                    .resolve_cast_target_type(target_type)
+                    .ok()
+                    .is_some_and(|ty| {
+                        matches!(
+                            ghostscope_dwarf::strip_type_aliases(&ty),
+                            DwarfType::PointerType { .. } | DwarfType::ArrayType { .. }
+                        )
+                    })
+                {
+                    return true;
+                }
+            }
             E::Variable(name) => {
                 if self.alias_variable_exists(name) {
                     return true;
@@ -242,6 +263,385 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
         }
         false
+    }
+
+    pub(super) fn resolve_cast_target_type(&self, target_type: &str) -> Result<DwarfType> {
+        let analyzer = self.process_analyzer;
+        let resolved = if let Some(context) = self.current_compile_time_context.as_ref() {
+            let module_path = Path::new(&context.module_path);
+            analyzer
+                .map(|analyzer| analyzer.try_resolve_type_spec_in_module(module_path, target_type))
+                .transpose()
+                .map_err(|err| CodeGenError::DwarfError(err.to_string()))?
+                .flatten()
+                .or_else(|| ghostscope_dwarf::DwarfAnalyzer::resolve_builtin_type_spec(target_type))
+        } else {
+            analyzer
+                .map(|analyzer| analyzer.try_resolve_type_spec(target_type))
+                .transpose()
+                .map_err(|err| CodeGenError::DwarfError(err.to_string()))?
+                .flatten()
+                .or_else(|| ghostscope_dwarf::DwarfAnalyzer::resolve_builtin_type_spec(target_type))
+        };
+
+        resolved.ok_or_else(|| {
+            CodeGenError::DwarfError(format!("cast target type '{target_type}' was not found"))
+        })
+    }
+
+    pub(super) fn cast_pointer_target_type(target_type: &DwarfType) -> Option<DwarfType> {
+        match ghostscope_dwarf::strip_type_aliases(target_type) {
+            DwarfType::PointerType { target_type, .. } => Some(target_type.as_ref().clone()),
+            _ => None,
+        }
+    }
+
+    fn is_float_dwarf_type(target_type: &DwarfType) -> bool {
+        match ghostscope_dwarf::strip_type_aliases(target_type) {
+            DwarfType::BaseType { encoding, .. } => {
+                *encoding == ghostscope_dwarf::constants::DW_ATE_float.0 as u16
+            }
+            _ => false,
+        }
+    }
+
+    fn is_bool_dwarf_type(target_type: &DwarfType) -> bool {
+        match ghostscope_dwarf::strip_type_aliases(target_type) {
+            DwarfType::BaseType { encoding, .. } => {
+                *encoding == ghostscope_dwarf::constants::DW_ATE_boolean.0 as u16
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn cast_value_byte_len(target_type: &DwarfType) -> Option<usize> {
+        if matches!(
+            ghostscope_dwarf::strip_type_aliases(target_type),
+            DwarfType::PointerType { .. }
+        ) {
+            return Some(8);
+        }
+
+        if let Some(integer_type) = ghostscope_dwarf::c_integer_comparison_type(target_type) {
+            return Some(integer_type.size.clamp(1, 8) as usize);
+        }
+
+        None
+    }
+
+    pub(super) fn cast_source_pointer_value(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<RuntimeAddress<'ctx>> {
+        if let Ok(address) = self.resolve_runtime_address_from_expr(expr) {
+            return Ok(address);
+        }
+
+        match self.compile_expr(expr)? {
+            BasicValueEnum::IntValue(value) => Ok(RuntimeAddress::available(
+                self.normalize_int_to_i64(value, "cast_ptr_i64")?,
+                self.context,
+            )),
+            BasicValueEnum::PointerValue(value) => self
+                .builder
+                .build_ptr_to_int(value, self.context.i64_type(), "cast_ptr_value")
+                .map(|value| RuntimeAddress::available(value, self.context))
+                .map_err(|err| CodeGenError::Builder(err.to_string())),
+            _ => Err(CodeGenError::TypeError(
+                "cast source expression did not produce an address-sized value".to_string(),
+            )),
+        }
+    }
+
+    pub(super) fn cast_source_memory_address(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<RuntimeAddress<'ctx>> {
+        if let Ok(address) = self.resolve_runtime_address_from_expr(expr) {
+            return Ok(address);
+        }
+
+        if let Some(plan) = self.query_dwarf_for_complex_expr(expr)? {
+            let status_ptr = if self.condition_context_active {
+                Some(self.get_or_create_cond_error_global())
+            } else {
+                None
+            };
+            let pc_address = self.get_compile_time_context()?.pc_address;
+            if let Ok(address) =
+                self.variable_read_plan_to_runtime_address(&plan, pc_address, status_ptr)
+            {
+                return Ok(address);
+            }
+        }
+
+        match self.compile_expr(expr)? {
+            BasicValueEnum::IntValue(value) => Ok(RuntimeAddress::available(
+                self.normalize_int_to_i64(value, "cast_mem_i64")?,
+                self.context,
+            )),
+            BasicValueEnum::PointerValue(value) => self
+                .builder
+                .build_ptr_to_int(value, self.context.i64_type(), "cast_mem_ptr")
+                .map(|value| RuntimeAddress::available(value, self.context))
+                .map_err(|err| CodeGenError::Builder(err.to_string())),
+            _ => Err(CodeGenError::TypeError(
+                "cast source expression is not addressable".to_string(),
+            )),
+        }
+    }
+
+    fn cast_lvalue_address_and_type(
+        &mut self,
+        expr: &Expr,
+        target_type: &str,
+    ) -> Result<DynamicLvalue<'ctx>> {
+        let target_type = self.resolve_cast_target_type(target_type)?;
+        let module_path = self
+            .current_compile_time_context
+            .as_ref()
+            .map(|context| PathBuf::from(&context.module_path));
+
+        if let Some(pointee_type) = Self::cast_pointer_target_type(&target_type) {
+            let address = self.cast_source_pointer_value(expr)?;
+            return Ok(DynamicLvalue {
+                address,
+                type_info: DynamicTypeInfo {
+                    dwarf_type: pointee_type,
+                    module_path,
+                },
+            });
+        }
+
+        let address = self.cast_source_memory_address(expr)?;
+        Ok(DynamicLvalue {
+            address,
+            type_info: DynamicTypeInfo {
+                dwarf_type: target_type,
+                module_path,
+            },
+        })
+    }
+
+    fn cast_index_base(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<Option<(IndexableElementInfo, RuntimeAddress<'ctx>)>> {
+        let Expr::Cast {
+            expr: source_expr,
+            target_type,
+        } = expr
+        else {
+            return Ok(None);
+        };
+
+        let target_type = self.resolve_cast_target_type(target_type)?;
+        let module_path = self
+            .current_compile_time_context
+            .as_ref()
+            .map(|context| PathBuf::from(&context.module_path));
+
+        match ghostscope_dwarf::strip_type_aliases(&target_type) {
+            DwarfType::PointerType {
+                target_type: element_type,
+                ..
+            } => {
+                let base_address = self.cast_source_pointer_value(source_expr)?;
+                Ok(Some((
+                    IndexableElementInfo {
+                        element_type: element_type.as_ref().clone(),
+                        stride: element_type.size().max(1),
+                        module_path,
+                    },
+                    base_address,
+                )))
+            }
+            DwarfType::ArrayType { element_type, .. } => {
+                let base_address = self.cast_source_memory_address(source_expr)?;
+                Ok(Some((
+                    IndexableElementInfo {
+                        element_type: element_type.as_ref().clone(),
+                        stride: element_type.size().max(1),
+                        module_path,
+                    },
+                    base_address,
+                )))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn dynamic_lvalue_from_indexable_base(
+        &mut self,
+        element_info: IndexableElementInfo,
+        base_address: RuntimeAddress<'ctx>,
+        index_value: IntValue<'ctx>,
+        name: &str,
+    ) -> Result<DynamicLvalue<'ctx>> {
+        let stride_value = self
+            .context
+            .i64_type()
+            .const_int(element_info.stride, false);
+        let byte_offset = self
+            .builder
+            .build_int_mul(index_value, stride_value, &format!("{name}_byte_offset"))
+            .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+        let element_address = self
+            .builder
+            .build_int_add(
+                base_address.value,
+                byte_offset,
+                &format!("{name}_element_address"),
+            )
+            .map_err(|err| CodeGenError::Builder(err.to_string()))?;
+
+        Ok(DynamicLvalue {
+            address: base_address.with_value(element_address),
+            type_info: DynamicTypeInfo {
+                dwarf_type: element_info.element_type,
+                module_path: element_info.module_path,
+            },
+        })
+    }
+
+    fn dynamic_lvalue_from_const_pointer_arithmetic(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<Option<DynamicLvalue<'ctx>>> {
+        let Some((base_expr, index)) = self.pointer_arithmetic_parts_expanding_aliases(expr)?
+        else {
+            return Ok(None);
+        };
+        let Some((element_info, base_address)) = self.cast_index_base(&base_expr)? else {
+            return Ok(None);
+        };
+        let index_value = self.context.i64_type().const_int(index as u64, true);
+        self.dynamic_lvalue_from_indexable_base(
+            element_info,
+            base_address,
+            index_value,
+            "dynamic_cast_ptr_arith",
+        )
+        .map(Some)
+    }
+
+    fn compile_cast_integer_value(
+        &mut self,
+        expr: &Expr,
+        target_type: &DwarfType,
+    ) -> Result<IntValue<'ctx>> {
+        let value = match self.compile_expr(expr)? {
+            BasicValueEnum::IntValue(value) => value,
+            BasicValueEnum::PointerValue(value) => self
+                .builder
+                .build_ptr_to_int(value, self.context.i64_type(), "cast_int_ptr")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+            _ => {
+                return Err(CodeGenError::TypeError(
+                    "integer cast source must be an integer or pointer".to_string(),
+                ))
+            }
+        };
+
+        if Self::is_bool_dwarf_type(target_type) {
+            let value = self.normalize_int_to_i64(value, "cast_bool_i64")?;
+            return self
+                .builder
+                .build_int_compare(
+                    inkwell::IntPredicate::NE,
+                    value,
+                    self.context.i64_type().const_zero(),
+                    "cast_bool",
+                )
+                .map_err(|err| CodeGenError::Builder(err.to_string()));
+        }
+
+        let Some(integer_type) = ghostscope_dwarf::c_integer_comparison_type(target_type) else {
+            return Err(CodeGenError::TypeError(format!(
+                "cast target '{}' is not an integer type",
+                target_type.type_name()
+            )));
+        };
+
+        let bit_width = integer_type.size.saturating_mul(8).clamp(1, 64) as u32;
+        let target_int_type = self.context.custom_width_int_type(bit_width);
+        let current_width = value.get_type().get_bit_width();
+        let narrowed = if current_width > bit_width {
+            self.builder
+                .build_int_truncate(value, target_int_type, "cast_int_trunc")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))?
+        } else if current_width < bit_width {
+            if integer_type.is_unsigned || current_width == 1 {
+                self.builder
+                    .build_int_z_extend(value, target_int_type, "cast_int_zext")
+                    .map_err(|err| CodeGenError::Builder(err.to_string()))?
+            } else {
+                self.builder
+                    .build_int_s_extend(value, target_int_type, "cast_int_sext")
+                    .map_err(|err| CodeGenError::Builder(err.to_string()))?
+            }
+        } else {
+            value
+        };
+
+        if bit_width == 64 {
+            return Ok(narrowed);
+        }
+
+        if integer_type.is_unsigned {
+            self.builder
+                .build_int_z_extend(narrowed, self.context.i64_type(), "cast_int_zext_i64")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))
+        } else {
+            self.builder
+                .build_int_s_extend(narrowed, self.context.i64_type(), "cast_int_sext_i64")
+                .map_err(|err| CodeGenError::Builder(err.to_string()))
+        }
+    }
+
+    fn compile_cast_expr_value(
+        &mut self,
+        expr: &Expr,
+        target_type: &str,
+    ) -> Result<BasicValueEnum<'ctx>> {
+        let target_type = self.resolve_cast_target_type(target_type)?;
+
+        if Self::cast_pointer_target_type(&target_type).is_some() {
+            let address = self.cast_source_pointer_value(expr)?;
+            let ptr_ty = self.context.ptr_type(AddressSpace::default());
+            return self
+                .builder
+                .build_int_to_ptr(address.value, ptr_ty, "cast_as_ptr")
+                .map(|value| value.into())
+                .map_err(|err| CodeGenError::Builder(err.to_string()));
+        }
+
+        if ghostscope_dwarf::is_c_aggregate_type(&target_type) {
+            let address = self.cast_source_memory_address(expr)?;
+            let ptr_ty = self.context.ptr_type(AddressSpace::default());
+            return self
+                .builder
+                .build_int_to_ptr(address.value, ptr_ty, "cast_aggregate_ptr")
+                .map(|value| value.into())
+                .map_err(|err| CodeGenError::Builder(err.to_string()));
+        }
+
+        if ghostscope_dwarf::c_integer_comparison_type(&target_type).is_some() {
+            return self
+                .compile_cast_integer_value(expr, &target_type)
+                .map(|value| value.into());
+        }
+
+        if Self::is_float_dwarf_type(&target_type) {
+            return Err(CodeGenError::TypeError(
+                "floating-point casts are only supported for memory reads/printing".to_string(),
+            ));
+        }
+
+        Err(CodeGenError::TypeError(format!(
+            "cast target '{}' is not supported as a value expression",
+            target_type.type_name()
+        )))
     }
 
     pub(crate) fn integer_literal_value(expr: &Expr) -> Option<i64> {
@@ -384,6 +784,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     }
 
     fn dwarf_integer_comparison_expr(&mut self, expr: &Expr) -> Option<CIntegerComparisonType> {
+        if let Expr::Cast { target_type, .. } = expr {
+            return self
+                .resolve_cast_target_type(target_type)
+                .ok()
+                .and_then(|ty| ghostscope_dwarf::c_integer_comparison_type(&ty));
+        }
+
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
                 return ghostscope_dwarf::c_integer_comparison_type(ty);
@@ -485,6 +892,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     fn is_dynamic_indexable_pointer_base(&mut self, expr: &Expr) -> Result<bool> {
         if matches!(expr, Expr::AddressOf(_)) {
+            return Ok(true);
+        }
+
+        if self.cast_index_base(expr)?.is_some() {
             return Ok(true);
         }
 
@@ -592,6 +1003,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 "alias expansion depth exceeded (cycle?)".into(),
             ));
         }
+        if let E::Cast { expr, target_type } = e {
+            let target_type_info = self.resolve_cast_target_type(target_type)?;
+            if Self::cast_pointer_target_type(&target_type_info).is_some() {
+                return self.cast_source_pointer_value(expr);
+            }
+            return self.cast_source_memory_address(expr);
+        }
         // Alias variable indirection: resolve its target expression first
         if let E::Variable(name) = e {
             if self.alias_variable_exists(name) {
@@ -653,6 +1071,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 }
             }
 
+            if let Some(lvalue) = self.dynamic_lvalue_address_and_type(resolved_inner)? {
+                return Ok(lvalue.address);
+            }
+
             if let Some(var) = self.query_dwarf_for_complex_expr(resolved_inner)? {
                 let status_ptr = if self.condition_context_active {
                     Some(self.get_or_create_cond_error_global())
@@ -682,6 +1104,16 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                     .build_int_add(base.value, off, "ptr_add")
                     .map_err(|err| CodeGenError::Builder(err.to_string()))?;
                 return Ok(base.with_value(value));
+            } else if let Some((element_info, base_address)) = self.cast_index_base(&ptr_side)? {
+                let index_value = self.context.i64_type().const_int(index as u64, true);
+                return self
+                    .dynamic_lvalue_from_indexable_base(
+                        element_info,
+                        base_address,
+                        index_value,
+                        "cast_ptr_add",
+                    )
+                    .map(|lvalue| lvalue.address);
             } else if let Some(var) = self.query_dwarf_for_complex_expr(&ptr_side)? {
                 if var.dwarf_type.is_some() {
                     let pointed_plan = var
@@ -2343,6 +2775,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 // Use unified DWARF expression compilation
                 self.compile_dwarf_expression(expr)
             }
+            Expr::Cast {
+                expr: inner,
+                target_type,
+            } => self.compile_cast_expr_value(inner, target_type),
             Expr::ChainAccess(_) => {
                 // Use unified DWARF expression compilation
                 self.compile_dwarf_expression(expr)
@@ -3001,6 +3437,14 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             expr
         );
 
+        if let crate::script::Expr::Cast {
+            expr: inner,
+            target_type,
+        } = expr
+        {
+            return self.compile_cast_expr_value(inner, target_type);
+        }
+
         if let crate::script::Expr::ArrayAccess(array_expr, index_expr) = expr {
             if let Some((value, _element_type)) =
                 self.compile_dynamic_array_access_value(array_expr, index_expr)?
@@ -3013,6 +3457,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 self.compile_dynamic_member_access_value(obj_expr, field)?
             {
                 return Ok(value);
+            }
+        }
+        if matches!(expr, crate::script::Expr::PointerDeref(_)) {
+            if let Some(lvalue) = self.dynamic_lvalue_address_and_type(expr)? {
+                return self
+                    .read_dynamic_address_value(lvalue.address, &lvalue.type_info.dwarf_type);
             }
         }
 
@@ -3089,12 +3539,45 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         Ok(Some((value, member_type)))
     }
 
-    fn dynamic_lvalue_address_and_type(
+    pub(super) fn dynamic_lvalue_address_and_type(
         &mut self,
         expr: &Expr,
     ) -> Result<Option<DynamicLvalue<'ctx>>> {
+        if let Expr::Variable(name) = expr {
+            if self.alias_variable_exists(name) {
+                let expanded = self.expand_alias_variable_expr(expr)?;
+                return self.dynamic_lvalue_address_and_type(&expanded);
+            }
+        }
+
+        if let Expr::Cast {
+            expr: inner,
+            target_type,
+        } = expr
+        {
+            return self
+                .cast_lvalue_address_and_type(inner, target_type)
+                .map(Some);
+        }
+
+        if let Expr::PointerDeref(inner) = expr {
+            let expanded_inner = self.expand_alias_variable_expr(inner)?;
+            if matches!(expanded_inner, Expr::Cast { .. }) {
+                return self.dynamic_lvalue_address_and_type(&expanded_inner);
+            }
+            if let Expr::BinaryOp { .. } = expanded_inner {
+                if let Some(lvalue) = self.dynamic_lvalue_address_and_type(&expanded_inner)? {
+                    return Ok(Some(lvalue));
+                }
+            }
+        }
+
         if let Expr::ArrayAccess(array_expr, index_expr) = expr {
             return self.compile_dynamic_array_element_address(array_expr, index_expr);
+        }
+
+        if let Some(lvalue) = self.dynamic_lvalue_from_const_pointer_arithmetic(expr)? {
+            return Ok(Some(lvalue));
         }
 
         if self.expands_to_nonliteral_pointer_arithmetic(expr)? {
@@ -3231,8 +3714,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let expanded_array_expr = self.expand_alias_variable_expr(array_expr)?;
         let has_dynamic_base =
             self.expands_to_nonliteral_pointer_arithmetic(&expanded_array_expr)?;
+        let cast_base = self.cast_index_base(&expanded_array_expr)?;
 
-        if literal_index.is_some() && !has_dynamic_base {
+        if literal_index.is_some() && !has_dynamic_base && cast_base.is_none() {
             return Ok(None);
         }
 
@@ -3243,88 +3727,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             None
         };
 
-        let (element_info, base_address, static_index) = match self
-            .query_dwarf_for_complex_expr(array_expr)?
+        let (element_info, base_address, static_index) = if let Some((element_info, base_address)) =
+            cast_base
         {
-            Some(array_plan) => {
-                let module_path = array_plan.module_path.clone();
-                let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
-                    CodeGenError::DwarfError(
-                        "Array expression has no DWARF type information".to_string(),
-                    )
-                })?;
-                match ghostscope_dwarf::strip_type_aliases(&array_type) {
-                    DwarfType::ArrayType { element_type, .. } => {
-                        let base_address = self.variable_read_plan_to_runtime_address(
-                            &array_plan,
-                            compile_context.pc_address,
-                            status_ptr,
-                        )?;
-                        (
-                            IndexableElementInfo {
-                                element_type: element_type.as_ref().clone(),
-                                stride: element_type.size().max(1),
-                                module_path,
-                            },
-                            base_address,
-                            0,
-                        )
-                    }
-                    DwarfType::PointerType { target_type, .. } => {
-                        let pointer_value = self.variable_read_plan_to_llvm_value(
-                            &array_plan,
-                            compile_context.pc_address,
-                            status_ptr,
-                        )?;
-                        let base_address = match pointer_value {
-                            BasicValueEnum::IntValue(value) => RuntimeAddress::available(
-                                self.normalize_int_to_i64(value, "dynamic_array_base_i64")?,
-                                self.context,
-                            ),
-                            BasicValueEnum::PointerValue(value) => self
-                                .builder
-                                .build_ptr_to_int(
-                                    value,
-                                    self.context.i64_type(),
-                                    "dynamic_array_base_ptr",
-                                )
-                                .map(|value| RuntimeAddress::available(value, self.context))
-                                .map_err(|err| CodeGenError::Builder(err.to_string()))?,
-                            _ => {
-                                return Err(CodeGenError::TypeError(
-                                    "array base pointer did not compile to an address".to_string(),
-                                ))
-                            }
-                        };
-                        (
-                            IndexableElementInfo {
-                                element_type: target_type.as_ref().clone(),
-                                stride: target_type.size().max(1),
-                                module_path,
-                            },
-                            base_address,
-                            0,
-                        )
-                    }
-                    other => {
-                        return Err(CodeGenError::TypeError(format!(
-                            "dynamic array index requires array or pointer type, got '{}'",
-                            other.type_name()
-                        )))
-                    }
-                }
-            }
-            None => {
-                if let Some((base_expr, static_index)) =
-                    self.pointer_arithmetic_parts_expanding_aliases(&expanded_array_expr)?
-                {
-                    let array_plan =
-                        self.query_dwarf_for_complex_expr(&base_expr)?
-                            .ok_or_else(|| {
-                                CodeGenError::VariableNotFound(Self::expr_to_debug_string(
-                                    &base_expr,
-                                ))
-                            })?;
+            (element_info, base_address, 0)
+        } else {
+            match self.query_dwarf_for_complex_expr(array_expr)? {
+                Some(array_plan) => {
                     let module_path = array_plan.module_path.clone();
                     let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
                         CodeGenError::DwarfError(
@@ -3345,7 +3754,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     module_path,
                                 },
                                 base_address,
-                                static_index,
+                                0,
                             )
                         }
                         DwarfType::PointerType { target_type, .. } => {
@@ -3382,75 +3791,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                                     module_path,
                                 },
                                 base_address,
-                                static_index,
-                            )
-                        }
-                        other => {
-                            return Err(CodeGenError::TypeError(format!(
-                                "dynamic array index requires array or pointer type, got '{}'",
-                                other.type_name()
-                            )))
-                        }
-                    }
-                } else if has_dynamic_base {
-                    let element_info = self
-                        .indexable_element_type_and_stride(&expanded_array_expr)?
-                        .ok_or_else(|| {
-                            CodeGenError::VariableNotFound(Self::expr_to_debug_string(array_expr))
-                        })?;
-                    let base_address =
-                        self.resolve_runtime_address_from_expr(&expanded_array_expr)?;
-                    (element_info, base_address, 0)
-                } else if let Some(array_lvalue) =
-                    self.dynamic_lvalue_address_and_type(&expanded_array_expr)?
-                {
-                    let module_path = array_lvalue.type_info.module_path.clone();
-                    match ghostscope_dwarf::strip_type_aliases(&array_lvalue.type_info.dwarf_type) {
-                        DwarfType::ArrayType { element_type, .. } => (
-                            IndexableElementInfo {
-                                element_type: element_type.as_ref().clone(),
-                                stride: element_type.size().max(1),
-                                module_path,
-                            },
-                            array_lvalue.address,
-                            0,
-                        ),
-                        DwarfType::PointerType { target_type, .. } => {
-                            let pointer_value = self.read_dynamic_address_value(
-                                array_lvalue.address,
-                                &array_lvalue.type_info.dwarf_type,
-                            )?;
-                            let base_address = match pointer_value {
-                                BasicValueEnum::IntValue(value) => RuntimeAddress::available(
-                                    self.normalize_int_to_i64(
-                                        value,
-                                        "dynamic_array_member_ptr_i64",
-                                    )?,
-                                    self.context,
-                                ),
-                                BasicValueEnum::PointerValue(value) => self
-                                    .builder
-                                    .build_ptr_to_int(
-                                        value,
-                                        self.context.i64_type(),
-                                        "dynamic_array_member_ptr",
-                                    )
-                                    .map(|value| RuntimeAddress::available(value, self.context))
-                                    .map_err(|err| CodeGenError::Builder(err.to_string()))?,
-                                _ => {
-                                    return Err(CodeGenError::TypeError(
-                                        "array member pointer did not compile to an address"
-                                            .to_string(),
-                                    ))
-                                }
-                            };
-                            (
-                                IndexableElementInfo {
-                                    element_type: target_type.as_ref().clone(),
-                                    stride: target_type.size().max(1),
-                                    module_path,
-                                },
-                                base_address,
                                 0,
                             )
                         }
@@ -3461,10 +3801,163 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             )))
                         }
                     }
-                } else {
-                    return Err(CodeGenError::VariableNotFound(Self::expr_to_debug_string(
-                        array_expr,
-                    )));
+                }
+                None => {
+                    if let Some((base_expr, static_index)) =
+                        self.pointer_arithmetic_parts_expanding_aliases(&expanded_array_expr)?
+                    {
+                        let array_plan = self
+                            .query_dwarf_for_complex_expr(&base_expr)?
+                            .ok_or_else(|| {
+                                CodeGenError::VariableNotFound(Self::expr_to_debug_string(
+                                    &base_expr,
+                                ))
+                            })?;
+                        let module_path = array_plan.module_path.clone();
+                        let array_type = array_plan.dwarf_type.clone().ok_or_else(|| {
+                            CodeGenError::DwarfError(
+                                "Array expression has no DWARF type information".to_string(),
+                            )
+                        })?;
+                        match ghostscope_dwarf::strip_type_aliases(&array_type) {
+                            DwarfType::ArrayType { element_type, .. } => {
+                                let base_address = self.variable_read_plan_to_runtime_address(
+                                    &array_plan,
+                                    compile_context.pc_address,
+                                    status_ptr,
+                                )?;
+                                (
+                                    IndexableElementInfo {
+                                        element_type: element_type.as_ref().clone(),
+                                        stride: element_type.size().max(1),
+                                        module_path,
+                                    },
+                                    base_address,
+                                    static_index,
+                                )
+                            }
+                            DwarfType::PointerType { target_type, .. } => {
+                                let pointer_value = self.variable_read_plan_to_llvm_value(
+                                    &array_plan,
+                                    compile_context.pc_address,
+                                    status_ptr,
+                                )?;
+                                let base_address = match pointer_value {
+                                    BasicValueEnum::IntValue(value) => RuntimeAddress::available(
+                                        self.normalize_int_to_i64(value, "dynamic_array_base_i64")?,
+                                        self.context,
+                                    ),
+                                    BasicValueEnum::PointerValue(value) => self
+                                        .builder
+                                        .build_ptr_to_int(
+                                            value,
+                                            self.context.i64_type(),
+                                            "dynamic_array_base_ptr",
+                                        )
+                                        .map(|value| RuntimeAddress::available(value, self.context))
+                                        .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                                    _ => {
+                                        return Err(CodeGenError::TypeError(
+                                            "array base pointer did not compile to an address"
+                                                .to_string(),
+                                        ))
+                                    }
+                                };
+                                (
+                                    IndexableElementInfo {
+                                        element_type: target_type.as_ref().clone(),
+                                        stride: target_type.size().max(1),
+                                        module_path,
+                                    },
+                                    base_address,
+                                    static_index,
+                                )
+                            }
+                            other => {
+                                return Err(CodeGenError::TypeError(format!(
+                                    "dynamic array index requires array or pointer type, got '{}'",
+                                    other.type_name()
+                                )))
+                            }
+                        }
+                    } else if has_dynamic_base {
+                        let element_info = self
+                            .indexable_element_type_and_stride(&expanded_array_expr)?
+                            .ok_or_else(|| {
+                                CodeGenError::VariableNotFound(Self::expr_to_debug_string(
+                                    array_expr,
+                                ))
+                            })?;
+                        let base_address =
+                            self.resolve_runtime_address_from_expr(&expanded_array_expr)?;
+                        (element_info, base_address, 0)
+                    } else if let Some(array_lvalue) =
+                        self.dynamic_lvalue_address_and_type(&expanded_array_expr)?
+                    {
+                        let module_path = array_lvalue.type_info.module_path.clone();
+                        match ghostscope_dwarf::strip_type_aliases(
+                            &array_lvalue.type_info.dwarf_type,
+                        ) {
+                            DwarfType::ArrayType { element_type, .. } => (
+                                IndexableElementInfo {
+                                    element_type: element_type.as_ref().clone(),
+                                    stride: element_type.size().max(1),
+                                    module_path,
+                                },
+                                array_lvalue.address,
+                                0,
+                            ),
+                            DwarfType::PointerType { target_type, .. } => {
+                                let pointer_value = self.read_dynamic_address_value(
+                                    array_lvalue.address,
+                                    &array_lvalue.type_info.dwarf_type,
+                                )?;
+                                let base_address = match pointer_value {
+                                    BasicValueEnum::IntValue(value) => RuntimeAddress::available(
+                                        self.normalize_int_to_i64(
+                                            value,
+                                            "dynamic_array_member_ptr_i64",
+                                        )?,
+                                        self.context,
+                                    ),
+                                    BasicValueEnum::PointerValue(value) => self
+                                        .builder
+                                        .build_ptr_to_int(
+                                            value,
+                                            self.context.i64_type(),
+                                            "dynamic_array_member_ptr",
+                                        )
+                                        .map(|value| RuntimeAddress::available(value, self.context))
+                                        .map_err(|err| CodeGenError::Builder(err.to_string()))?,
+                                    _ => {
+                                        return Err(CodeGenError::TypeError(
+                                            "array member pointer did not compile to an address"
+                                                .to_string(),
+                                        ))
+                                    }
+                                };
+                                (
+                                    IndexableElementInfo {
+                                        element_type: target_type.as_ref().clone(),
+                                        stride: target_type.size().max(1),
+                                        module_path,
+                                    },
+                                    base_address,
+                                    0,
+                                )
+                            }
+                            other => {
+                                return Err(CodeGenError::TypeError(format!(
+                                    "dynamic array index requires array or pointer type, got '{}'",
+                                    other.type_name()
+                                )))
+                            }
+                        }
+                    } else {
+                        return Err(CodeGenError::VariableNotFound(Self::expr_to_debug_string(
+                            array_expr,
+                        )));
+                    }
                 }
             }
         };
@@ -3529,6 +4022,10 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         use crate::script::ast::Expr as E;
 
         let expanded = self.expand_alias_variable_expr(expr)?;
+
+        if let Some((element_info, _base_address)) = self.cast_index_base(&expanded)? {
+            return Ok(Some(element_info));
+        }
 
         if let Some(plan) = self.query_dwarf_for_complex_expr(&expanded)? {
             if let Some(dwarf_type) = plan.dwarf_type.as_ref() {
@@ -3848,6 +4345,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 format!("{}.{}", Self::expr_to_debug_string(obj), field)
             }
             Expr::ArrayAccess(arr, _) => format!("{}[index]", Self::expr_to_debug_string(arr)),
+            Expr::Cast { expr, target_type } => format!(
+                "cast({}, \"{}\")",
+                Self::expr_to_debug_string(expr),
+                target_type
+            ),
             Expr::ChainAccess(chain) => chain.join("."),
             Expr::PointerDeref(expr) => format!("*{}", Self::expr_to_debug_string(expr)),
             _ => "expr".to_string(),

--- a/ghostscope-compiler/src/script/ast.rs
+++ b/ghostscope-compiler/src/script/ast.rs
@@ -10,8 +10,12 @@ pub enum Expr {
     PointerDeref(Box<Expr>),           // *ptr
     AddressOf(Box<Expr>),              // &expr
     ArrayAccess(Box<Expr>, Box<Expr>), // arr[0] (new)
-    ChainAccess(Vec<String>),          // person.name.first (new)
-    SpecialVar(String),                // For $arg0, $arg1, $retval, $pc, $sp etc.
+    Cast {
+        expr: Box<Expr>,
+        target_type: String,
+    },
+    ChainAccess(Vec<String>), // person.name.first (new)
+    SpecialVar(String),       // For $arg0, $arg1, $retval, $pc, $sp etc.
     // Builtin function call, e.g., strncmp(expr, "lit", n), starts_with(expr, "lit")
     BuiltinCall {
         name: String,
@@ -186,6 +190,7 @@ pub fn infer_type(expr: &Expr) -> Result<VarType, String> {
         Expr::PointerDeref(_) => Ok(VarType::Int), // Same as above
         Expr::AddressOf(_) => Ok(VarType::Int), // Address as integer/pointer value for now
         Expr::ArrayAccess(_, _) => Ok(VarType::Int), // New: array access returns element type (assume int for now)
+        Expr::Cast { .. } => Ok(VarType::Int),       // Cast type is resolved during codegen.
         Expr::ChainAccess(_) => Ok(VarType::Int), // New: chain access returns final member type (assume int for now)
         Expr::SpecialVar(_) => Ok(VarType::Int),  // Special variables like $arg0, $retval etc.
         Expr::BuiltinCall { name, args: _ } => match name.as_str() {

--- a/ghostscope-compiler/src/script/grammar.pest
+++ b/ghostscope-compiler/src/script/grammar.pest
@@ -74,6 +74,8 @@ factor = {
     strncmp_call |
     starts_with_call |
     hex_call |
+    postfix_access |
+    cast_call |
     bool |
     string |
     hex_int |
@@ -97,18 +99,25 @@ strncmp_call = { "strncmp" ~ "(" ~ expr ~ "," ~ expr ~ "," ~ expr ~ ")" }
 starts_with_call = { "starts_with" ~ "(" ~ expr ~ "," ~ expr ~ ")" }
 memcmp_call = { "memcmp" ~ "(" ~ expr ~ "," ~ expr ~ ("," ~ expr)? ~ ")" }
 hex_call = { "hex" ~ "(" ~ string ~ ")" }
+cast_call = { "cast" ~ "(" ~ expr ~ "," ~ string ~ ")" }
 
 special_var = @{ "$" ~ (ASCII_ALPHANUMERIC | "_")+ }
 
 // Complex variable access patterns
 complex_variable = { chain_access | array_access | member_access | pointer_deref | address_of }
+postfix_access = { postfix_base ~ postfix_suffix+ }
+postfix_base = { cast_call | special_var | identifier | "(" ~ expr ~ ")" }
+postfix_suffix = { member_suffix | index_suffix }
+member_suffix = { "." ~ identifier }
+index_suffix = { "[" ~ expr ~ "]" }
 
 chain_access = { identifier ~ ("." ~ identifier)* ~ ("[" ~ expr ~ "]")? }
 array_access = { identifier ~ "[" ~ expr ~ "]" ~ ("." ~ identifier)* }
 // Ensure member_access doesn't preempt cases followed by '[' (those should be parsed by chain_access)
 member_access = { identifier ~ ("." ~ identifier)+ ~ !("[") }
-pointer_deref = { "*" ~ ( "(" ~ expr ~ ")" | complex_variable | identifier ) }
-address_of = { "&" ~ ( "(" ~ expr ~ ")" | complex_variable | identifier ) }
+unary_target = _{ "(" ~ expr ~ ")" | postfix_access | cast_call | complex_variable | special_var | identifier }
+pointer_deref = { "*" ~ unary_target }
+address_of = { "&" ~ unary_target }
 
 add_op = { "+" | "-" }
 mul_op = { "*" | "/" }

--- a/ghostscope-compiler/src/script/parser.rs
+++ b/ghostscope-compiler/src/script/parser.rs
@@ -136,7 +136,7 @@ fn detect_unknown_keyword(input: &str) -> Option<String> {
     // Valid statement starters that should not be flagged as unknown
     const SUPPORTED_HEADS: &[&str] = &["trace", "print", "if", "else", "let", "backtrace", "bt"];
     // Builtin call names allowed at expression head
-    const BUILTIN_CALLS: &[&str] = &["memcmp", "strncmp", "starts_with", "hex"];
+    const BUILTIN_CALLS: &[&str] = &["memcmp", "strncmp", "starts_with", "hex", "cast"];
 
     // Helper: simple Levenshtein distance (small strings, few keywords)
     fn levenshtein(a: &str, b: &str) -> usize {
@@ -826,6 +826,8 @@ fn parse_factor(pair: Pair<Rule>) -> Result<Expr> {
                 Rule::strncmp_call => parse_builtin_call(inner),
                 Rule::starts_with_call => parse_builtin_call(inner),
                 Rule::hex_call => parse_builtin_call(inner),
+                Rule::postfix_access => parse_postfix_access(inner),
+                Rule::cast_call => parse_cast_call(inner),
                 Rule::chain_access => parse_chain_access(inner),
                 Rule::pointer_deref => parse_pointer_deref(inner),
                 Rule::address_of => parse_address_of(inner),
@@ -1154,6 +1156,76 @@ fn parse_builtin_call(pair: Pair<Rule>) -> Result<Expr> {
     }
 }
 
+fn parse_cast_call(pair: Pair<Rule>) -> Result<Expr> {
+    let mut inner = pair.into_inner();
+    let expr_pair = inner.next().ok_or(ParseError::InvalidExpression)?;
+    let type_pair = inner.next().ok_or(ParseError::InvalidExpression)?;
+    let raw_type = type_pair.as_str();
+    let target_type = raw_type
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .ok_or_else(|| ParseError::SyntaxError("cast target type must be a string".to_string()))?
+        .to_string();
+
+    Ok(Expr::Cast {
+        expr: Box::new(parse_expr(expr_pair)?),
+        target_type,
+    })
+}
+
+fn parse_postfix_access(pair: Pair<Rule>) -> Result<Expr> {
+    let mut inner = pair.into_inner();
+    let base = inner.next().ok_or(ParseError::InvalidExpression)?;
+    let mut expr = match base.as_rule() {
+        Rule::postfix_base => {
+            let base_inner = base
+                .into_inner()
+                .next()
+                .ok_or(ParseError::InvalidExpression)?;
+            match base_inner.as_rule() {
+                Rule::cast_call => parse_cast_call(base_inner)?,
+                Rule::special_var => Expr::SpecialVar(base_inner.as_str().to_string()),
+                Rule::identifier => Expr::Variable(base_inner.as_str().to_string()),
+                Rule::expr => parse_expr(base_inner)?,
+                _ => return Err(ParseError::UnexpectedToken(base_inner.as_rule())),
+            }
+        }
+        _ => return Err(ParseError::UnexpectedToken(base.as_rule())),
+    };
+
+    for suffix in inner {
+        let suffix_inner = suffix
+            .into_inner()
+            .next()
+            .ok_or(ParseError::InvalidExpression)?;
+        match suffix_inner.as_rule() {
+            Rule::member_suffix => {
+                let field = suffix_inner
+                    .into_inner()
+                    .next()
+                    .ok_or(ParseError::InvalidExpression)?
+                    .as_str()
+                    .to_string();
+                expr = Expr::MemberAccess(Box::new(expr), field);
+            }
+            Rule::index_suffix => {
+                let index_pair = suffix_inner
+                    .into_inner()
+                    .next()
+                    .ok_or(ParseError::InvalidExpression)?;
+                let parsed_index = parse_expr(index_pair)?;
+                let parsed_index = integer_literal_value(&parsed_index)
+                    .map(Expr::Int)
+                    .unwrap_or(parsed_index);
+                expr = Expr::ArrayAccess(Box::new(expr), Box::new(parsed_index));
+            }
+            _ => return Err(ParseError::UnexpectedToken(suffix_inner.as_rule())),
+        }
+    }
+
+    Ok(expr)
+}
+
 fn parse_trace_pattern(pair: Pair<Rule>) -> Result<TracePattern> {
     let inner = pair
         .into_inner()
@@ -1451,7 +1523,10 @@ fn parse_pointer_deref(pair: Pair<Rule>) -> Result<Expr> {
     let target = inner.next().ok_or(ParseError::InvalidExpression)?;
     let parsed = match target.as_rule() {
         Rule::expr => parse_expr(target)?,
+        Rule::postfix_access => parse_postfix_access(target)?,
+        Rule::cast_call => parse_cast_call(target)?,
         Rule::complex_variable => parse_complex_variable(target)?,
+        Rule::special_var => Expr::SpecialVar(target.as_str().to_string()),
         Rule::identifier => Expr::Variable(target.as_str().to_string()),
         _ => return Err(ParseError::UnexpectedToken(target.as_rule())),
     };
@@ -1468,7 +1543,10 @@ fn parse_address_of(pair: Pair<Rule>) -> Result<Expr> {
     let target = inner.next().ok_or(ParseError::InvalidExpression)?;
     let parsed = match target.as_rule() {
         Rule::expr => parse_expr(target)?,
+        Rule::postfix_access => parse_postfix_access(target)?,
+        Rule::cast_call => parse_cast_call(target)?,
         Rule::complex_variable => parse_complex_variable(target)?,
+        Rule::special_var => Expr::SpecialVar(target.as_str().to_string()),
         Rule::identifier => Expr::Variable(target.as_str().to_string()),
         _ => return Err(ParseError::UnexpectedToken(target.as_rule())),
     };
@@ -1492,6 +1570,47 @@ trace foo {
 "#;
         let r = parse(script);
         assert!(r.is_ok(), "parse failed: {:?}", r.err());
+    }
+
+    #[test]
+    fn parse_cast_member_and_index_access() {
+        let script = r#"
+trace foo {
+    print cast($arg0, "struct request *").id;
+    print cast($arg1, "u32 *")[2];
+    print *cast($arg1, "u32 *");
+    print &cast($arg0, "struct request *").id;
+}
+"#;
+        let program = parse(script).expect("parse should succeed");
+        let Statement::TracePoint { body, .. } = &program.statements[0] else {
+            panic!("expected trace point");
+        };
+        assert!(matches!(
+            &body[0],
+            Statement::Print(PrintStatement::ComplexVariable(Expr::MemberAccess(obj, field)))
+                if field == "id" && matches!(obj.as_ref(), Expr::Cast { .. })
+        ));
+        assert!(matches!(
+            &body[1],
+            Statement::Print(PrintStatement::ComplexVariable(Expr::ArrayAccess(base, index)))
+                if matches!(base.as_ref(), Expr::Cast { .. })
+                    && matches!(index.as_ref(), Expr::Int(2))
+        ));
+        assert!(matches!(
+            &body[2],
+            Statement::Print(PrintStatement::ComplexVariable(Expr::PointerDeref(inner)))
+                if matches!(inner.as_ref(), Expr::Cast { .. })
+        ));
+        assert!(matches!(
+            &body[3],
+            Statement::Print(PrintStatement::ComplexVariable(Expr::AddressOf(inner)))
+                if matches!(
+                    inner.as_ref(),
+                    Expr::MemberAccess(obj, field)
+                        if field == "id" && matches!(obj.as_ref(), Expr::Cast { .. })
+                )
+        ));
     }
 
     #[test]

--- a/ghostscope-dwarf/src/analyzer/mod.rs
+++ b/ghostscope-dwarf/src/analyzer/mod.rs
@@ -22,6 +22,7 @@ mod type_lookup;
 
 pub use module_resolution::ModuleDefaultPolicy;
 pub use source_resolution::{SourceLineAddressSearch, SourceLineQuerySearch};
+pub use type_lookup::TypeLookupAmbiguity;
 
 #[cfg(test)]
 use crate::{

--- a/ghostscope-dwarf/src/analyzer/type_lookup.rs
+++ b/ghostscope-dwarf/src/analyzer/type_lookup.rs
@@ -1,8 +1,74 @@
 use super::DwarfAnalyzer;
 use crate::semantics::VariableReadPlan;
-use std::path::Path;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeLookupAmbiguity {
+    pub type_name: String,
+    pub module_paths: Vec<PathBuf>,
+}
+
+impl fmt::Display for TypeLookupAmbiguity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let modules = self
+            .module_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            f,
+            "type '{}' is ambiguous across loaded modules: {}",
+            self.type_name, modules
+        )
+    }
+}
+
+impl std::error::Error for TypeLookupAmbiguity {}
 
 impl DwarfAnalyzer {
+    pub fn resolve_builtin_type_spec(type_spec: &str) -> Option<crate::TypeInfo> {
+        resolve_type_spec_with(type_spec, |_| None)
+    }
+
+    pub fn resolve_type_spec_in_module<P: AsRef<Path>>(
+        &self,
+        module_path: P,
+        type_spec: &str,
+    ) -> Option<crate::TypeInfo> {
+        let module_path = module_path.as_ref().to_path_buf();
+        resolve_type_spec_with(type_spec, |name| {
+            self.resolve_named_type_in_module(&module_path, name)
+                .or_else(|| self.resolve_named_type(name))
+        })
+    }
+
+    pub fn try_resolve_type_spec_in_module<P: AsRef<Path>>(
+        &self,
+        module_path: P,
+        type_spec: &str,
+    ) -> std::result::Result<Option<crate::TypeInfo>, TypeLookupAmbiguity> {
+        let module_path = module_path.as_ref().to_path_buf();
+        try_resolve_type_spec_with(type_spec, |name| {
+            if let Some(ty) = self.resolve_named_type_in_module(&module_path, name) {
+                return Ok(Some(ty));
+            }
+            self.resolve_unique_named_type_outside_module(&module_path, name)
+        })
+    }
+
+    pub fn resolve_type_spec(&self, type_spec: &str) -> Option<crate::TypeInfo> {
+        resolve_type_spec_with(type_spec, |name| self.resolve_named_type(name))
+    }
+
+    pub fn try_resolve_type_spec(
+        &self,
+        type_spec: &str,
+    ) -> std::result::Result<Option<crate::TypeInfo>, TypeLookupAmbiguity> {
+        try_resolve_type_spec_with(type_spec, |name| self.resolve_unique_named_type(name))
+    }
+
     fn resolve_type_shallow_by_name_in_module_with_tags<P: AsRef<Path>>(
         &self,
         module_path: P,
@@ -23,6 +89,82 @@ impl DwarfAnalyzer {
         self.modules
             .values()
             .find_map(|module_data| module_data.resolve_type_shallow_by_name_with_tags(name, tags))
+    }
+
+    fn resolve_named_type_in_module(
+        &self,
+        module_path: &Path,
+        name: &str,
+    ) -> Option<crate::TypeInfo> {
+        let tags = [
+            gimli::constants::DW_TAG_structure_type,
+            gimli::constants::DW_TAG_class_type,
+            gimli::constants::DW_TAG_union_type,
+            gimli::constants::DW_TAG_enumeration_type,
+        ];
+        self.resolve_type_shallow_by_name_in_module_with_tags(module_path, name, &tags)
+    }
+
+    fn resolve_named_type(&self, name: &str) -> Option<crate::TypeInfo> {
+        let tags = [
+            gimli::constants::DW_TAG_structure_type,
+            gimli::constants::DW_TAG_class_type,
+            gimli::constants::DW_TAG_union_type,
+            gimli::constants::DW_TAG_enumeration_type,
+        ];
+        self.resolve_type_shallow_by_name_with_tags(name, &tags)
+    }
+
+    fn resolve_unique_named_type_outside_module(
+        &self,
+        module_path: &Path,
+        name: &str,
+    ) -> std::result::Result<Option<crate::TypeInfo>, TypeLookupAmbiguity> {
+        self.resolve_unique_named_type_with_filter(name, |candidate| candidate != module_path)
+    }
+
+    fn resolve_unique_named_type(
+        &self,
+        name: &str,
+    ) -> std::result::Result<Option<crate::TypeInfo>, TypeLookupAmbiguity> {
+        self.resolve_unique_named_type_with_filter(name, |_| true)
+    }
+
+    fn resolve_unique_named_type_with_filter(
+        &self,
+        name: &str,
+        include_module: impl Fn(&Path) -> bool,
+    ) -> std::result::Result<Option<crate::TypeInfo>, TypeLookupAmbiguity> {
+        let tags = [
+            gimli::constants::DW_TAG_structure_type,
+            gimli::constants::DW_TAG_class_type,
+            gimli::constants::DW_TAG_union_type,
+            gimli::constants::DW_TAG_enumeration_type,
+        ];
+        let mut matches = self
+            .modules
+            .iter()
+            .filter(|(path, _)| include_module(path.as_path()))
+            .filter_map(|(path, module_data)| {
+                module_data
+                    .resolve_type_shallow_by_name_with_tags(name, &tags)
+                    .map(|ty| (path.clone(), ty))
+            })
+            .collect::<Vec<_>>();
+
+        if matches.len() > 1 {
+            let mut module_paths = matches
+                .iter()
+                .map(|(path, _)| path.clone())
+                .collect::<Vec<_>>();
+            module_paths.sort();
+            return Err(TypeLookupAmbiguity {
+                type_name: name.to_string(),
+                module_paths,
+            });
+        }
+
+        Ok(matches.pop().map(|(_, ty)| ty))
     }
 
     pub(super) fn complete_unknown_pointer_target_type(
@@ -187,5 +329,231 @@ impl DwarfAnalyzer {
             name,
             &[gimli::constants::DW_TAG_enumeration_type],
         )
+    }
+}
+
+fn resolve_type_spec_with<F>(type_spec: &str, mut resolve_named: F) -> Option<crate::TypeInfo>
+where
+    F: FnMut(&str) -> Option<crate::TypeInfo>,
+{
+    try_resolve_type_spec_with(type_spec, |name| {
+        Ok::<_, std::convert::Infallible>(resolve_named(name))
+    })
+    .ok()
+    .flatten()
+}
+
+fn try_resolve_type_spec_with<F, E>(
+    type_spec: &str,
+    mut resolve_named: F,
+) -> std::result::Result<Option<crate::TypeInfo>, E>
+where
+    F: FnMut(&str) -> std::result::Result<Option<crate::TypeInfo>, E>,
+{
+    // TODO: This parser intentionally accepts only C/C++-style type specs for now.
+    // Add an explicit TypeSpec/parser layer before extending this to Rust or other languages.
+    let mut spec = type_spec.trim();
+    if spec.is_empty() {
+        return Ok(None);
+    }
+
+    let mut arrays = Vec::new();
+    while let Some((base, count)) = take_array_suffix(spec) {
+        arrays.push(count);
+        spec = base.trim_end();
+    }
+
+    let mut pointer_count = 0usize;
+    while let Some(base) = spec.strip_suffix('*') {
+        pointer_count += 1;
+        spec = base.trim_end();
+    }
+
+    let (qualifiers, base_spec) = strip_leading_qualifiers(spec);
+    let Some(mut ty) = try_resolve_base_type_spec(base_spec, &mut resolve_named)? else {
+        return Ok(None);
+    };
+
+    for qualifier in qualifiers.into_iter().rev() {
+        ty = crate::TypeInfo::QualifiedType {
+            qualifier,
+            underlying_type: Box::new(ty),
+        };
+    }
+
+    for _ in 0..pointer_count {
+        ty = crate::TypeInfo::PointerType {
+            target_type: Box::new(ty),
+            size: 8,
+        };
+    }
+
+    for count in arrays.into_iter().rev() {
+        let element_size = ty.size();
+        let total_size = count.and_then(|count| element_size.checked_mul(count));
+        ty = crate::TypeInfo::ArrayType {
+            element_type: Box::new(ty),
+            element_count: count,
+            total_size,
+        };
+    }
+
+    Ok(Some(ty))
+}
+
+fn take_array_suffix(spec: &str) -> Option<(&str, Option<u64>)> {
+    let spec = spec.trim_end();
+    if !spec.ends_with(']') {
+        return None;
+    }
+    let open = spec.rfind('[')?;
+    let inside = spec[open + 1..spec.len() - 1].trim();
+    let count = if inside.is_empty() {
+        None
+    } else {
+        Some(inside.parse::<u64>().ok()?)
+    };
+    Some((&spec[..open], count))
+}
+
+fn strip_leading_qualifiers(mut spec: &str) -> (Vec<crate::TypeQualifier>, &str) {
+    let mut qualifiers = Vec::new();
+    loop {
+        let trimmed = spec.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("const ") {
+            qualifiers.push(crate::TypeQualifier::Const);
+            spec = rest;
+        } else if let Some(rest) = trimmed.strip_prefix("volatile ") {
+            qualifiers.push(crate::TypeQualifier::Volatile);
+            spec = rest;
+        } else if let Some(rest) = trimmed.strip_prefix("restrict ") {
+            qualifiers.push(crate::TypeQualifier::Restrict);
+            spec = rest;
+        } else {
+            return (qualifiers, trimmed);
+        }
+    }
+}
+
+fn try_resolve_base_type_spec<F, E>(
+    spec: &str,
+    resolve_named: &mut F,
+) -> std::result::Result<Option<crate::TypeInfo>, E>
+where
+    F: FnMut(&str) -> std::result::Result<Option<crate::TypeInfo>, E>,
+{
+    let spec = spec.trim();
+    if let Some(ty) = builtin_type_spec(spec) {
+        return Ok(Some(ty));
+    }
+
+    for prefix in ["struct ", "class ", "union ", "enum "] {
+        if let Some(name) = spec.strip_prefix(prefix) {
+            return resolve_named(name.trim());
+        }
+    }
+
+    resolve_named(spec)
+}
+
+fn builtin_type_spec(spec: &str) -> Option<crate::TypeInfo> {
+    let normalized = spec
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    let (name, size, encoding) = match normalized.as_str() {
+        "void" => {
+            return Some(crate::TypeInfo::UnknownType {
+                name: "void".to_string(),
+            })
+        }
+        "bool" | "_bool" => ("bool", 1, gimli::constants::DW_ATE_boolean.0 as u16),
+        "char" | "signed char" | "i8" | "int8_t" | "__s8" => {
+            ("i8", 1, gimli::constants::DW_ATE_signed_char.0 as u16)
+        }
+        "unsigned char" | "u8" | "uint8_t" | "__u8" | "byte" => {
+            ("u8", 1, gimli::constants::DW_ATE_unsigned_char.0 as u16)
+        }
+        "short" | "short int" | "signed short" | "signed short int" | "i16" | "int16_t"
+        | "__s16" => ("i16", 2, gimli::constants::DW_ATE_signed.0 as u16),
+        "unsigned short" | "unsigned short int" | "u16" | "uint16_t" | "__u16" => {
+            ("u16", 2, gimli::constants::DW_ATE_unsigned.0 as u16)
+        }
+        "int" | "signed" | "signed int" | "i32" | "int32_t" | "__s32" => {
+            ("i32", 4, gimli::constants::DW_ATE_signed.0 as u16)
+        }
+        "unsigned" | "unsigned int" | "u32" | "uint32_t" | "__u32" => {
+            ("u32", 4, gimli::constants::DW_ATE_unsigned.0 as u16)
+        }
+        "long"
+        | "long int"
+        | "signed long"
+        | "signed long int"
+        | "long long"
+        | "long long int"
+        | "signed long long"
+        | "signed long long int"
+        | "i64"
+        | "int64_t"
+        | "__s64"
+        | "ssize_t" => ("i64", 8, gimli::constants::DW_ATE_signed.0 as u16),
+        "unsigned long"
+        | "unsigned long int"
+        | "unsigned long long"
+        | "unsigned long long int"
+        | "u64"
+        | "uint64_t"
+        | "__u64"
+        | "size_t" => ("u64", 8, gimli::constants::DW_ATE_unsigned.0 as u16),
+        "float" | "f32" => ("f32", 4, gimli::constants::DW_ATE_float.0 as u16),
+        "double" | "f64" => ("f64", 8, gimli::constants::DW_ATE_float.0 as u16),
+        "long double" => ("long double", 16, gimli::constants::DW_ATE_float.0 as u16),
+        _ => return None,
+    };
+
+    Some(crate::TypeInfo::BaseType {
+        name: name.to_string(),
+        size,
+        encoding,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_builtin_pointer_and_array_specs() {
+        let ty = DwarfAnalyzer::resolve_builtin_type_spec("const unsigned int *[4]")
+            .expect("type should resolve");
+        let crate::TypeInfo::ArrayType {
+            element_type,
+            element_count,
+            total_size,
+        } = ty
+        else {
+            panic!("expected array type");
+        };
+        assert_eq!(element_count, Some(4));
+        assert_eq!(total_size, Some(32));
+        let crate::TypeInfo::PointerType { target_type, size } = *element_type else {
+            panic!("expected pointer element");
+        };
+        assert_eq!(size, 8);
+        assert!(matches!(
+            *target_type,
+            crate::TypeInfo::QualifiedType {
+                qualifier: crate::TypeQualifier::Const,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resolves_builtin_c_integer_aliases() {
+        let ty = DwarfAnalyzer::resolve_builtin_type_spec("uint64_t").expect("type should resolve");
+        assert_eq!(ty.size(), 8);
+        assert!(ty.is_unsigned_int());
     }
 }

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -24,6 +24,7 @@ pub use analyzer::{
     AddressQueryResult, AnalyzerStats, DwarfAnalyzer, ExecutableFileInfo, FunctionQueryResult,
     MainExecutableInfo, ModuleDefaultPolicy, ModuleLoadingEvent, ModuleLoadingStats, ModuleStats,
     SectionInfo, SharedLibraryInfo, SimpleFileInfo, SourceLineAddressSearch, SourceLineQuerySearch,
+    TypeLookupAmbiguity,
 };
 
 // Re-export essential core and semantic support types.


### PR DESCRIPTION
Add script-level cast(expr, "TYPE") support backed by module-scoped DWARF type lookup, lower pointer, aggregate, array, and scalar casts through eBPF codegen, document the type-name and memory-read semantics, and cover duplicate module type names plus nested cast behavior in the cast e2e fixture.