### PR TITLE
fix: distinguish missing backtrace unwind rows

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -726,7 +726,7 @@ backtrace: truncated, 2 frames (max 2)
   #1 0x1234 [sample_program+0x1234] raw=0x55... cookie=0x...
 ```
 
-`status=complete` means DWARF unwinding reached a natural stop before the configured depth cap. `status=truncated` means GhostScope hit the configured depth cap or the eBPF tail-call unwind budget before a natural stop. Other statuses explain where unwinding stopped, for example unsupported CFI, unavailable module offsets, a failed user-memory read, or an invalid next frame. When available, `stopped:` includes a stable reason label and numeric code.
+`status=complete` means DWARF unwinding reached a natural stop before the configured depth cap. `status=truncated` means GhostScope hit the configured depth cap or the eBPF tail-call unwind budget before a natural stop. Other statuses explain where unwinding stopped, for example no unwind rows for the current PC, unsupported CFI, unavailable module offsets, a failed user-memory read, or an invalid next frame. When available, `stopped:` includes a stable reason label and numeric code.
 
 ## Examples
 

--- a/docs/zh/scripting.md
+++ b/docs/zh/scripting.md
@@ -755,7 +755,7 @@ backtrace: truncated, 2 frames (max 2)
   #1 0x1234 [sample_program+0x1234] raw=0x55... cookie=0x...
 ```
 
-`status=complete` 表示 DWARF unwind 在达到配置的深度上限前自然结束。`status=truncated` 表示 GhostScope 达到了配置的深度上限，或先达到了 eBPF tail-call unwind 预算。其他状态会说明 unwind 停止的原因，例如 CFI 不支持、模块偏移不可用、读取用户栈内存失败，或下一帧地址/CFA 不合法。可用时，`stopped:` 会附带稳定的原因标签和数字 code。
+`status=complete` 表示 DWARF unwind 在达到配置的深度上限前自然结束。`status=truncated` 表示 GhostScope 达到了配置的深度上限，或先达到了 eBPF tail-call unwind 预算。其他状态会说明 unwind 停止的原因，例如当前 PC 没有可用的 unwind row、CFI 不支持、模块偏移不可用、读取用户栈内存失败，或下一帧地址/CFA 不合法。可用时，`stopped:` 会附带稳定的原因标签和数字 code。
 
 ## 示例
 

