### PR TITLE
test: wait for PID module mapping in backtrace e2e

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -56,6 +56,16 @@ Compiler optimizations (-O2, -O3) can cause variables to be optimized away or ge
 ### 9. Dynamically Loaded Libraries (dlopen)
 GhostScope scans `/proc/PID/maps` at startup, and runtime map-change monitoring now refreshes module mappings for `-p <pid>` and standalone `-t <path>` runs while sysmon is enabled. For `bt`/`backtrace`, this can add compact DWARF CFI rows and module offsets for libraries loaded later through `dlopen`, subject to `backtrace_unwind_rows_max_entries` and the map-change race noted above.
 
+`-p <pid>` has one startup edge case: trace setup snapshots the PID's
+current `/proc/<pid>/maps` before resolving function-name targets. If
+GhostScope attaches immediately after launching a process and the dynamic
+loader has not mapped a shared library yet, a trace whose target function
+lives in that library can fail setup before runtime map-change monitoring has
+anything to refresh. This mainly affects launch-and-immediately-attach
+workflows; attaching to an already-running process, waiting until the library
+appears in `/proc/<pid>/maps`, or using `-t <path> -p <pid>` for a known
+library target avoids the race.
+
 This runtime refresh does not automatically create new trace probes or make print/global-variable targets available for a library that was unknown when the script was compiled and attached. Those targets still depend on the target module and debug information being available during trace setup.
 
 ### 10. Global Variables in `-t` Mode

--- a/docs/zh/limitations.md
+++ b/docs/zh/limitations.md
@@ -56,6 +56,14 @@ GhostScope 能识别 `DW_OP_form_tls_address`，但运行时 TLS 地址解析目
 ### 9. 动态加载库（dlopen）
 GhostScope 启动时会扫描进程的 `/proc/PID/maps` 获取已加载的动态库信息；现在在 `-p <pid>` 和启用 sysmon 的独立 `-t <path>` 下，也会通过运行时 map-change 监控刷新模块映射。对 `bt`/`backtrace` 来说，这可以为后续通过 `dlopen` 加载的库追加 compact DWARF CFI rows 和模块偏移，但仍受 `backtrace_unwind_rows_max_entries` 以及上文提到的 map-change 竞态限制。
 
+`-p <pid>` 有一个启动边界：trace setup 会先快照该 PID 当前的
+`/proc/<pid>/maps`，再解析函数名目标。如果 GhostScope 紧贴进程启动，而
+动态加载器还没有把某个共享库映射进来，脚本又要 trace 这个库里的函数，
+setup 可能在运行时 map-change 监控有机会刷新之前失败。这主要影响“启动后
+立刻 attach”的流程；attach 到已运行的进程、等目标库出现在
+`/proc/<pid>/maps` 后再启动 GhostScope，或对已知库目标使用
+`-t <path> -p <pid>`，都可以避开这个竞态。
+
 这条运行时刷新链路不会自动新增 trace probe，也不会让脚本编译/附加时尚未知的库立即支持 print 或全局变量目标。这些目标仍依赖 trace setup 阶段能够看到对应目标模块和调试信息。
 
 ### 10. -t 模式下的全局变量支持

--- a/e2e-tests/tests/backtrace_execution.rs
+++ b/e2e-tests/tests/backtrace_execution.rs
@@ -111,7 +111,31 @@ async fn run_backtrace_binary_with_args(
     extra_args: Vec<OsString>,
     config_content: Option<&str>,
 ) -> anyhow::Result<(usize, String, String)> {
+    run_backtrace_binary_with_args_and_mapped_module(
+        binary_path,
+        script,
+        output_events_per_sec,
+        timeout_secs,
+        extra_args,
+        config_content,
+        None,
+    )
+    .await
+}
+
+async fn run_backtrace_binary_with_args_and_mapped_module(
+    binary_path: &Path,
+    script: &str,
+    output_events_per_sec: u32,
+    timeout_secs: u64,
+    extra_args: Vec<OsString>,
+    config_content: Option<&str>,
+    required_mapped_module: Option<&str>,
+) -> anyhow::Result<(usize, String, String)> {
     let target = spawn_backtrace_fixture_program(binary_path).await?;
+    if let Some(module) = required_mapped_module {
+        wait_for_target_maps_to_contain(&target, module, Duration::from_secs(2)).await?;
+    }
     let rate_arg = output_events_per_sec.to_string();
 
     let mut cli_args = vec![
@@ -140,6 +164,40 @@ async fn run_backtrace_binary_with_args(
     anyhow::ensure!(exit_code == 0, "stderr={stderr} stdout={stdout}");
     let count = stdout.matches("backtrace: ").count();
     Ok((count, stdout, stderr))
+}
+
+async fn wait_for_target_maps_to_contain(
+    target: &TargetHandle,
+    module_name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let maps_path = format!("/proc/{}/maps", target.sandbox_pid());
+    let command = format!(
+        "grep -F -- {} {} >/dev/null",
+        shell_quote(module_name),
+        shell_quote(&maps_path)
+    );
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let output = target.sandbox().run_shell(&command)?;
+        if output.status.success() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let maps_output = target.sandbox().run_shell(&format!(
+                "cat {} 2>/dev/null || true",
+                shell_quote(&maps_path)
+            ))?;
+            anyhow::bail!(
+                "timed out waiting for target pid {} maps to include {}\nMAPS:\n{}",
+                target.sandbox_pid(),
+                module_name,
+                String::from_utf8_lossy(&maps_output.stdout)
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 async fn run_backtrace_target_mode_library_with_depth(
@@ -992,12 +1050,20 @@ trace cross_module_lib_leaf {
 }
 "#;
 
-    let (count, stdout, stderr) = run_backtrace_fixture_with_depth_and_rate(
-        "backtrace_cross_module_program",
+    let binary_path = FIXTURES.get_test_binary("backtrace_cross_module_program")?;
+    let depth_arg = OsString::from("5");
+    let (count, stdout, stderr) = run_backtrace_binary_with_args_and_mapped_module(
+        &binary_path,
         script,
-        5,
         250,
         3,
+        vec![OsString::from("--backtrace-depth"), depth_arg],
+        None,
+        // PID-mode function targets are resolved from the initial
+        // /proc/<pid>/maps snapshot. Runtime map-change refresh can improve
+        // later backtrace rendering, but it cannot add a probe whose shared
+        // object was not mapped before script compilation.
+        Some("libbacktrace_cross_module.so"),
     )
     .await?;
     if count == 0 && stderr.contains("BPF_PROG_LOAD") {


### PR DESCRIPTION
PID-mode function targets are resolved from the initial /proc/<pid>/maps snapshot before runtime map-change refresh can help. Wait for the affected cross-module e2e test to observe the shared object first, and document the launch-and-immediate-attach edge case.