### PR TITLE
fix: treat unusable debuglink files as missing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -658,8 +658,10 @@ function/variable/type counts. The TUI loading screen shows the same source
 categories in its progress and completion views.
 
 `missing` means the module was mapped and loaded, but GhostScope did not find
-usable DWARF for that module. Use `--log --log-level debug --log-file <path>`
-or `RUST_LOG=debug` for the full paths and lower-level resolution details.
+usable DWARF for that module. This includes `.gnu_debuglink` files that match
+the binary but contain no `.debug_info`. Use
+`--log --log-level debug --log-file <path>` or `RUST_LOG=debug` for the full
+paths and lower-level resolution details.
 
 ### Debug Output Defaults
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -161,6 +161,11 @@ When `--debug-file`/`-d` is used, GhostScope validates available CRC and
 Build-ID metadata before loading the file. Mismatches are rejected unless
 `--allow-loose-debug-match` is explicitly set.
 
+Automatic `.gnu_debuglink` discovery is reported as `debuglink` only when the
+separate file contains usable `.debug_info`. A file that passes CRC or Build-ID
+checks but contains no DWARF is ignored, debuginfod fallback is tried when
+enabled, and the module is otherwise reported as `missing`.
+
 **Debug file search paths (following GDB conventions):**
 
 GhostScope automatically searches for debug files in the following locations:

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -648,6 +648,7 @@ export LLVM_SYS_170_PREFIX=/usr/lib/llvm-17
 类型数量。TUI 加载界面的进度和完成视图也会展示相同的来源分类。
 
 `missing` 表示该模块已被映射并加载，但 GhostScope 没有找到可用的 DWARF。
+这也包括 `.gnu_debuglink` 文件与二进制匹配、但不包含 `.debug_info` 的情况。
 如果需要查看完整路径和更细的解析步骤，使用
 `--log --log-level debug --log-file <path>` 或 `RUST_LOG=debug` 查看日志。
 

--- a/docs/zh/install.md
+++ b/docs/zh/install.md
@@ -160,6 +160,10 @@ sudo ghostscope -p $(pidof your_program) --debug-file /path/to/your_program.debu
 使用 `--debug-file`/`-d` 时，GhostScope 会在加载前校验可用的 CRC 和
 Build-ID 元数据。不匹配会被拒绝，除非显式设置 `--allow-loose-debug-match`。
 
+自动 `.gnu_debuglink` 发现只有在独立文件包含可用 `.debug_info` 时才会报告为
+`debuglink`。如果文件通过了 CRC 或 Build-ID 校验但不包含 DWARF，GhostScope
+会忽略它，启用 debuginfod 时会继续 fallback，否则该模块会报告为 `missing`。
+
 **调试文件搜索路径（遵循 GDB 约定）：**
 
 GhostScope 会自动在以下位置搜索调试文件：

