### PR TITLE
fix: package cli scripting docs

### DIFF
--- a/ghostscope/src/cli/docs.rs
+++ b/ghostscope/src/cli/docs.rs
@@ -1,5 +1,4 @@
-pub const SCRIPT_HELP: &str =
-    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../docs/scripting.md"));
+pub const SCRIPT_HELP: &str = include_str!("scripting.md");
 
 pub fn print_script_help() {
     print!("{SCRIPT_HELP}");

--- a/ghostscope/src/cli/scripting.md
+++ b/ghostscope/src/cli/scripting.md
@@ -1,0 +1,1 @@
+../../../docs/scripting.md


### PR DESCRIPTION
Embed the CLI scripting help through a package-local symlink so cargo publish includes the markdown while the repository keeps a single source document under docs/.