--- a/e2e-tests/tests/backtrace_execution.rs
+++ b/e2e-tests/tests/backtrace_execution.rs
@@ -420,7 +420,8 @@ trace dummy_touch {
     assert!(
         !block.contains("stopped: invalid frame")
             && !block.contains("stopped: read error")
-            && !block.contains("stopped: unsupported CFI"),
+            && !block.contains("stopped: unsupported CFI")
+            && !block.contains("stopped: no unwind rows for PC"),
         "full user stack should not stop on an unwind error\nBLOCK:\n{block}\nSTDERR:\n{stderr}"
     );
     assert_no_adjacent_duplicate_frame_locations(block)?;
@@ -606,7 +607,8 @@ trace dummy_touch {
         assert!(
             !block.contains("stopped: invalid frame")
                 && !block.contains("stopped: read error")
-                && !block.contains("stopped: unsupported CFI"),
+                && !block.contains("stopped: unsupported CFI")
+                && !block.contains("stopped: no unwind rows for PC"),
             "deep multi-bt stack should not stop on an unwind error\nBLOCK:\n{block}\nSTDERR:\n{stderr}"
         );
     }
@@ -662,7 +664,8 @@ trace dummy_touch {
         assert!(
             !event.contains("stopped: invalid frame")
                 && !event.contains("stopped: read error")
-                && !event.contains("stopped: unsupported CFI"),
+                && !event.contains("stopped: unsupported CFI")
+                && !event.contains("stopped: no unwind rows for PC"),
             "conditional bt should not consume stale slot state\nEVENT:\n{event}"
         );
     }
@@ -805,7 +808,8 @@ trace dummy_touch {
         "non-PIE PID-mode CFI rows should match raw ET_EXEC PCs and unwind callers\nBLOCK:\n{block}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
     );
     assert!(
-        !block.contains("stopped: unsupported CFI"),
+        !block.contains("stopped: unsupported CFI")
+            && !block.contains("stopped: no unwind rows for PC"),
         "non-PIE PID-mode rows should not be shifted by mapping base\nBLOCK:\n{block}\nSTDERR:\n{stderr}"
     );
 
@@ -861,7 +865,8 @@ trace cross_module_lib_leaf {
     assert!(
         !block.contains("stopped: invalid frame")
             && !block.contains("stopped: read error")
-            && !block.contains("stopped: unsupported CFI"),
+            && !block.contains("stopped: unsupported CFI")
+            && !block.contains("stopped: no unwind rows for PC"),
         "cross-module stack should not stop on an unwind error\nBLOCK:\n{block}\nSTDERR:\n{stderr}"
     );
     assert_no_adjacent_duplicate_frame_locations(block)?;
@@ -1033,7 +1038,8 @@ trace hot_bt_probe {
     assert!(
         !stdout.contains("stopped: invalid frame")
             && !stdout.contains("stopped: read error")
-            && !stdout.contains("stopped: unsupported CFI"),
+            && !stdout.contains("stopped: unsupported CFI")
+            && !stdout.contains("stopped: no unwind rows for PC"),
         "depth=128 full backtrace should not stop on an unwind error\nSTDOUT: {stdout}\nSTDERR: {stderr}"
     );
 
@@ -1064,7 +1070,8 @@ trace hot_bt_probe {
     assert!(
         !stdout.contains("stopped: invalid frame")
             && !stdout.contains("stopped: read error")
-            && !stdout.contains("stopped: unsupported CFI"),
+            && !stdout.contains("stopped: unsupported CFI")
+            && !stdout.contains("stopped: no unwind rows for PC"),
         "deep full backtrace should not regress into unwind errors under event load\nSTDOUT: {stdout}\nSTDERR: {stderr}"
     );
     assert!(

--- a/ghostscope-compiler/src/ebpf/codegen/backtrace.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/backtrace.rs
@@ -68,6 +68,12 @@ struct BtFrameValidation<'ctx> {
     error_code: IntValue<'ctx>,
 }
 
+enum BacktraceUnwindRowForPc {
+    Usable(ghostscope_protocol::BacktraceUnwindRow),
+    Missing,
+    Unsupported,
+}
+
 impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     pub(crate) fn prepare_backtrace_unwind_rows(&mut self, statements: &[Statement]) {
         self.backtrace_unwind_rows.clear();
@@ -287,15 +293,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
 
         let row = self
-            .compact_unwind_row_for_backtrace(&compile_ctx.module_path, compile_ctx.pc_address)
-            .and_then(|row| backtrace_unwind_row_from_compact(&row));
-        let initial_status = if row.is_some() {
-            BacktraceStatus::ReadError
-        } else if self.process_analyzer.is_some() {
-            BacktraceStatus::UnsupportedCfi
-        } else {
-            BacktraceStatus::DwarfUnavailable
-        };
+            .usable_backtrace_unwind_row_for_pc(&compile_ctx.module_path, compile_ctx.pc_address);
+        let initial_status = self.status_for_backtrace_unwind_row_for_pc(&row);
         let status = self.status_or_offsets_unavailable(initial_status, offsets_found)?;
         self.store_u8_value(
             inst_buffer,
@@ -304,7 +303,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             "bt_initial_status",
         )?;
 
-        let Some(row) = row else {
+        let BacktraceUnwindRowForPc::Usable(row) = row else {
             return Ok(());
         };
 
@@ -404,8 +403,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 .build_unconditional_branch(done)
                 .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
         } else if self.backtrace_unwind_rows.is_empty() {
-            let status =
-                self.status_or_offsets_unavailable(BacktraceStatus::UnsupportedCfi, offsets_found)?;
+            let status = self
+                .status_or_offsets_unavailable(BacktraceStatus::NoUnwindRowsForPc, offsets_found)?;
             self.store_u8_value(
                 inst_buffer,
                 data_base + BACKTRACE_DATA_STATUS_OFFSET,
@@ -433,7 +432,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
                 self.builder.position_at_end(missing_block);
                 let status = self.status_or_offsets_unavailable(
-                    BacktraceStatus::UnsupportedCfi,
+                    BacktraceStatus::NoUnwindRowsForPc,
                     offsets_found,
                 )?;
                 self.store_u8_value(
@@ -646,8 +645,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         }
 
         if self.backtrace_unwind_rows.is_empty() {
-            let status =
-                self.status_or_offsets_unavailable(BacktraceStatus::UnsupportedCfi, offsets_found)?;
+            let status = self
+                .status_or_offsets_unavailable(BacktraceStatus::NoUnwindRowsForPc, offsets_found)?;
             self.store_u8_value(
                 inst_buffer,
                 data_base + BACKTRACE_DATA_STATUS_OFFSET,
@@ -657,19 +656,21 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             return Ok(());
         }
 
-        let row = self
-            .compact_unwind_row_for_backtrace(&compile_ctx.module_path, compile_ctx.pc_address)
-            .and_then(|row| backtrace_unwind_row_from_compact(&row));
-        let Some(row) = row else {
-            let status =
-                self.status_or_offsets_unavailable(BacktraceStatus::UnsupportedCfi, offsets_found)?;
-            self.store_u8_value(
-                inst_buffer,
-                data_base + BACKTRACE_DATA_STATUS_OFFSET,
-                status,
-                "bt_status_no_initial_row",
-            )?;
-            return Ok(());
+        let row = match self
+            .usable_backtrace_unwind_row_for_pc(&compile_ctx.module_path, compile_ctx.pc_address)
+        {
+            BacktraceUnwindRowForPc::Usable(row) => row,
+            row_status => {
+                let initial_status = self.status_for_backtrace_unwind_row_for_pc(&row_status);
+                let status = self.status_or_offsets_unavailable(initial_status, offsets_found)?;
+                self.store_u8_value(
+                    inst_buffer,
+                    data_base + BACKTRACE_DATA_STATUS_OFFSET,
+                    status,
+                    "bt_status_no_initial_row",
+                )?;
+                return Ok(());
+            }
         };
 
         let status =
@@ -788,8 +789,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
 
             self.builder.position_at_end(missing_block);
-            let status =
-                self.status_or_offsets_unavailable(BacktraceStatus::UnsupportedCfi, offsets_found)?;
+            let status = self
+                .status_or_offsets_unavailable(BacktraceStatus::NoUnwindRowsForPc, offsets_found)?;
             self.store_u8_value(
                 inst_buffer,
                 data_base + BACKTRACE_DATA_STATUS_OFFSET,
@@ -1563,7 +1564,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         self.builder.position_at_end(row_missing_block);
         self.store_tail_backtrace_status(
             inst_buffer,
-            BacktraceStatus::UnsupportedCfi,
+            BacktraceStatus::NoUnwindRowsForPc,
             BACKTRACE_ERROR_NONE,
         )?;
         self.builder
@@ -1759,6 +1760,38 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let module_address = ModuleAddress::new(PathBuf::from(module_path), pc);
         let ctx = analyzer.resolve_pc(&module_address).ok()?;
         analyzer.compact_unwind_row_for_context(&ctx).ok().flatten()
+    }
+
+    fn usable_backtrace_unwind_row_for_pc(
+        &self,
+        module_path: &str,
+        pc: u64,
+    ) -> BacktraceUnwindRowForPc {
+        let Some(row) = self.compact_unwind_row_for_backtrace(module_path, pc) else {
+            return BacktraceUnwindRowForPc::Missing;
+        };
+        match backtrace_unwind_row_from_compact(&row) {
+            Some(row) => BacktraceUnwindRowForPc::Usable(row),
+            None => BacktraceUnwindRowForPc::Unsupported,
+        }
+    }
+
+    fn status_for_backtrace_unwind_row_for_pc(
+        &self,
+        row: &BacktraceUnwindRowForPc,
+    ) -> BacktraceStatus {
+        match row {
+            BacktraceUnwindRowForPc::Usable(_) => BacktraceStatus::ReadError,
+            BacktraceUnwindRowForPc::Missing if self.process_analyzer.is_some() => {
+                BacktraceStatus::NoUnwindRowsForPc
+            }
+            BacktraceUnwindRowForPc::Unsupported if self.process_analyzer.is_some() => {
+                BacktraceStatus::UnsupportedCfi
+            }
+            BacktraceUnwindRowForPc::Missing | BacktraceUnwindRowForPc::Unsupported => {
+                BacktraceStatus::DwarfUnavailable
+            }
+        }
     }
 
     fn runtime_row_from_static(

--- a/ghostscope-protocol/src/trace_event.rs
+++ b/ghostscope-protocol/src/trace_event.rs
@@ -225,6 +225,7 @@ pub enum BacktraceStatus {
     ReadError = 5,
     InternalError = 6,
     InvalidFrame = 7,
+    NoUnwindRowsForPc = 8,
 }
 
 impl BacktraceStatus {
@@ -238,6 +239,7 @@ impl BacktraceStatus {
             5 => Self::ReadError,
             6 => Self::InternalError,
             7 => Self::InvalidFrame,
+            8 => Self::NoUnwindRowsForPc,
             _ => Self::InternalError,
         }
     }
@@ -252,6 +254,7 @@ impl BacktraceStatus {
             Self::ReadError => "read error",
             Self::InternalError => "internal error",
             Self::InvalidFrame => "invalid frame",
+            Self::NoUnwindRowsForPc => "no unwind rows for PC",
         }
     }
 }
@@ -377,6 +380,24 @@ mod tests {
             execution_status: 0,
         };
         assert_eq!(inst.instruction_type(), InstructionType::EndInstruction);
+    }
+
+    #[test]
+    fn backtrace_status_wire_values_and_labels_are_stable() {
+        assert_eq!(BacktraceStatus::UnsupportedCfi as u8, 3);
+        assert_eq!(BacktraceStatus::NoUnwindRowsForPc as u8, 8);
+        assert_eq!(
+            BacktraceStatus::from_u8(8),
+            BacktraceStatus::NoUnwindRowsForPc
+        );
+        assert_eq!(
+            BacktraceStatus::NoUnwindRowsForPc.label(),
+            "no unwind rows for PC"
+        );
+        assert_eq!(
+            BacktraceStatus::from_u8(255),
+            BacktraceStatus::InternalError
+        );
     }
 
     #[test]

--- a/ghostscope-ui/src/components/ebpf_panel/renderer.rs
+++ b/ghostscope-ui/src/components/ebpf_panel/renderer.rs
@@ -772,6 +772,7 @@ impl EbpfPanelRenderer {
             BacktraceStatus::Truncated
             | BacktraceStatus::DwarfUnavailable
             | BacktraceStatus::UnsupportedCfi
+            | BacktraceStatus::NoUnwindRowsForPc
             | BacktraceStatus::OffsetsUnavailable => Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),

--- a/ghostscope/src/trace/backtrace.rs
+++ b/ghostscope/src/trace/backtrace.rs
@@ -332,7 +332,10 @@ impl BacktraceRenderer {
         coordinator: &ProcessManager,
         pids: &[u32],
     ) -> BacktraceStatus {
-        if status != BacktraceStatus::UnsupportedCfi {
+        if !matches!(
+            status,
+            BacktraceStatus::UnsupportedCfi | BacktraceStatus::NoUnwindRowsForPc
+        ) {
             return status;
         }
 
@@ -800,6 +803,14 @@ mod tests {
             .iter()
             .any(|line| line.contains("stopped: unsupported CFI")));
         assert_eq!(output.last().map(String::as_str), Some("after"));
+    }
+
+    #[test]
+    fn formats_no_unwind_rows_for_pc_status() {
+        assert_eq!(
+            format_backtrace_header(BacktraceStatus::NoUnwindRowsForPc, 1, 3),
+            "backtrace: no unwind rows for PC, 1 frame (max 3)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a backtrace status for PCs that are not covered by any prepared unwind row, so runtime table misses no longer look like unsupported CFI.

Keep the existing UnsupportedCfi value for rows whose CFI rules cannot be lowered to the compact eBPF unwinder.