--- a/e2e-tests/tests/common/sandbox.rs
+++ b/e2e-tests/tests/common/sandbox.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use super::termination::{terminate_pid_gracefully, GRACEFUL_TERMINATION_TIMEOUT};
+use super::termination::{
+    terminate_pid_with_escalation, FORCEFUL_TERMINATION_TIMEOUT, GRACEFUL_TERMINATION_TIMEOUT,
+};
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::ffi::OsString;
@@ -1431,22 +1433,31 @@ impl SandboxHandle {
 
     pub fn terminate_pid(&self, pid: u32) -> Result<()> {
         let label = self.label().to_owned();
-        terminate_pid_gracefully(
+        terminate_pid_with_escalation(
             pid,
             &label,
             GRACEFUL_TERMINATION_TIMEOUT,
-            |pid| match &*self.inner {
-                SandboxInner::Host => {
-                    terminate_pid_with_shell("host", pid, &format!("kill -TERM {pid}"))
-                }
-                SandboxInner::Docker(inner) => terminate_pid_with_shell(
-                    &inner.container_name,
-                    pid,
-                    &format!("docker exec {} kill -TERM {}", inner.container_name, pid),
-                ),
-            },
+            FORCEFUL_TERMINATION_TIMEOUT,
+            |pid| self.send_signal_to_pid(pid, "TERM"),
+            |pid| self.send_signal_to_pid(pid, "KILL"),
             |pid| self.pid_is_running(pid),
         )
+    }
+
+    fn send_signal_to_pid(&self, pid: u32, signal: &str) -> Result<()> {
+        match &*self.inner {
+            SandboxInner::Host => {
+                send_pid_signal_with_shell("host", pid, &format!("kill -{signal} {pid}"))
+            }
+            SandboxInner::Docker(inner) => send_pid_signal_with_shell(
+                &inner.container_name,
+                pid,
+                &format!(
+                    "docker exec {} kill -{} {}",
+                    inner.container_name, signal, pid
+                ),
+            ),
+        }
     }
 
     fn pid_is_running(&self, pid: u32) -> Result<bool> {
@@ -2104,11 +2115,11 @@ fn stage_host_binary_under_repo(host_bin: &Path, name: &str) -> Result<PathBuf> 
     Ok(staged)
 }
 
-fn terminate_pid_with_shell(label: &str, pid: u32, command: &str) -> Result<()> {
+fn send_pid_signal_with_shell(label: &str, pid: u32, command: &str) -> Result<()> {
     let _ = Command::new("bash")
         .args(["-lc", command])
         .status()
-        .with_context(|| format!("failed to terminate pid {pid} in {label}"))?;
+        .with_context(|| format!("failed to signal pid {pid} in {label}"))?;
     Ok(())
 }
 

--- a/e2e-tests/tests/common/termination.rs
+++ b/e2e-tests/tests/common/termination.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use std::time::{Duration, Instant};
 
 pub(crate) const GRACEFUL_TERMINATION_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const FORCEFUL_TERMINATION_TIMEOUT: Duration = Duration::from_secs(2);
 const TERMINATION_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[cfg(unix)]
@@ -26,15 +27,18 @@ pub(crate) fn send_sigterm(pid: u32, label: &str) -> anyhow::Result<()> {
     anyhow::bail!("SIGTERM helpers are only supported on Unix test platforms");
 }
 
-pub(crate) fn terminate_pid_gracefully<Send, Running>(
+pub(crate) fn terminate_pid_with_escalation<SendTerm, SendKill, Running>(
     pid: u32,
     label: &str,
-    wait_timeout: Duration,
-    mut send_term: Send,
+    graceful_timeout: Duration,
+    forceful_timeout: Duration,
+    mut send_term: SendTerm,
+    mut send_kill: SendKill,
     mut is_running: Running,
 ) -> anyhow::Result<()>
 where
-    Send: FnMut(u32) -> anyhow::Result<()>,
+    SendTerm: FnMut(u32) -> anyhow::Result<()>,
+    SendKill: FnMut(u32) -> anyhow::Result<()>,
     Running: FnMut(u32) -> anyhow::Result<bool>,
 {
     if !is_running(pid)? {
@@ -42,16 +46,34 @@ where
     }
 
     send_term(pid)?;
+    if wait_for_pid_exit(pid, graceful_timeout, &mut is_running)? {
+        return Ok(());
+    }
 
+    send_kill(pid)?;
+    if wait_for_pid_exit(pid, forceful_timeout, &mut is_running)? {
+        return Ok(());
+    }
+
+    anyhow::bail!("timed out waiting for {label} pid {pid} to exit after SIGTERM and SIGKILL");
+}
+
+fn wait_for_pid_exit<Running>(
+    pid: u32,
+    wait_timeout: Duration,
+    is_running: &mut Running,
+) -> anyhow::Result<bool>
+where
+    Running: FnMut(u32) -> anyhow::Result<bool>,
+{
     let deadline = Instant::now() + wait_timeout;
     while Instant::now() < deadline {
         if !is_running(pid)? {
-            return Ok(());
+            return Ok(true);
         }
         std::thread::sleep(TERMINATION_POLL_INTERVAL);
     }
-
-    anyhow::bail!("timed out waiting for {label} pid {pid} to exit after SIGTERM");
+    Ok(false)
 }
 
 pub(crate) fn terminate_std_child_gracefully(

--- a/e2e-tests/tests/fixtures/startup_load_report/Makefile
+++ b/e2e-tests/tests/fixtures/startup_load_report/Makefile
@@ -10,12 +10,14 @@ UNSTRIPPED ?= $(BINARY).unstripped
 EMBEDDED_BINARY ?= debug_source_report_embedded
 NO_DEBUGLINK_BINARY ?= debug_source_report_no_debuglink
 NO_DEBUGLINK_UNSTRIPPED ?= $(NO_DEBUGLINK_BINARY).unstripped
+NO_DWARF_DEBUGLINK_BINARY ?= debug_source_report_no_dwarf_debuglink
+NO_DWARF_DEBUG_FILE ?= debug_source_report_no_dwarf.debug
 MISSING_BINARY ?= debug_source_report_missing
 MISSING_UNSTRIPPED ?= $(MISSING_BINARY).unstripped
 BAD_DEBUG ?= bad.debug
 SCRIPT_FILE ?= trace.gs
 
-all: $(BINARY) $(EMBEDDED_BINARY) $(NO_DEBUGLINK_BINARY) $(MISSING_BINARY) $(BAD_DEBUG) $(SCRIPT_FILE)
+all: $(BINARY) $(EMBEDDED_BINARY) $(NO_DEBUGLINK_BINARY) $(NO_DWARF_DEBUGLINK_BINARY) $(MISSING_BINARY) $(BAD_DEBUG) $(SCRIPT_FILE)
 
 $(UNSTRIPPED): debug_source_report.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
@@ -38,6 +40,15 @@ $(NO_DEBUGLINK_BINARY): $(NO_DEBUGLINK_UNSTRIPPED)
 	cp $(NO_DEBUGLINK_UNSTRIPPED) $@
 	$(OBJCOPY) --strip-debug $@
 
+$(NO_DWARF_DEBUG_FILE): $(UNSTRIPPED)
+	cp $(UNSTRIPPED) $@
+	$(OBJCOPY) --strip-debug $@
+
+$(NO_DWARF_DEBUGLINK_BINARY): $(UNSTRIPPED) $(NO_DWARF_DEBUG_FILE)
+	cp $(UNSTRIPPED) $@
+	$(OBJCOPY) --strip-debug $@
+	$(OBJCOPY) --add-gnu-debuglink=$(notdir $(NO_DWARF_DEBUG_FILE)) $@
+
 $(MISSING_UNSTRIPPED): debug_source_report.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
@@ -52,6 +63,6 @@ $(SCRIPT_FILE):
 	printf '%s\n' 'trace debug_source_probe {' '    print "startup-load-report";' '}' > $@
 
 clean:
-	rm -f $(BINARY) $(DEBUG_FILE) $(UNSTRIPPED) $(EMBEDDED_BINARY) $(NO_DEBUGLINK_BINARY) $(NO_DEBUGLINK_UNSTRIPPED) $(MISSING_BINARY) $(MISSING_UNSTRIPPED) $(BAD_DEBUG) $(SCRIPT_FILE)
+	rm -f $(BINARY) $(DEBUG_FILE) $(UNSTRIPPED) $(EMBEDDED_BINARY) $(NO_DEBUGLINK_BINARY) $(NO_DEBUGLINK_UNSTRIPPED) $(NO_DWARF_DEBUGLINK_BINARY) $(NO_DWARF_DEBUG_FILE) $(MISSING_BINARY) $(MISSING_UNSTRIPPED) $(BAD_DEBUG) $(SCRIPT_FILE)
 
 .PHONY: all clean

--- a/e2e-tests/tests/script_execution.rs
+++ b/e2e-tests/tests/script_execution.rs
@@ -2732,6 +2732,7 @@ trace add_numbers {
 
     let (exit_code, stdout, stderr) = common::runner::GhostscopeRunner::new()
         .with_script(script_content)
+        .with_target(&binary_path)
         .attach_to(&target)
         .timeout_secs(3)
         .enable_sysmon_for_target(false)

--- a/e2e-tests/tests/startup_load_report_execution.rs
+++ b/e2e-tests/tests/startup_load_report_execution.rs
@@ -17,6 +17,7 @@ const FIXTURE_BINARY: &str = "debug_source_report";
 const FIXTURE_DEBUG_FILE: &str = "debug_source_report.debug";
 const EMBEDDED_BINARY: &str = "debug_source_report_embedded";
 const NO_DEBUGLINK_BINARY: &str = "debug_source_report_no_debuglink";
+const NO_DWARF_DEBUGLINK_BINARY: &str = "debug_source_report_no_dwarf_debuglink";
 const MISSING_BINARY: &str = "debug_source_report_missing";
 const BAD_DEBUG_FILE: &str = "bad.debug";
 const TEST_CONFIG: &str = r#"
@@ -134,6 +135,47 @@ async fn test_startup_report_shows_missing_source_without_module_details() -> Re
 
 #[tokio::test]
 #[serial_test::serial]
+async fn test_startup_report_treats_debuglink_without_dwarf_as_missing() -> Result<()> {
+    init();
+
+    if !is_host_topology() {
+        println!("skipping startup load report e2e outside host->host topology");
+        return Ok(());
+    }
+
+    let fixture = ensure_startup_report_fixture()?;
+    let run =
+        run_startup_report_command_for_binary(&fixture, &fixture.no_dwarf_debuglink_binary, &[])?;
+
+    assert!(
+        run.status.success(),
+        "no-DWARF debuglink startup report run failed with status {}\n{}",
+        run.status,
+        run.output
+    );
+    assert_output_contains(&run.output, "\x1b[32mDWARF ready:\x1b[0m");
+    assert_output_contains(&run.output, "Startup load report:");
+    assert_output_contains(&run.output, "\x1b[33mmissing:1\x1b[0m");
+    assert_output_contains(&run.output, "modules loaded: 1 completed, 0 failed");
+    assert_output_contains(&run.output, "\x1b[33mmissing DWARF:\x1b[0m");
+    assert_output_contains(&run.output, NO_DWARF_DEBUGLINK_BINARY);
+    assert!(
+        !run.output.contains("\x1b[34mdebuglink:1\x1b[0m"),
+        "debuglink file without .debug_info should not be reported as debuglink\n{}",
+        run.output
+    );
+    assert!(
+        !run.output.contains("module details:"),
+        "missing-DWARF modules should stay out of module details\n{}",
+        run.output
+    );
+    assert_output_contains(&run.output, "Dry run complete; no uprobes attached.");
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
 async fn test_startup_report_shows_explicit_debug_file_source() -> Result<()> {
     init();
 
@@ -212,6 +254,7 @@ struct StartupReportFixture {
     binary: PathBuf,
     embedded_binary: PathBuf,
     no_debuglink_binary: PathBuf,
+    no_dwarf_debuglink_binary: PathBuf,
     missing_binary: PathBuf,
     debug_file: PathBuf,
     bad_debug_file: PathBuf,
@@ -232,6 +275,7 @@ fn ensure_startup_report_fixture() -> Result<StartupReportFixture> {
                 binary: dir.join(FIXTURE_BINARY),
                 embedded_binary: dir.join(EMBEDDED_BINARY),
                 no_debuglink_binary: dir.join(NO_DEBUGLINK_BINARY),
+                no_dwarf_debuglink_binary: dir.join(NO_DWARF_DEBUGLINK_BINARY),
                 missing_binary: dir.join(MISSING_BINARY),
                 debug_file: dir.join(FIXTURE_DEBUG_FILE),
                 bad_debug_file: dir.join(BAD_DEBUG_FILE),

--- a/ghostscope-dwarf/src/loader.rs
+++ b/ghostscope-dwarf/src/loader.rs
@@ -6,8 +6,9 @@ use crate::{
     objfile::LoadedObjfile,
 };
 use ghostscope_debuginfod::DebuginfodClient;
+use std::ffi::OsStr;
 use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tokio::task;
 
@@ -16,6 +17,19 @@ use tokio::task;
 pub struct ExplicitDebugFile {
     pub target_module: PathBuf,
     pub debug_file: PathBuf,
+}
+
+impl ExplicitDebugFile {
+    pub fn new(target_module: PathBuf, debug_file: PathBuf) -> Self {
+        Self {
+            target_module,
+            debug_file,
+        }
+    }
+
+    fn matches_module(&self, module_path: &Path) -> bool {
+        paths_equivalent(module_path, &self.target_module)
+    }
 }
 
 /// Configuration for module loading (parallel only)
@@ -157,7 +171,8 @@ impl ModuleLoader {
                 let debuginfod_client = debuginfod_client.clone();
                 let explicit_debug_file_for_module =
                     explicit_debug_file.as_ref().and_then(|explicit| {
-                        paths_equivalent(&mapping.path, &explicit.target_module)
+                        explicit
+                            .matches_module(&mapping.path)
                             .then(|| explicit.debug_file.clone())
                     });
 
@@ -239,7 +254,7 @@ fn validate_explicit_debug_file_target(
 ) -> Result<()> {
     let matches: Vec<&ModuleMapping> = mappings
         .iter()
-        .filter(|mapping| paths_equivalent(&mapping.path, &explicit.target_module))
+        .filter(|mapping| explicit.matches_module(&mapping.path))
         .collect();
 
     match matches.len() {
@@ -280,6 +295,10 @@ fn paths_equivalent(left: &Path, right: &Path) -> bool {
         return true;
     }
 
+    if proc_root_paths_equivalent(left, right) {
+        return true;
+    }
+
     if let (Ok(left), Ok(right)) = (left.canonicalize(), right.canonicalize()) {
         if left == right {
             return true;
@@ -290,6 +309,47 @@ fn paths_equivalent(left: &Path, right: &Path) -> bool {
         (Ok(left), Ok(right)) => left.dev() == right.dev() && left.ino() == right.ino(),
         _ => false,
     }
+}
+
+fn proc_root_paths_equivalent(left: &Path, right: &Path) -> bool {
+    match (strip_proc_root_prefix(left), strip_proc_root_prefix(right)) {
+        (Some(left), Some(right)) => left == right,
+        (Some(left), None) => left.as_path() == right,
+        (None, Some(right)) => left == right.as_path(),
+        (None, None) => false,
+    }
+}
+
+fn strip_proc_root_prefix(path: &Path) -> Option<PathBuf> {
+    let mut components = path.components();
+    if !matches!(components.next(), Some(Component::RootDir)) {
+        return None;
+    }
+    if !matches!(
+        components.next(),
+        Some(Component::Normal(component)) if component == OsStr::new("proc")
+    ) {
+        return None;
+    }
+    if !matches!(
+        components.next(),
+        Some(Component::Normal(pid)) if pid.to_string_lossy().parse::<u32>().is_ok()
+    ) {
+        return None;
+    }
+    if !matches!(
+        components.next(),
+        Some(Component::Normal(component)) if component == OsStr::new("root")
+    ) {
+        return None;
+    }
+
+    let remaining = components.as_path();
+    let mut stripped = PathBuf::from("/");
+    if !remaining.as_os_str().is_empty() {
+        stripped.push(remaining);
+    }
+    Some(stripped)
 }
 
 /// ModuleLoader with attached progress callback (for method chaining)
@@ -308,5 +368,53 @@ where
     /// Load modules with attached progress callback
     pub async fn load(self) -> Result<Vec<LoadedObjfile>> {
         self.loader.load_with_progress(self.callback).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_debug_file_matches_proc_root_rewritten_target_path() {
+        let mapping = ModuleMapping::from_path(PathBuf::from("/proc/123/root/usr/bin/app"));
+        let explicit = ExplicitDebugFile::new(
+            PathBuf::from("/usr/bin/app"),
+            PathBuf::from("/tmp/app.debug"),
+        );
+
+        assert!(explicit.matches_module(&mapping.path));
+        assert!(validate_explicit_debug_file_target(&[mapping], &explicit).is_ok());
+    }
+
+    #[test]
+    fn explicit_debug_file_rejects_unmatched_proc_root_target_path() {
+        let mapping = ModuleMapping::from_path(PathBuf::from("/proc/123/root/usr/bin/other"));
+        let explicit = ExplicitDebugFile::new(
+            PathBuf::from("/usr/bin/app"),
+            PathBuf::from("/tmp/app.debug"),
+        );
+
+        let error = validate_explicit_debug_file_target(&[mapping], &explicit)
+            .expect_err("unmatched explicit debug file should be rejected")
+            .to_string();
+
+        assert!(error.contains("/usr/bin/app"));
+    }
+
+    #[test]
+    fn proc_root_paths_equivalent_normalizes_either_side() {
+        assert!(proc_root_paths_equivalent(
+            Path::new("/proc/123/root/usr/bin/app"),
+            Path::new("/usr/bin/app")
+        ));
+        assert!(proc_root_paths_equivalent(
+            Path::new("/usr/lib/libfoo.so"),
+            Path::new("/proc/456/root/usr/lib/libfoo.so")
+        ));
+        assert!(!proc_root_paths_equivalent(
+            Path::new("/proc/123/root/usr/bin/app"),
+            Path::new("/usr/bin/other")
+        ));
     }
 }

--- a/ghostscope-dwarf/src/objfile/loading.rs
+++ b/ghostscope-dwarf/src/objfile/loading.rs
@@ -111,40 +111,35 @@ impl LoadedObjfile {
                                 let debug_mapped = Arc::new(debug_mapped);
                                 let debug_path = debug_mapped.path.display().to_string();
                                 let debug_dwarf = Self::load_dwarf_sections(&debug_mapped)?;
-                                (
-                                    Arc::new(debug_dwarf),
-                                    debug_mapped,
-                                    DebugInfoSource::Debuglink { path: debug_path },
-                                )
+                                if Self::has_debug_info(&debug_dwarf) {
+                                    (
+                                        Arc::new(debug_dwarf),
+                                        debug_mapped,
+                                        DebugInfoSource::Debuglink { path: debug_path },
+                                    )
+                                } else {
+                                    tracing::warn!(
+                                        "Ignoring separate debug file {} for {} because it contains no .debug_info",
+                                        debug_mapped.path.display(),
+                                        module_mapping.path.display()
+                                    );
+                                    Self::load_debuginfod_debug_file_or_missing(
+                                        debuginfod_client.as_ref(),
+                                        &binary_mapped,
+                                        &module_mapping.path,
+                                        dwarf_data,
+                                    )
+                                    .await
+                                }
                             }
                             None => {
-                                match Self::try_load_debuginfod_debug_file(
+                                Self::load_debuginfod_debug_file_or_missing(
                                     debuginfod_client.as_ref(),
                                     &binary_mapped,
                                     &module_mapping.path,
+                                    dwarf_data,
                                 )
                                 .await
-                                {
-                                    Some((debug_dwarf, debug_mapped)) => {
-                                        let debug_path = debug_mapped.path.display().to_string();
-                                        (
-                                            Arc::new(debug_dwarf),
-                                            debug_mapped,
-                                            DebugInfoSource::Debuginfod { path: debug_path },
-                                        )
-                                    }
-                                    None => {
-                                        tracing::warn!(
-                                            "No separate debug file found for: {}",
-                                            module_mapping.path.display()
-                                        );
-                                        (
-                                            Arc::new(dwarf_data),
-                                            Arc::clone(&binary_mapped),
-                                            DebugInfoSource::Missing,
-                                        )
-                                    }
-                                }
                             }
                         }
                     }
@@ -305,6 +300,37 @@ impl LoadedObjfile {
 
     fn has_debug_info(dwarf: &DwarfData) -> bool {
         matches!(dwarf.units().next(), Ok(Some(_)))
+    }
+
+    async fn load_debuginfod_debug_file_or_missing(
+        debuginfod_client: Option<&Arc<DebuginfodClient>>,
+        binary_mapped: &Arc<MappedFile>,
+        module_path: &Path,
+        fallback_dwarf: DwarfData,
+    ) -> (Arc<DwarfData>, Arc<MappedFile>, DebugInfoSource) {
+        match Self::try_load_debuginfod_debug_file(debuginfod_client, binary_mapped, module_path)
+            .await
+        {
+            Some((debug_dwarf, debug_mapped)) => {
+                let debug_path = debug_mapped.path.display().to_string();
+                (
+                    Arc::new(debug_dwarf),
+                    debug_mapped,
+                    DebugInfoSource::Debuginfod { path: debug_path },
+                )
+            }
+            None => {
+                tracing::warn!(
+                    "No usable separate debug file found for: {}",
+                    module_path.display()
+                );
+                (
+                    Arc::new(fallback_dwarf),
+                    Arc::clone(binary_mapped),
+                    DebugInfoSource::Missing,
+                )
+            }
+        }
     }
 
     async fn try_load_debuginfod_debug_file(

--- a/ghostscope/src/core/session.rs
+++ b/ghostscope/src/core/session.rs
@@ -219,10 +219,7 @@ impl GhostSession {
                 .map(|pid| PathBuf::from(format!("/proc/{pid}/exe")))
         })?;
 
-        Some(ExplicitDebugFile {
-            target_module,
-            debug_file,
-        })
+        Some(ExplicitDebugFile::new(target_module, debug_file))
     }
 
     fn build_debuginfod_client(&self) -> Result<Option<Arc<DebuginfodClient>>> {


### PR DESCRIPTION
Match explicit debug-file targets across /proc/<pid>/root path rewrites so host-to-container PID sessions can use the requested debug file.

Ignore debuglink files that pass identity checks but contain no .debug_info, then continue debuginfod fallback or report the module as missing.

Add startup report coverage for no-DWARF debuglink files and exercise explicit debug-file loading with both -t and -p.