### PR TITLE
feat: diagnose rejected Rust value adapters

### DIFF
--- a/bins/dwarf-tool/README.md
+++ b/bins/dwarf-tool/README.md
@@ -2,4 +2,14 @@
 
 `dwarf-tool` is a standalone binary that ships with GhostScope for inspecting DWARF information and validating the `ghostscope-dwarf` parser stack. It is useful when debugging symbol resolution without running the full tracing pipeline.
 
+Rust value-adapter diagnostics can be queried from a target binary without
+starting the traced process:
+
+```bash
+dwarf-tool -t ./target/debug/my-program rust-adapter MY_GLOBAL
+```
+
+Add `--json` to inspect the target producer, rustc and DWARF versions, adapter
+status, rejection stage and reason, and the selected capture plan.
+
 Usage examples and context can be found in the main documentation: <https://github.com/swananan/ghostscope#readme>.

--- a/bins/dwarf-tool/src/main.rs
+++ b/bins/dwarf-tool/src/main.rs
@@ -6,7 +6,8 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use ghostscope_dwarf::{
     AddressQueryResult, DwarfAnalyzer, FunctionQueryResult, ModuleLoadingEvent, ModuleLoadingStats,
-    SectionType,
+    SectionType, SourceLanguage, ValueAdapterOutcome, ValueAdapterReport, ValueAdapterStage,
+    ValueCapturePlan, ValuePresentation, VariableAccessPath,
 };
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -19,7 +20,7 @@ use tracing::warn;
 #[command(about = "DWARF debug information analysis tool with multiple analysis modes")]
 #[command(author = "swananan")]
 #[command(
-    after_help = "SUBCOMMANDS:\n  source-line (s)            Analyze variables at specific source file:line location\n  function (f)               Find function addresses and analyze variables at those addresses\n  module-addr (m)            Analyze variables at specific module:address location\n  modules (ls)               List all loaded modules\n  source-files (sf)          List source files grouped by module\n  benchmark                  Performance benchmarking\n  benchmark-source-line      Benchmark a source-line query with a warm analyzer"
+    after_help = "SUBCOMMANDS:\n  source-line (s)            Analyze variables at specific source file:line location\n  function (f)               Find function addresses and analyze variables at those addresses\n  module-addr (m)            Analyze variables at specific module:address location\n  rust-adapter (ra)          Explain Rust value adaptation for a global variable\n  modules (ls)               List all loaded modules\n  source-files (sf)          List source files grouped by module\n  benchmark                  Performance benchmarking\n  benchmark-source-line      Benchmark a source-line query with a warm analyzer"
 )]
 struct Cli {
     /// Process ID to analyze
@@ -112,6 +113,18 @@ enum Commands {
         /// Quiet output
         #[arg(short, long)]
         quiet: bool,
+        /// JSON output
+        #[arg(long)]
+        json: bool,
+    },
+    /// Explain Rust value adapter selection for a global/static variable
+    #[command(name = "rust-adapter", alias = "ra")]
+    RustAdapter {
+        /// Global/static variable name
+        name: String,
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
         /// JSON output
         #[arg(long)]
         json: bool,
@@ -247,6 +260,24 @@ struct SourceFileOutput {
     basename: String,
 }
 
+#[derive(Debug, serde::Serialize)]
+struct ValueAdapterOutput {
+    variable: String,
+    module: String,
+    type_name: String,
+    qualified_type_name: Option<String>,
+    source_language: String,
+    producer: Option<String>,
+    rustc_version: Option<String>,
+    dwarf_version: Option<u16>,
+    adapter: Option<String>,
+    status: String,
+    stage: Option<String>,
+    reason: Option<String>,
+    presentation: Option<String>,
+    capture: Option<String>,
+}
+
 // Helper trait to extract common options from commands
 trait CommonOptions {
     fn verbose(&self) -> bool;
@@ -260,6 +291,7 @@ impl CommonOptions for Commands {
             Commands::SourceLine { verbose, .. } => *verbose,
             Commands::Function { verbose, .. } => *verbose,
             Commands::ModuleAddr { verbose, .. } => *verbose,
+            Commands::RustAdapter { verbose, .. } => *verbose,
             Commands::Globals { verbose, .. } => *verbose,
             Commands::GlobalsAll { verbose, .. } => *verbose,
             Commands::BenchmarkSourceLine { .. } => false,
@@ -275,6 +307,7 @@ impl CommonOptions for Commands {
             Commands::SourceLine { quiet, .. } => *quiet,
             Commands::Function { quiet, .. } => *quiet,
             Commands::ModuleAddr { quiet, .. } => *quiet,
+            Commands::RustAdapter { .. } => false,
             Commands::Globals { quiet, .. } => *quiet,
             Commands::GlobalsAll { quiet, .. } => *quiet,
             Commands::BenchmarkSourceLine { .. } => false,
@@ -290,6 +323,7 @@ impl CommonOptions for Commands {
             Commands::SourceLine { json, .. } => *json,
             Commands::Function { json, .. } => *json,
             Commands::ModuleAddr { json, .. } => *json,
+            Commands::RustAdapter { json, .. } => *json,
             Commands::Globals { json, .. } => *json,
             Commands::GlobalsAll { json, .. } => *json,
             Commands::BenchmarkSourceLine { json, .. } => *json,
@@ -366,7 +400,9 @@ fn validate_args(cli: &Cli) -> Result<()> {
         if !target_file.is_file() {
             return Err(anyhow::anyhow!("Target path is not a file: {target_path}"));
         }
-        println!("✓ Target file found: {target_path}");
+        if !cli.command.json() {
+            println!("✓ Target file found: {target_path}");
+        }
     }
 
     Ok(())
@@ -515,7 +551,7 @@ async fn load_analyzer_with_breakdown(
 }
 
 async fn load_analyzer_and_execute(cli: Cli) -> Result<std::time::Duration> {
-    if !cli.command.quiet() {
+    if !cli.command.quiet() && !cli.command.json() {
         if cli.pid.is_some() {
             println!("Loading modules from PID {}...", cli.pid.unwrap());
         } else if let Some(ref target) = cli.target {
@@ -543,6 +579,9 @@ async fn load_analyzer_and_execute(cli: Cli) -> Result<std::time::Duration> {
             module, address, ..
         } => {
             analyze_module_address(&mut analyzer, module, address, &cli.command).await?;
+        }
+        Commands::RustAdapter { name, .. } => {
+            analyze_rust_adapter(&analyzer, name, &cli.command)?;
         }
         Commands::Globals { name, .. } => {
             analyze_globals(&mut analyzer, cli.pid, name, &cli.command).await?;
@@ -812,6 +851,163 @@ async fn analyze_module_address(
     }
 
     Ok(())
+}
+
+fn analyze_rust_adapter(
+    analyzer: &DwarfAnalyzer,
+    variable_name: &str,
+    options: &Commands,
+) -> Result<()> {
+    let preferred_module = analyzer
+        .get_main_executable()
+        .map(|executable| PathBuf::from(executable.path))
+        .or_else(|| {
+            analyzer
+                .get_loaded_modules()
+                .first()
+                .map(|path| (*path).clone())
+        })
+        .ok_or_else(|| anyhow::anyhow!("No loaded module is available for type lookup"))?;
+    let Some((module_path, plan)) = analyzer.plan_global_access_read_plan(
+        &preferred_module,
+        variable_name,
+        &VariableAccessPath::default(),
+    )?
+    else {
+        return Err(anyhow::anyhow!(
+            "Global/static variable '{variable_name}' was not found"
+        ));
+    };
+    let current = analyzer
+        .resolved_type_for_plan(&plan)?
+        .ok_or_else(|| anyhow::anyhow!("Variable '{variable_name}' has no usable DWARF type"))?;
+    let report = analyzer.explain_value_read_plan(&current, Some(&module_path))?;
+    let output = value_adapter_output(variable_name, &module_path, report);
+
+    if options.json() {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("=== Rust Value Adapter: '{variable_name}' ===");
+        println!("Module:     {}", output.module);
+        println!("Type:       {}", output.type_name);
+        if let Some(qualified_type_name) = &output.qualified_type_name {
+            println!("Qualified:  {qualified_type_name}");
+        }
+        println!("Language:   {}", output.source_language);
+        if let Some(producer) = &output.producer {
+            println!("Producer:   {producer}");
+        }
+        if let Some(rustc_version) = &output.rustc_version {
+            println!("rustc:      {rustc_version}");
+        }
+        if let Some(dwarf_version) = output.dwarf_version {
+            println!("DWARF:      {dwarf_version}");
+        }
+        println!(
+            "Adapter:    {}",
+            output.adapter.as_deref().unwrap_or("(none)")
+        );
+        println!("Status:     {}", output.status);
+        if let Some(stage) = &output.stage {
+            println!("Stage:      {stage}");
+        }
+        if let Some(reason) = &output.reason {
+            println!("Reason:     {reason}");
+        }
+        if let Some(presentation) = &output.presentation {
+            println!("Presentation: {presentation}");
+        }
+        if let Some(capture) = &output.capture {
+            println!("Capture:      {capture}");
+        }
+    }
+
+    Ok(())
+}
+
+fn value_adapter_output(
+    variable_name: &str,
+    module_path: &std::path::Path,
+    report: ValueAdapterReport,
+) -> ValueAdapterOutput {
+    let (status, stage, reason, presentation, capture) = match report.outcome {
+        ValueAdapterOutcome::NotApplicable => ("not-applicable", None, None, None, None),
+        ValueAdapterOutcome::Applied { plan } => (
+            "applied",
+            None,
+            None,
+            Some(value_presentation_name(&plan.presentation).to_string()),
+            Some(value_capture_name(&plan.capture).to_string()),
+        ),
+        ValueAdapterOutcome::Rejected { stage, reason } => (
+            "rejected",
+            Some(value_adapter_stage_name(stage).to_string()),
+            Some(reason),
+            None,
+            None,
+        ),
+    };
+
+    ValueAdapterOutput {
+        variable: variable_name.to_string(),
+        module: module_path.display().to_string(),
+        type_name: report.type_name,
+        qualified_type_name: report.qualified_type_name,
+        source_language: source_language_name(report.source_language),
+        producer: report.producer.map(|producer| producer.raw),
+        rustc_version: report.rustc_version.map(|version| version.to_string()),
+        dwarf_version: report.dwarf_version,
+        adapter: report.adapter,
+        status: status.to_string(),
+        stage,
+        reason,
+        presentation,
+        capture,
+    }
+}
+
+fn source_language_name(language: SourceLanguage) -> String {
+    match language {
+        SourceLanguage::C => "C".to_string(),
+        SourceLanguage::Cpp => "C++".to_string(),
+        SourceLanguage::Rust => "Rust".to_string(),
+        SourceLanguage::Other(value) => format!("DW_LANG_0x{value:x}"),
+        SourceLanguage::Unknown => "unknown".to_string(),
+    }
+}
+
+fn value_adapter_stage_name(stage: ValueAdapterStage) -> &'static str {
+    match stage {
+        ValueAdapterStage::LayoutValidation => "layout-validation",
+        ValueAdapterStage::ReadPlanConstruction => "read-plan-construction",
+    }
+}
+
+fn value_presentation_name(presentation: &ValuePresentation) -> &'static str {
+    match presentation {
+        ValuePresentation::Dwarf => "dwarf",
+        ValuePresentation::Utf8String => "utf8-string",
+        ValuePresentation::Sequence { .. } => "sequence",
+        ValuePresentation::ByteString => "byte-string",
+        ValuePresentation::SingleField { .. } => "single-field",
+        ValuePresentation::SignedStateStruct { .. } => "signed-state-struct",
+        ValuePresentation::ReferenceCountedStruct { .. } => "reference-counted-struct",
+        ValuePresentation::HashTable { .. } => "hash-table",
+        ValuePresentation::BTree { .. } => "btree",
+    }
+}
+
+fn value_capture_name(capture: &ValueCapturePlan) -> &'static str {
+    match capture {
+        ValueCapturePlan::ProjectedValue { .. } => "projected-value",
+        ValueCapturePlan::InlineView { .. } => "inline-view",
+        ValueCapturePlan::ProjectedView { .. } => "projected-view",
+        ValueCapturePlan::IndirectBytes { .. } => "indirect-bytes",
+        ValueCapturePlan::IndirectSequence { .. } => "indirect-sequence",
+        ValueCapturePlan::IndirectRingSequence { .. } => "indirect-ring-sequence",
+        ValueCapturePlan::IndirectHashTable { .. } => "indirect-hash-table",
+        ValueCapturePlan::IndirectBTree { .. } => "indirect-btree",
+    }
 }
 
 fn list_modules(analyzer: &DwarfAnalyzer, options: &Commands) {

--- a/bins/dwarf-tool/tests/demangle_lookup.rs
+++ b/bins/dwarf-tool/tests/demangle_lookup.rs
@@ -199,3 +199,33 @@ async fn test_rust_lookup_functions_and_globals() -> anyhow::Result<()> {
     let _ = guard.0.kill().await;
     Ok(())
 }
+
+#[tokio::test]
+async fn test_rust_adapter_diagnostics_from_target_dwarf() -> anyhow::Result<()> {
+    let bin = build_rust_fixture("rust_global_program");
+
+    let applied = run_dwarf_tool_text(&bin, "rust-adapter", &["G_OWNED_MESSAGE", "--json"]).await?;
+    let applied: serde_json::Value = serde_json::from_str(&applied)?;
+    assert_eq!(applied["source_language"], "Rust");
+    assert_eq!(applied["qualified_type_name"], "alloc::string::String");
+    assert_eq!(applied["adapter"], "String");
+    assert_eq!(applied["status"], "applied");
+    assert_eq!(applied["presentation"], "utf8-string");
+    assert_eq!(applied["capture"], "indirect-bytes");
+    assert!(applied["producer"]
+        .as_str()
+        .is_some_and(|producer| producer.contains("rustc version")));
+    assert!(applied["rustc_version"].as_str().is_some());
+
+    let lookalike = run_dwarf_tool_text(&bin, "rust-adapter", &["G_USER_STRING", "--json"]).await?;
+    let lookalike: serde_json::Value = serde_json::from_str(&lookalike)?;
+    assert_eq!(lookalike["source_language"], "Rust");
+    assert_eq!(
+        lookalike["qualified_type_name"],
+        "rust_global_program::user_types::String"
+    );
+    assert_eq!(lookalike["adapter"], serde_json::Value::Null);
+    assert_eq!(lookalike["status"], "not-applicable");
+
+    Ok(())
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -343,6 +343,30 @@ GhostScope provides a standalone `dwarf-tool` for testing and debugging DWARF pa
 cargo build -p dwarf-tool
 ```
 
+To inspect Rust value-adapter selection for a global or static variable, point
+the tool at the target binary rather than GhostScope's own build toolchain:
+
+```bash
+cargo run -p dwarf-tool -- \
+  -t ./target/debug/my-program \
+  rust-adapter MY_GLOBAL
+```
+
+The report includes the reconstructed qualified type name, source language,
+`DW_AT_producer`, parsed rustc version, DWARF version, selected adapter, and
+capture plan. A `rejected` result identifies whether target-layout validation
+or read-plan construction failed and describes the unmet DWARF constraints.
+Use `--json` for machine-readable output. If a rejected adapter is followed by
+a failed ordinary DWARF fallback, the normal CLI and TUI compilation failure
+includes the same diagnostic. Successful conservative fallbacks remain quiet
+and emit details only through the `ghostscope_dwarf::value_adapter` debug
+target:
+
+```bash
+RUST_LOG=ghostscope_dwarf::value_adapter=debug \
+  cargo run -p ghostscope -- --log ...
+```
+
 ### Debug Output Files
 
 ```bash

--- a/docs/zh/development.md
+++ b/docs/zh/development.md
@@ -335,6 +335,28 @@ GhostScope 提供了一个独立的 `dwarf-tool` 用于测试和调试 DWARF 解
 cargo build -p dwarf-tool
 ```
 
+可以让工具直接读取目标二进制，检查某个全局或静态变量的 Rust 值适配器
+选择结果；这里使用的是目标程序的 DWARF，而不是 GhostScope 自身的构建
+工具链：
+
+```bash
+cargo run -p dwarf-tool -- \
+  -t ./target/debug/my-program \
+  rust-adapter MY_GLOBAL
+```
+
+报告包含重建后的完整类型名、源语言、`DW_AT_producer`、解析出的 rustc
+版本、DWARF 版本、适配器和采集计划。`rejected` 会指出失败发生在目标布局
+校验还是读取计划构建阶段，并说明未满足的 DWARF 约束。`--json` 可输出
+机器可读结果。如果适配器被拒绝后普通 DWARF 回退也失败，CLI 和 TUI
+原有的编译失败结果会直接包含同一份诊断。成功的保守回退保持静默，只通过
+`ghostscope_dwarf::value_adapter` debug target 输出详细信息：
+
+```bash
+RUST_LOG=ghostscope_dwarf::value_adapter=debug \
+  cargo run -p ghostscope -- --log ...
+```
+
 ### Debug 输出文件
 
 ```bash

--- a/e2e-tests/tests/fixtures/rust_adapter_rejection_program/alloc.rs
+++ b/e2e-tests/tests/fixtures/rust_adapter_rejection_program/alloc.rs
@@ -1,0 +1,20 @@
+pub mod string {
+    pub struct String;
+}
+
+#[used]
+#[no_mangle]
+pub static G_REJECTED_STRING: string::String = string::String;
+
+#[inline(never)]
+#[no_mangle]
+pub extern "C" fn observe_adapter_rejection() -> usize {
+    std::hint::black_box(&G_REJECTED_STRING as *const _ as usize)
+}
+
+fn main() {
+    loop {
+        std::hint::black_box(observe_adapter_rejection());
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}

--- a/e2e-tests/tests/rust_adapter_diagnostics_execution.rs
+++ b/e2e-tests/tests/rust_adapter_diagnostics_execution.rs
@@ -1,0 +1,70 @@
+//! CLI diagnostics for rejected Rust value adapters.
+
+mod common;
+
+use std::path::{Path, PathBuf};
+
+use common::{
+    init,
+    rust_toolchain::{compile_standalone_fixture, fixture_tempdir, rustc_for_toolchain},
+};
+
+const TOOLCHAIN: &str = "1.88.0";
+
+fn compile_fixture(rustc: &Path, output_dir: &Path) -> anyhow::Result<PathBuf> {
+    // The source filename makes rustc use `alloc` as the crate name, producing
+    // the qualified type identity `alloc::string::String` in target DWARF.
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/rust_adapter_rejection_program/alloc.rs");
+    let binary = output_dir.join("rust_adapter_rejection_program");
+    compile_standalone_fixture(rustc, TOOLCHAIN, &source, &binary)?;
+    Ok(binary)
+}
+
+#[tokio::test]
+async fn test_cli_reports_rust_adapter_rejection_when_dwarf_fallback_fails() -> anyhow::Result<()> {
+    init();
+
+    let rustc = rustc_for_toolchain(TOOLCHAIN)
+        .ok_or_else(|| anyhow::anyhow!("required Rust toolchain {TOOLCHAIN} is not installed"))?;
+    let temp_dir = fixture_tempdir()?;
+    let binary = compile_fixture(&rustc, temp_dir.path())?;
+    let target = common::targets::TargetLauncher::binary(&binary)
+        .current_dir(temp_dir.path())
+        .spawn()
+        .await?;
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    let script = r#"
+trace observe_adapter_rejection {
+    print "SHOULD_NOT_LOAD:{}", G_REJECTED_STRING;
+}
+"#;
+    let result = common::runner::GhostscopeRunner::new()
+        .with_script(script)
+        .attach_to(&target)
+        .timeout_secs(5)
+        .enable_sysmon_for_target(false)
+        .run()
+        .await;
+    target.terminate().await?;
+
+    let (exit_code, stdout, stderr) = result?;
+    let output = format!("{stdout}\n{stderr}");
+    assert_ne!(exit_code, 0, "expected compilation failure: {output}");
+    for expected in [
+        "Variable 'G_REJECTED_STRING' has no concrete DWARF size",
+        "Rust value adapter diagnostic (ordinary DWARF fallback also failed):",
+        "adapter: String",
+        "type: alloc::string::String",
+        "rejected at: layout-validation",
+        "reason: expected `vec.buf[.inner].ptr` and `vec.len`",
+        "target rustc: 1.88.0",
+        "target DWARF:",
+        "producer:",
+    ] {
+        assert!(output.contains(expected), "missing '{expected}': {output}");
+    }
+
+    Ok(())
+}

--- a/ghostscope-compiler/src/ebpf/codegen/args.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/args.rs
@@ -292,6 +292,12 @@ fn btree_capture_limits(
     Ok((max_nodes, max_len, data_len))
 }
 
+#[derive(Default)]
+struct SemanticValueResolution {
+    plan: Option<ghostscope_dwarf::ValueReadPlan>,
+    rejection: Option<ghostscope_dwarf::ValueAdapterReport>,
+}
+
 impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     pub(super) const UNKNOWN_CHAR_ARRAY_READ_FALLBACK: usize = 256;
 
@@ -299,13 +305,42 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         &self,
         resolved_type: &ghostscope_dwarf::ResolvedType,
         type_module_path: Option<&std::path::Path>,
-    ) -> Result<Option<ghostscope_dwarf::ValueReadPlan>> {
+    ) -> Result<SemanticValueResolution> {
         let Some(analyzer) = self.process_analyzer else {
-            return Ok(None);
+            return Ok(SemanticValueResolution::default());
         };
-        analyzer
-            .value_read_plan(resolved_type, type_module_path)
-            .map_err(|error| CodeGenError::DwarfError(error.to_string()))
+        let report = analyzer
+            .explain_value_read_plan(resolved_type, type_module_path)
+            .map_err(|error| CodeGenError::DwarfError(error.to_string()))?;
+        match &report.outcome {
+            ghostscope_dwarf::ValueAdapterOutcome::NotApplicable => {
+                Ok(SemanticValueResolution::default())
+            }
+            ghostscope_dwarf::ValueAdapterOutcome::Applied { plan } => {
+                Ok(SemanticValueResolution {
+                    plan: Some((**plan).clone()),
+                    rejection: None,
+                })
+            }
+            ghostscope_dwarf::ValueAdapterOutcome::Rejected { stage, reason } => {
+                debug!(
+                    target: "ghostscope_dwarf::value_adapter",
+                    adapter = report.adapter.as_deref().unwrap_or("unknown"),
+                    type_name = report.type_name,
+                    qualified_type_name = ?report.qualified_type_name,
+                    producer = ?report.producer.as_ref().map(|producer| producer.raw.as_str()),
+                    rustc_version = ?report.rustc_version,
+                    dwarf_version = ?report.dwarf_version,
+                    ?stage,
+                    %reason,
+                    "Rust value adapter rejected target DWARF; using DWARF presentation"
+                );
+                Ok(SemanticValueResolution {
+                    plan: None,
+                    rejection: Some(report),
+                })
+            }
+        }
     }
 
     fn complex_arg_from_value_read_plan(
@@ -621,7 +656,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         display_name: Option<String>,
     ) -> Result<ComplexArg<'ctx>> {
         let pc_address = self.get_compile_time_context()?.pc_address;
-        let semantic_plan = if let Some(analyzer) = self.process_analyzer {
+        let semantic_resolution = if let Some(analyzer) = self.process_analyzer {
             let resolved_type = analyzer
                 .resolved_type_for_plan(&plan)
                 .map_err(|error| CodeGenError::DwarfError(error.to_string()))?;
@@ -629,239 +664,252 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 Some(resolved_type) => {
                     self.semantic_value_read_plan(&resolved_type, plan.module_path.as_deref())?
                 }
-                None => None,
+                None => SemanticValueResolution::default(),
             }
         } else {
-            None
+            SemanticValueResolution::default()
         };
-        let materialized = self.variable_read_plan_to_materialization(plan, pc_address)?;
-        let display_name = display_name.unwrap_or_else(|| materialized.name.clone());
+        let SemanticValueResolution {
+            plan: semantic_plan,
+            rejection,
+        } = semantic_resolution;
+        let fallback_result = (|| {
+            let materialized = self.variable_read_plan_to_materialization(plan, pc_address)?;
+            let display_name = display_name.unwrap_or_else(|| materialized.name.clone());
 
-        match &materialized.materialization {
-            ghostscope_dwarf::VariableMaterialization::Unavailable {
-                availability: ghostscope_dwarf::Availability::OptimizedOut,
-            } => {
-                let optimized_type = ghostscope_dwarf::TypeInfo::OptimizedOut {
-                    name: materialized.name.clone(),
-                };
-                Ok(ComplexArg {
-                    var_name_index: self.trace_context.add_variable_name(display_name)?,
-                    type_index: self.trace_context.add_type(optimized_type)?,
-                    access_path: Vec::new(),
-                    data_len: 0,
-                    source: ComplexArgSource::ImmediateBytes { bytes: Vec::new() },
-                })
-            }
-            ghostscope_dwarf::VariableMaterialization::Unavailable { availability } => {
-                Err(Self::dwarf_expression_unavailable_error(
-                    &materialized.name,
-                    availability,
-                    pc_address,
-                ))
-            }
-            ghostscope_dwarf::VariableMaterialization::UserMemoryRead { address } => {
-                let dwarf_type = materialized.dwarf_type.clone().ok_or_else(|| {
-                    CodeGenError::DwarfError(
-                        "Expression has no DWARF type information".to_string(),
-                    )
-                })?;
-                let module_hint =
-                    Self::module_path_for_offsets(materialized.module_path.as_deref());
-                if let Some(semantic_plan) = semantic_plan {
-                    let descriptor =
-                        self.resolve_planned_address(address, None, module_hint.as_deref())?;
-                    return self.complex_arg_from_value_read_plan(
-                        display_name,
-                        dwarf_type,
-                        descriptor,
-                        semantic_plan,
-                    );
+            match &materialized.materialization {
+                ghostscope_dwarf::VariableMaterialization::Unavailable {
+                    availability: ghostscope_dwarf::Availability::OptimizedOut,
+                } => {
+                    let optimized_type = ghostscope_dwarf::TypeInfo::OptimizedOut {
+                        name: materialized.name.clone(),
+                    };
+                    Ok(ComplexArg {
+                        var_name_index: self.trace_context.add_variable_name(display_name)?,
+                        type_index: self.trace_context.add_type(optimized_type)?,
+                        access_path: Vec::new(),
+                        data_len: 0,
+                        source: ComplexArgSource::ImmediateBytes { bytes: Vec::new() },
+                    })
                 }
-                let data_len = Self::compute_read_size_for_type(&dwarf_type);
-                if data_len == 0 {
-                    return Err(CodeGenError::TypeSizeNotAvailable(display_name));
+                ghostscope_dwarf::VariableMaterialization::Unavailable { availability } => {
+                    Err(Self::dwarf_expression_unavailable_error(
+                        &materialized.name,
+                        availability,
+                        pc_address,
+                    ))
                 }
-                Ok(ComplexArg {
-                    var_name_index: self.trace_context.add_variable_name(display_name)?,
-                    type_index: self.trace_context.add_type(dwarf_type.clone())?,
-                    access_path: Vec::new(),
-                    data_len,
-                    source: ComplexArgSource::RuntimeRead {
-                        address: address.clone(),
-                        dwarf_type,
-                        module_for_offsets: module_hint,
-                    },
-                })
-            }
-            ghostscope_dwarf::VariableMaterialization::DirectValue { .. } => {
-                let dwarf_type = materialized.dwarf_type.clone().ok_or_else(|| {
-                    CodeGenError::DwarfError(
-                        "Expression has no DWARF type information".to_string(),
-                    )
-                })?;
-                if let Some(ghostscope_dwarf::ValueReadPlan {
-                    presentation,
-                    capture:
-                        ghostscope_dwarf::ValueCapturePlan::ProjectedValue { value: projected },
-                }) = semantic_plan.as_ref()
-                {
-                    let projected_type = &projected.resolved_type.summary;
-                    if Self::compute_read_size_for_type(projected_type) == 0
-                        && is_known_zero_sized_type(projected_type)
-                    {
-                        return Ok(ComplexArg {
-                            var_name_index: self
-                                .trace_context
-                                .add_variable_name(display_name)?,
-                            type_index: self.trace_context.add_type_with_presentation(
-                                projected_type.clone(),
-                                presentation.clone(),
-                            )?,
-                            access_path: Vec::new(),
-                            data_len: 0,
-                            source: ComplexArgSource::ImmediateBytes { bytes: Vec::new() },
-                        });
+                ghostscope_dwarf::VariableMaterialization::UserMemoryRead { address } => {
+                    let dwarf_type = materialized.dwarf_type.clone().ok_or_else(|| {
+                        CodeGenError::DwarfError(
+                            "Expression has no DWARF type information".to_string(),
+                        )
+                    })?;
+                    let module_hint =
+                        Self::module_path_for_offsets(materialized.module_path.as_deref());
+                    if let Some(semantic_plan) = semantic_plan {
+                        let descriptor =
+                            self.resolve_planned_address(address, None, module_hint.as_deref())?;
+                        return self.complex_arg_from_value_read_plan(
+                            display_name,
+                            dwarf_type,
+                            descriptor,
+                            semantic_plan,
+                        );
                     }
-                }
-                if let Some(ghostscope_dwarf::ValueReadPlan {
-                    presentation,
-                    capture:
-                        ghostscope_dwarf::ValueCapturePlan::InlineView { output_type },
-                }) = semantic_plan.as_ref()
-                {
-                    let data_len = inline_view_data_len(&dwarf_type, output_type)?;
+                    let data_len = Self::compute_read_size_for_type(&dwarf_type);
                     if data_len == 0 {
-                        return Ok(ComplexArg {
-                            var_name_index: self
-                                .trace_context
-                                .add_variable_name(display_name)?,
-                            type_index: self.trace_context.add_type_with_presentation(
-                                output_type.clone(),
-                                presentation.clone(),
-                            )?,
-                            access_path: Vec::new(),
-                            data_len: 0,
-                            source: ComplexArgSource::ImmediateBytes { bytes: Vec::new() },
-                        });
+                        return Err(CodeGenError::TypeSizeNotAvailable(display_name));
                     }
+                    Ok(ComplexArg {
+                        var_name_index: self.trace_context.add_variable_name(display_name)?,
+                        type_index: self.trace_context.add_type(dwarf_type.clone())?,
+                        access_path: Vec::new(),
+                        data_len,
+                        source: ComplexArgSource::RuntimeRead {
+                            address: address.clone(),
+                            dwarf_type,
+                            module_for_offsets: module_hint,
+                        },
+                    })
                 }
-                let value =
-                    self.variable_materialization_to_llvm_value(&materialized, pc_address, None)?;
-                let value = match value {
-                    BasicValueEnum::IntValue(value) => value,
-                    BasicValueEnum::PointerValue(value) => self
-                        .builder
-                        .build_ptr_to_int(value, self.context.i64_type(), "direct_ptr_to_i64")
-                        .map_err(|e| CodeGenError::Builder(e.to_string()))?,
-                    _ => {
-                        return Err(CodeGenError::DwarfError(format!(
-                            "direct DWARF value '{}' did not lower to an integer",
-                            materialized.name
-                        )))
+                ghostscope_dwarf::VariableMaterialization::DirectValue { .. } => {
+                    let dwarf_type = materialized.dwarf_type.clone().ok_or_else(|| {
+                        CodeGenError::DwarfError(
+                            "Expression has no DWARF type information".to_string(),
+                        )
+                    })?;
+                    if let Some(ghostscope_dwarf::ValueReadPlan {
+                        presentation,
+                        capture:
+                            ghostscope_dwarf::ValueCapturePlan::ProjectedValue { value: projected },
+                    }) = semantic_plan.as_ref()
+                    {
+                        let projected_type = &projected.resolved_type.summary;
+                        if Self::compute_read_size_for_type(projected_type) == 0
+                            && is_known_zero_sized_type(projected_type)
+                        {
+                            return Ok(ComplexArg {
+                                var_name_index: self
+                                    .trace_context
+                                    .add_variable_name(display_name)?,
+                                type_index: self.trace_context.add_type_with_presentation(
+                                    projected_type.clone(),
+                                    presentation.clone(),
+                                )?,
+                                access_path: Vec::new(),
+                                data_len: 0,
+                                source: ComplexArgSource::ImmediateBytes { bytes: Vec::new() },
+                            });
+                        }
                     }
-                };
-                if let Some(semantic_plan) = semantic_plan {
-                    match semantic_plan.capture {
-                        ghostscope_dwarf::ValueCapturePlan::ProjectedValue {
-                            value: projected,
-                        } => {
-                            let offset =
-                                projected_member_offset(&projected, "projected value")?;
-                            let projected_type = projected.resolved_type.summary;
-                            let data_len = Self::compute_read_size_for_type(&projected_type);
-                            let container_len = Self::compute_read_size_for_type(&dwarf_type);
-                            let projected_end = usize::try_from(offset)
-                                .ok()
-                                .and_then(|offset| offset.checked_add(data_len));
-                            if data_len == 0
-                                || data_len > 8
-                                || projected_end
-                                    .is_none_or(|end| end > container_len || end > 8)
-                            {
-                                return Err(CodeGenError::DwarfError(format!(
-                                    "direct semantic projection for '{}' does not fit one eBPF register",
-                                    materialized.name
-                                )));
-                            }
-                            let value = if offset == 0 {
-                                value
-                            } else {
-                                let shift = value.get_type().const_int(offset * 8, false);
-                                self.builder
-                                    .build_right_shift(
-                                        value,
-                                        shift,
-                                        false,
-                                        "semantic_projected_direct_value",
-                                    )
-                                    .map_err(|error| {
-                                        CodeGenError::Builder(error.to_string())
-                                    })?
-                            };
+                    if let Some(ghostscope_dwarf::ValueReadPlan {
+                        presentation,
+                        capture:
+                            ghostscope_dwarf::ValueCapturePlan::InlineView { output_type },
+                    }) = semantic_plan.as_ref()
+                    {
+                        let data_len = inline_view_data_len(&dwarf_type, output_type)?;
+                        if data_len == 0 {
                             return Ok(ComplexArg {
                                 var_name_index: self
                                     .trace_context
                                     .add_variable_name(display_name)?,
                                 type_index: self.trace_context.add_type_with_presentation(
-                                    projected_type,
-                                    semantic_plan.presentation,
+                                    output_type.clone(),
+                                    presentation.clone(),
                                 )?,
                                 access_path: Vec::new(),
-                                data_len,
-                                source: ComplexArgSource::ComputedInt {
-                                    value,
-                                    byte_len: data_len,
-                                },
+                                data_len: 0,
+                                source: ComplexArgSource::ImmediateBytes { bytes: Vec::new() },
                             });
                         }
-                        ghostscope_dwarf::ValueCapturePlan::InlineView { output_type } => {
-                            let data_len = inline_view_data_len(&dwarf_type, &output_type)?;
-                            if data_len == 0 || data_len > 8 {
-                                return Err(CodeGenError::DwarfError(format!(
-                                    "direct semantic view for '{}' does not fit one eBPF register",
-                                    materialized.name
-                                )));
-                            }
-                            return Ok(ComplexArg {
-                                var_name_index: self
-                                    .trace_context
-                                    .add_variable_name(display_name)?,
-                                type_index: self.trace_context.add_type_with_presentation(
-                                    output_type,
-                                    semantic_plan.presentation,
-                                )?,
-                                access_path: Vec::new(),
-                                data_len,
-                                source: ComplexArgSource::ComputedInt {
-                                    value,
-                                    byte_len: data_len,
-                                },
-                            });
-                        }
-                        ghostscope_dwarf::ValueCapturePlan::ProjectedView { .. } => {
+                    }
+                    let value =
+                        self.variable_materialization_to_llvm_value(&materialized, pc_address, None)?;
+                    let value = match value {
+                        BasicValueEnum::IntValue(value) => value,
+                        BasicValueEnum::PointerValue(value) => self
+                            .builder
+                            .build_ptr_to_int(value, self.context.i64_type(), "direct_ptr_to_i64")
+                            .map_err(|e| CodeGenError::Builder(e.to_string()))?,
+                        _ => {
                             return Err(CodeGenError::DwarfError(format!(
-                                "direct semantic view for '{}' requires an address-backed root",
+                                "direct DWARF value '{}' did not lower to an integer",
                                 materialized.name
-                            )));
+                            )))
                         }
-                        _ => {}
+                    };
+                    if let Some(semantic_plan) = semantic_plan {
+                        match semantic_plan.capture {
+                            ghostscope_dwarf::ValueCapturePlan::ProjectedValue {
+                                value: projected,
+                            } => {
+                                let offset =
+                                    projected_member_offset(&projected, "projected value")?;
+                                let projected_type = projected.resolved_type.summary;
+                                let data_len = Self::compute_read_size_for_type(&projected_type);
+                                let container_len = Self::compute_read_size_for_type(&dwarf_type);
+                                let projected_end = usize::try_from(offset)
+                                    .ok()
+                                    .and_then(|offset| offset.checked_add(data_len));
+                                if data_len == 0
+                                    || data_len > 8
+                                    || projected_end
+                                        .is_none_or(|end| end > container_len || end > 8)
+                                {
+                                    return Err(CodeGenError::DwarfError(format!(
+                                        "direct semantic projection for '{}' does not fit one eBPF register",
+                                        materialized.name
+                                    )));
+                                }
+                                let value = if offset == 0 {
+                                    value
+                                } else {
+                                    let shift = value.get_type().const_int(offset * 8, false);
+                                    self.builder
+                                        .build_right_shift(
+                                            value,
+                                            shift,
+                                            false,
+                                            "semantic_projected_direct_value",
+                                        )
+                                        .map_err(|error| {
+                                            CodeGenError::Builder(error.to_string())
+                                        })?
+                                };
+                                return Ok(ComplexArg {
+                                    var_name_index: self
+                                        .trace_context
+                                        .add_variable_name(display_name)?,
+                                    type_index: self.trace_context.add_type_with_presentation(
+                                        projected_type,
+                                        semantic_plan.presentation,
+                                    )?,
+                                    access_path: Vec::new(),
+                                    data_len,
+                                    source: ComplexArgSource::ComputedInt {
+                                        value,
+                                        byte_len: data_len,
+                                    },
+                                });
+                            }
+                            ghostscope_dwarf::ValueCapturePlan::InlineView { output_type } => {
+                                let data_len = inline_view_data_len(&dwarf_type, &output_type)?;
+                                if data_len == 0 || data_len > 8 {
+                                    return Err(CodeGenError::DwarfError(format!(
+                                        "direct semantic view for '{}' does not fit one eBPF register",
+                                        materialized.name
+                                    )));
+                                }
+                                return Ok(ComplexArg {
+                                    var_name_index: self
+                                        .trace_context
+                                        .add_variable_name(display_name)?,
+                                    type_index: self.trace_context.add_type_with_presentation(
+                                        output_type,
+                                        semantic_plan.presentation,
+                                    )?,
+                                    access_path: Vec::new(),
+                                    data_len,
+                                    source: ComplexArgSource::ComputedInt {
+                                        value,
+                                        byte_len: data_len,
+                                    },
+                                });
+                            }
+                            ghostscope_dwarf::ValueCapturePlan::ProjectedView { .. } => {
+                                return Err(CodeGenError::DwarfError(format!(
+                                    "direct semantic view for '{}' requires an address-backed root",
+                                    materialized.name
+                                )));
+                            }
+                            _ => {}
+                        }
                     }
+                    let data_len = Self::compute_read_size_for_type(&dwarf_type).clamp(1, 8);
+                    Ok(ComplexArg {
+                        var_name_index: self.trace_context.add_variable_name(display_name)?,
+                        type_index: self.trace_context.add_type(dwarf_type)?,
+                        access_path: Vec::new(),
+                        data_len,
+                        source: ComplexArgSource::ComputedInt { value, byte_len: data_len },
+                    })
                 }
-                let data_len = Self::compute_read_size_for_type(&dwarf_type).clamp(1, 8);
-                Ok(ComplexArg {
-                    var_name_index: self.trace_context.add_variable_name(display_name)?,
-                    type_index: self.trace_context.add_type(dwarf_type)?,
-                    access_path: Vec::new(),
-                    data_len,
-                    source: ComplexArgSource::ComputedInt { value, byte_len: data_len },
-                })
+                ghostscope_dwarf::VariableMaterialization::Composite { .. } => Err(
+                    CodeGenError::DwarfError(format!(
+                        "DWARF variable '{}' is split across pieces; piece reconstruction is not implemented",
+                        materialized.name
+                    )),
+                ),
             }
-            ghostscope_dwarf::VariableMaterialization::Composite { .. } => Err(
-                CodeGenError::DwarfError(format!(
-                    "DWARF variable '{}' is split across pieces; piece reconstruction is not implemented",
-                    materialized.name
-                )),
-            ),
+        })();
+
+        match rejection {
+            Some(report) => {
+                fallback_result.map_err(|error| error.with_value_adapter_rejection(report))
+            }
+            None => fallback_result,
         }
     }
 
@@ -870,10 +918,11 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         expr: &crate::script::ast::Expr,
         lvalue: crate::ebpf::expression::DynamicLvalue<'ctx>,
     ) -> Result<ComplexArg<'ctx>> {
-        if let Some(plan) = self.semantic_value_read_plan(
+        let SemanticValueResolution { plan, rejection } = self.semantic_value_read_plan(
             &lvalue.type_info.resolved_type,
             lvalue.type_info.type_module_path.as_deref(),
-        )? {
+        )?;
+        if let Some(plan) = plan {
             return self.complex_arg_from_value_read_plan(
                 self.expr_to_name(expr),
                 lvalue.type_info.resolved_type.summary,
@@ -881,24 +930,32 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 plan,
             );
         }
-        let dwarf_type = lvalue.type_info.resolved_type.summary;
-        let data_len = Self::compute_read_size_for_type(&dwarf_type);
-        if data_len == 0 {
-            return Err(CodeGenError::TypeSizeNotAvailable(self.expr_to_name(expr)));
-        }
+        let fallback_result = (|| {
+            let dwarf_type = lvalue.type_info.resolved_type.summary;
+            let data_len = Self::compute_read_size_for_type(&dwarf_type);
+            if data_len == 0 {
+                return Err(CodeGenError::TypeSizeNotAvailable(self.expr_to_name(expr)));
+            }
 
-        Ok(ComplexArg {
-            var_name_index: self
-                .trace_context
-                .add_variable_name(self.expr_to_name(expr))?,
-            type_index: self.trace_context.add_type(dwarf_type)?,
-            access_path: Vec::new(),
-            data_len,
-            source: ComplexArgSource::MemDump {
-                address: lvalue.address,
-                len: data_len,
-            },
-        })
+            Ok(ComplexArg {
+                var_name_index: self
+                    .trace_context
+                    .add_variable_name(self.expr_to_name(expr))?,
+                type_index: self.trace_context.add_type(dwarf_type)?,
+                access_path: Vec::new(),
+                data_len,
+                source: ComplexArgSource::MemDump {
+                    address: lvalue.address,
+                    len: data_len,
+                },
+            })
+        })();
+        match rejection {
+            Some(report) => {
+                fallback_result.map_err(|error| error.with_value_adapter_rejection(report))
+            }
+            None => fallback_result,
+        }
     }
 
     fn complex_arg_from_cast_expr(

--- a/ghostscope-compiler/src/ebpf/context.rs
+++ b/ghostscope-compiler/src/ebpf/context.rs
@@ -72,6 +72,12 @@ pub enum CodeGenError {
     DwarfError(String),
     #[error("Type size not available for variable: {0}")]
     TypeSizeNotAvailable(String),
+    #[error("{source}")]
+    ValueAdapterFallback {
+        #[source]
+        source: Box<CodeGenError>,
+        report: Box<ghostscope_dwarf::ValueAdapterReport>,
+    },
     #[error("Trace context error: {0}")]
     TraceContext(#[from] ghostscope_protocol::TraceContextOverflow),
 }

--- a/ghostscope-compiler/src/lib.rs
+++ b/ghostscope-compiler/src/lib.rs
@@ -78,6 +78,20 @@ impl CompileError {
 }
 
 impl CodeGenError {
+    pub(crate) fn with_value_adapter_rejection(
+        self,
+        report: ghostscope_dwarf::ValueAdapterReport,
+    ) -> Self {
+        debug_assert!(matches!(
+            report.outcome,
+            ghostscope_dwarf::ValueAdapterOutcome::Rejected { .. }
+        ));
+        Self::ValueAdapterFallback {
+            source: Box::new(self),
+            report: Box::new(report),
+        }
+    }
+
     pub fn user_message(&self) -> Cow<'_, str> {
         match self {
             CodeGenError::VariableNotInScope(name) => {
@@ -87,9 +101,55 @@ impl CodeGenError {
             CodeGenError::TypeSizeNotAvailable(name) => Cow::Owned(format!(
                 "Variable '{name}' has no concrete DWARF size at this probe PC"
             )),
+            CodeGenError::ValueAdapterFallback { source, report } => {
+                let mut message = source.user_message().into_owned();
+                if let Some(diagnostic) = format_value_adapter_rejection(report) {
+                    message.push_str("\n\n");
+                    message.push_str(&diagnostic);
+                }
+                Cow::Owned(message)
+            }
             _ => Cow::Owned(self.to_string()),
         }
     }
+}
+
+fn format_value_adapter_rejection(report: &ghostscope_dwarf::ValueAdapterReport) -> Option<String> {
+    let ghostscope_dwarf::ValueAdapterOutcome::Rejected { stage, reason } = &report.outcome else {
+        return None;
+    };
+    let stage = match stage {
+        ghostscope_dwarf::ValueAdapterStage::LayoutValidation => "layout-validation",
+        ghostscope_dwarf::ValueAdapterStage::ReadPlanConstruction => "read-plan-construction",
+    };
+    let type_name = report
+        .qualified_type_name
+        .as_deref()
+        .unwrap_or(&report.type_name);
+    let mut lines = vec![
+        concat!(
+            "Rust value adapter diagnostic ",
+            "(ordinary DWARF fallback also failed):"
+        )
+        .to_string(),
+        format!(
+            "  adapter: {}",
+            report.adapter.as_deref().unwrap_or("unknown")
+        ),
+        format!("  type: {type_name}"),
+        format!("  rejected at: {stage}"),
+        format!("  reason: {reason}"),
+    ];
+    if let Some(version) = report.rustc_version {
+        lines.push(format!("  target rustc: {version}"));
+    }
+    if let Some(version) = report.dwarf_version {
+        lines.push(format!("  target DWARF: {version}"));
+    }
+    if let Some(producer) = &report.producer {
+        lines.push(format!("  producer: {}", producer.raw));
+    }
+    Some(lines.join("\n"))
 }
 
 // Public re-exports from script::compiler module
@@ -399,6 +459,38 @@ mod tests {
             err.user_message().as_ref(),
             "Use of variable 'x' outside of its scope"
         );
+    }
+
+    #[test]
+    fn user_message_appends_rejected_value_adapter_context() {
+        let report = ghostscope_dwarf::ValueAdapterReport {
+            source_language: ghostscope_dwarf::SourceLanguage::Rust,
+            type_name: "String".to_string(),
+            qualified_type_name: Some("alloc::string::String".to_string()),
+            adapter: Some("String".to_string()),
+            producer: Some(ghostscope_dwarf::ProducerInfo::new(
+                "clang LLVM (rustc version 1.88.0)",
+            )),
+            rustc_version: Some(ghostscope_dwarf::RustcVersion::new(1, 88, 0)),
+            dwarf_version: Some(4),
+            outcome: ghostscope_dwarf::ValueAdapterOutcome::Rejected {
+                stage: ghostscope_dwarf::ValueAdapterStage::LayoutValidation,
+                reason: "missing String Vec layout".to_string(),
+            },
+        };
+        let err = CompileError::CodeGen(
+            CodeGenError::TypeSizeNotAvailable("value".to_string())
+                .with_value_adapter_rejection(report),
+        );
+        let message = err.user_message();
+
+        assert!(message.contains("Variable 'value' has no concrete DWARF size"));
+        assert!(message.contains("adapter: String"));
+        assert!(message.contains("type: alloc::string::String"));
+        assert!(message.contains("rejected at: layout-validation"));
+        assert!(message.contains("reason: missing String Vec layout"));
+        assert!(message.contains("target rustc: 1.88.0"));
+        assert!(message.contains("target DWARF: 4"));
     }
 
     #[test]

--- a/ghostscope-dwarf/src/analyzer/type_context.rs
+++ b/ghostscope-dwarf/src/analyzer/type_context.rs
@@ -4,8 +4,8 @@ use crate::{
     CompilationUnitMetadata, CuId, MemberLayout, ModuleId, PcContext, ProjectedValueRead,
     ProjectedValueStep, ProjectedViewField, ProjectedViewFieldCapture, ResolvedType, Result,
     SemanticType, StructMember, TypeId, TypeIdentity, TypeInfo, TypeLayoutError, TypeOrigin,
-    TypeProjection, TypeProjectionLayout, ValueCapturePlan, ValueReadPlan, VariableAccessSegment,
-    VariableReadPlan,
+    TypeProjection, TypeProjectionLayout, ValueAdapterOutcome, ValueAdapterReport,
+    ValueAdapterStage, ValueCapturePlan, ValueReadPlan, VariableAccessSegment, VariableReadPlan,
 };
 use std::path::Path;
 
@@ -287,6 +287,38 @@ impl DwarfAnalyzer {
         current: &ResolvedType,
         type_module_path: Option<&Path>,
     ) -> Result<Option<ValueReadPlan>> {
+        let report = self.explain_value_read_plan(current, type_module_path)?;
+        match report.outcome {
+            ValueAdapterOutcome::NotApplicable => Ok(None),
+            ValueAdapterOutcome::Applied { plan } => Ok(Some(*plan)),
+            ValueAdapterOutcome::Rejected { stage, reason } => {
+                tracing::debug!(
+                    target: "ghostscope_dwarf::value_adapter",
+                    adapter = report.adapter.as_deref().unwrap_or("unknown"),
+                    type_name = report.type_name,
+                    qualified_type_name = ?report.qualified_type_name,
+                    producer = ?report.producer.as_ref().map(|producer| producer.raw.as_str()),
+                    rustc_version = ?report.rustc_version,
+                    dwarf_version = ?report.dwarf_version,
+                    ?stage,
+                    %reason,
+                    "Rust value adapter rejected target DWARF; using DWARF presentation"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    /// Explain whether a source-language adapter can present this value.
+    ///
+    /// A rejected report is a normal, conservative fallback rather than an
+    /// analysis error. Producer metadata is included only to aid debugging;
+    /// target DWARF remains the source of layout truth.
+    pub fn explain_value_read_plan(
+        &self,
+        current: &ResolvedType,
+        type_module_path: Option<&Path>,
+    ) -> Result<ValueAdapterReport> {
         let qualified_name = match (
             crate::language::requires_dwarf_qualified_name(current),
             current.identity.layout_dwarf_id(),
@@ -294,11 +326,61 @@ impl DwarfAnalyzer {
             (true, Some(type_id)) => self.qualified_type_name(type_id)?,
             _ => None,
         };
-        let Some(layout) =
-            crate::language::resolve_value_layout(current, qualified_name.as_deref())
-        else {
-            return Ok(None);
+        let origin = current.origin.as_ref();
+        let mut report = ValueAdapterReport {
+            source_language: origin
+                .map(|origin| origin.language)
+                .unwrap_or(crate::SourceLanguage::Unknown),
+            type_name: current.summary.type_name(),
+            qualified_type_name: qualified_name,
+            adapter: None,
+            producer: origin.and_then(|origin| origin.producer.clone()),
+            rustc_version: origin.and_then(TypeOrigin::rustc_version),
+            dwarf_version: origin.map(|origin| origin.dwarf_version),
+            outcome: ValueAdapterOutcome::NotApplicable,
         };
+
+        let (adapter, layout) = match crate::language::resolve_value_layout(
+            current,
+            report.qualified_type_name.as_deref(),
+        ) {
+            crate::language::ValueLayoutResolution::NotApplicable => return Ok(report),
+            crate::language::ValueLayoutResolution::Rejected { adapter, reason } => {
+                report.adapter = Some(adapter.to_string());
+                report.outcome = ValueAdapterOutcome::Rejected {
+                    stage: ValueAdapterStage::LayoutValidation,
+                    reason: reason.to_string(),
+                };
+                return Ok(report);
+            }
+            crate::language::ValueLayoutResolution::Applied { adapter, layout } => {
+                (adapter, layout)
+            }
+        };
+        report.adapter = Some(adapter.to_string());
+        report.outcome = match self.build_value_read_plan(current, type_module_path, layout)? {
+            Some(plan) => ValueAdapterOutcome::Applied {
+                plan: Box::new(plan),
+            },
+            None => ValueAdapterOutcome::Rejected {
+                stage: ValueAdapterStage::ReadPlanConstruction,
+                reason: concat!(
+                    "validated root layout could not form a capture plan because ",
+                    "a dependent template type, projection, pointer target, width, ",
+                    "or alignment was unavailable or inconsistent in target DWARF"
+                )
+                .to_string(),
+            },
+        };
+        Ok(report)
+    }
+
+    fn build_value_read_plan(
+        &self,
+        current: &ResolvedType,
+        type_module_path: Option<&Path>,
+        layout: crate::language::ValueLayout,
+    ) -> Result<Option<ValueReadPlan>> {
         let layout = match layout {
             crate::language::ValueLayout::ProjectedValue {
                 value_path,

--- a/ghostscope-dwarf/src/language/mod.rs
+++ b/ghostscope-dwarf/src/language/mod.rs
@@ -8,13 +8,13 @@ pub(crate) use rust::{
     btree_value_read_plan, hash_table_value_read_plan, CompositeStructFieldCapture,
     IndirectSequenceAddressing, IndirectSequenceKind, ProjectedPathSegment,
     ProjectedStructPresentation, ProjectedValuePresentation, ProjectedValueRequirement,
-    RingSequenceLengthKind, RustPlanContext, ValueLayout,
+    RingSequenceLengthKind, RustPlanContext, ValueLayout, ValueLayoutResolution,
 };
 
 pub(crate) fn resolve_value_layout(
     current: &crate::ResolvedType,
     dwarf_qualified_name: Option<&str>,
-) -> Option<ValueLayout> {
+) -> ValueLayoutResolution {
     rust::resolve_value_layout(current, dwarf_qualified_name)
 }
 

--- a/ghostscope-dwarf/src/language/rust/mod.rs
+++ b/ghostscope-dwarf/src/language/rust/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use plan::{btree_value_read_plan, hash_table_value_read_plan, RustPla
 pub(crate) use value::{
     CompositeStructFieldCapture, IndirectSequenceAddressing, IndirectSequenceKind,
     ProjectedPathSegment, ProjectedStructPresentation, ProjectedValuePresentation,
-    ProjectedValueRequirement, RingSequenceLengthKind, ValueLayout,
+    ProjectedValueRequirement, RingSequenceLengthKind, ValueLayout, ValueLayoutResolution,
 };
 
 pub(super) fn resolve_tuple_index(index: u32) -> crate::VariableAccessSegment {
@@ -21,8 +21,8 @@ pub(super) fn annotate_type_info(type_info: &mut crate::TypeInfo) {
 pub(super) fn resolve_value_layout(
     current: &crate::ResolvedType,
     dwarf_qualified_name: Option<&str>,
-) -> Option<ValueLayout> {
-    value::resolve_value_layout(current, dwarf_qualified_name)
+) -> ValueLayoutResolution {
+    value::diagnose_value_layout(current, dwarf_qualified_name)
 }
 
 pub(super) fn requires_dwarf_qualified_name(current: &crate::ResolvedType) -> bool {

--- a/ghostscope-dwarf/src/language/rust/value.rs
+++ b/ghostscope-dwarf/src/language/rust/value.rs
@@ -18,6 +18,25 @@ pub(crate) enum ValueLayout {
     BTree(BTreeLayout),
 }
 
+/// Result of asking the Rust adapter layer for a semantic value layout.
+///
+/// Recognition establishes only a candidate type identity. `Applied` means
+/// the concrete target DWARF also passed layout validation. `Rejected` keeps
+/// identity mismatch separate from an unsafe or unsupported layout so callers
+/// can preserve the ordinary DWARF fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValueLayoutResolution {
+    NotApplicable,
+    Applied {
+        adapter: &'static str,
+        layout: ValueLayout,
+    },
+    Rejected {
+        adapter: &'static str,
+        reason: &'static str,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProjectedValuePresentation {
     Transparent,
@@ -182,156 +201,304 @@ pub(super) fn requires_dwarf_qualified_name(current: &ResolvedType) -> bool {
     })
 }
 
+#[cfg(test)]
 pub(super) fn resolve_value_layout(
     current: &ResolvedType,
     dwarf_qualified_name: Option<&str>,
 ) -> Option<ValueLayout> {
-    if current.origin.as_ref()?.language != SourceLanguage::Rust {
-        return None;
+    match diagnose_value_layout(current, dwarf_qualified_name) {
+        ValueLayoutResolution::Applied { layout, .. } => Some(layout),
+        ValueLayoutResolution::NotApplicable | ValueLayoutResolution::Rejected { .. } => None,
+    }
+}
+
+pub(super) fn diagnose_value_layout(
+    current: &ResolvedType,
+    dwarf_qualified_name: Option<&str>,
+) -> ValueLayoutResolution {
+    if current.origin.as_ref().map(|origin| origin.language) != Some(SourceLanguage::Rust) {
+        return ValueLayoutResolution::NotApplicable;
     }
 
     // rust-gdb does not select printers from the target CU's rustc version.
     // Its wrapper adds the invoking toolchain's `lib/rustlib/etc` directory,
     // while the target only requests the generic loader through
-    // `.debug_gdb_scripts`. GhostScope may use `origin.rustc_version()` to
-    // prioritize candidates, but never as proof of a private layout: every
-    // branch below must validate type identity, member paths, offsets, and
-    // widths from the target's DWARF. Any semantic fact DWARF cannot express
-    // must be documented at the special case that relies on it.
-
+    // `.debug_gdb_scripts`. GhostScope records the producer for diagnostics,
+    // but every adapter below validates identity and physical target DWARF.
     let TypeInfo::StructType { name, .. } = strip_type_aliases(&current.summary) else {
-        return None;
+        return ValueLayoutResolution::NotApplicable;
+    };
+    let Some(adapter) = RustValueAdapter::recognize(name, dwarf_qualified_name) else {
+        return ValueLayoutResolution::NotApplicable;
     };
 
-    if is_std_btree_map(name, dwarf_qualified_name) {
-        return rust_btree_layout(&current.summary, BTreeKind::Map).map(ValueLayout::BTree);
+    match adapter.resolve(&current.summary) {
+        Some(layout) => ValueLayoutResolution::Applied {
+            adapter: adapter.name(),
+            layout,
+        },
+        None => ValueLayoutResolution::Rejected {
+            adapter: adapter.name(),
+            reason: adapter.layout_rejection_reason(),
+        },
+    }
+}
+
+/// Rust standard-library identities with optional semantic presentations.
+///
+/// Recognition selects a candidate; it never proves a physical layout.
+/// `resolve` must validate every required member, offset, and width from the
+/// target DWARF. Validation failure is a conservative rejection, and callers
+/// must retain ordinary DWARF handling rather than require an adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RustValueAdapter {
+    BTreeMap,
+    BTreeSet,
+    HashMap,
+    HashSet,
+    Rc { pointee_is_str: bool },
+    Arc { pointee_is_str: bool },
+    Ref,
+    RefMut,
+    RefCell,
+    Cell,
+    NonZero,
+    PathReference,
+    StrReference,
+    SliceReference,
+    BoxStr,
+    String,
+    OsString,
+    PathBuf,
+    Vec,
+    VecDeque,
+}
+
+impl RustValueAdapter {
+    fn recognize(name: &str, dwarf_qualified_name: Option<&str>) -> Option<Self> {
+        if is_std_btree_map(name, dwarf_qualified_name) {
+            Some(Self::BTreeMap)
+        } else if is_std_btree_set(name, dwarf_qualified_name) {
+            Some(Self::BTreeSet)
+        } else if is_std_hash_map(name, dwarf_qualified_name) {
+            Some(Self::HashMap)
+        } else if is_std_hash_set(name, dwarf_qualified_name) {
+            Some(Self::HashSet)
+        } else if is_std_rc(name, dwarf_qualified_name) {
+            Some(Self::Rc {
+                pointee_is_str: has_first_generic_argument(name, "Rc", "str")
+                    || dwarf_qualified_name
+                        .is_some_and(|name| has_first_generic_argument(name, "Rc", "str")),
+            })
+        } else if is_std_arc(name, dwarf_qualified_name) {
+            Some(Self::Arc {
+                pointee_is_str: has_first_generic_argument(name, "Arc", "str")
+                    || dwarf_qualified_name
+                        .is_some_and(|name| has_first_generic_argument(name, "Arc", "str")),
+            })
+        } else if is_std_ref(name, dwarf_qualified_name) {
+            Some(Self::Ref)
+        } else if is_std_ref_mut(name, dwarf_qualified_name) {
+            Some(Self::RefMut)
+        } else if is_std_ref_cell(name, dwarf_qualified_name) {
+            Some(Self::RefCell)
+        } else if is_std_cell(name, dwarf_qualified_name) {
+            Some(Self::Cell)
+        } else if is_std_nonzero(name, dwarf_qualified_name) {
+            Some(Self::NonZero)
+        } else if is_std_path_ref_name(name) {
+            Some(Self::PathReference)
+        } else if matches!(
+            name,
+            "&str" | "&mut str" | "&'static str" | "&'static mut str"
+        ) {
+            Some(Self::StrReference)
+        } else if is_slice_name(name) {
+            Some(Self::SliceReference)
+        } else if is_std_box_str(name, dwarf_qualified_name) {
+            Some(Self::BoxStr)
+        } else if is_std_string(name, dwarf_qualified_name) {
+            Some(Self::String)
+        } else if is_std_os_string(name, dwarf_qualified_name) {
+            Some(Self::OsString)
+        } else if is_std_path_buf(name, dwarf_qualified_name) {
+            Some(Self::PathBuf)
+        } else if is_std_vec(name, dwarf_qualified_name) {
+            Some(Self::Vec)
+        } else if is_std_vec_deque(name, dwarf_qualified_name) {
+            Some(Self::VecDeque)
+        } else {
+            None
+        }
     }
 
-    if is_std_btree_set(name, dwarf_qualified_name) {
-        return rust_btree_layout(&current.summary, BTreeKind::Set).map(ValueLayout::BTree);
+    fn name(self) -> &'static str {
+        match self {
+            Self::BTreeMap => "BTreeMap",
+            Self::BTreeSet => "BTreeSet",
+            Self::HashMap => "HashMap",
+            Self::HashSet => "HashSet",
+            Self::Rc { .. } => "Rc",
+            Self::Arc { .. } => "Arc",
+            Self::Ref => "Ref",
+            Self::RefMut => "RefMut",
+            Self::RefCell => "RefCell",
+            Self::Cell => "Cell",
+            Self::NonZero => "NonZero",
+            Self::PathReference => "&Path",
+            Self::StrReference => "&str",
+            Self::SliceReference => "slice reference",
+            Self::BoxStr => "Box<str>",
+            Self::String => "String",
+            Self::OsString => "OsString",
+            Self::PathBuf => "PathBuf",
+            Self::Vec => "Vec",
+            Self::VecDeque => "VecDeque",
+        }
     }
 
-    if is_std_hash_map(name, dwarf_qualified_name) {
-        return rust_hash_table_layout(&current.summary, HashTableKind::Map)
-            .map(ValueLayout::HashTable);
-    }
-
-    if is_std_hash_set(name, dwarf_qualified_name) {
-        return rust_hash_table_layout(&current.summary, HashTableKind::Set)
-            .map(ValueLayout::HashTable);
-    }
-
-    if is_std_rc(name, dwarf_qualified_name) {
-        let pointee_is_str = has_first_generic_argument(name, "Rc", "str")
-            || dwarf_qualified_name
-                .is_some_and(|name| has_first_generic_argument(name, "Rc", "str"));
-        return rust_reference_counted_layout(&current.summary, "Rc", "value", pointee_is_str)
-            .map(ValueLayout::CompositeStruct);
-    }
-
-    if is_std_arc(name, dwarf_qualified_name) {
-        let pointee_is_str = has_first_generic_argument(name, "Arc", "str")
-            || dwarf_qualified_name
-                .is_some_and(|name| has_first_generic_argument(name, "Arc", "str"));
-        return rust_reference_counted_layout(&current.summary, "Arc", "data", pointee_is_str)
-            .map(ValueLayout::CompositeStruct);
-    }
-
-    if is_std_ref(name, dwarf_qualified_name) || is_std_ref_mut(name, dwarf_qualified_name) {
-        return rust_ref_layout(&current.summary).map(ValueLayout::CompositeStruct);
-    }
-
-    if is_std_ref_cell(name, dwarf_qualified_name) {
-        return rust_ref_cell_layout(&current.summary).map(ValueLayout::ProjectedStruct);
-    }
-
-    if is_std_cell(name, dwarf_qualified_name) {
-        return rust_cell_value_path(&current.summary).map(|value_path| {
-            ValueLayout::ProjectedValue {
-                value_path,
-                presentation: ProjectedValuePresentation::SingleField {
-                    type_name: "Cell",
-                    field_name: "value",
-                },
+    fn resolve(self, root: &TypeInfo) -> Option<ValueLayout> {
+        let layout = match self {
+            Self::BTreeMap => {
+                return rust_btree_layout(root, BTreeKind::Map).map(ValueLayout::BTree)
             }
-        });
-    }
-
-    if is_std_nonzero(name, dwarf_qualified_name) {
-        return rust_nonzero_value_path(&current.summary).map(|value_path| {
-            ValueLayout::ProjectedValue {
-                value_path,
-                presentation: ProjectedValuePresentation::Transparent,
+            Self::BTreeSet => {
+                return rust_btree_layout(root, BTreeKind::Set).map(ValueLayout::BTree)
             }
-        });
+            Self::HashMap => {
+                return rust_hash_table_layout(root, HashTableKind::Map)
+                    .map(ValueLayout::HashTable);
+            }
+            Self::HashSet => {
+                return rust_hash_table_layout(root, HashTableKind::Set)
+                    .map(ValueLayout::HashTable);
+            }
+            Self::Rc { pointee_is_str } => {
+                return rust_reference_counted_layout(root, "Rc", "value", pointee_is_str)
+                    .map(ValueLayout::CompositeStruct);
+            }
+            Self::Arc { pointee_is_str } => {
+                return rust_reference_counted_layout(root, "Arc", "data", pointee_is_str)
+                    .map(ValueLayout::CompositeStruct);
+            }
+            Self::Ref | Self::RefMut => {
+                return rust_ref_layout(root).map(ValueLayout::CompositeStruct);
+            }
+            Self::RefCell => return rust_ref_cell_layout(root).map(ValueLayout::ProjectedStruct),
+            Self::Cell => {
+                return rust_cell_value_path(root).map(|value_path| ValueLayout::ProjectedValue {
+                    value_path,
+                    presentation: ProjectedValuePresentation::SingleField {
+                        type_name: "Cell",
+                        field_name: "value",
+                    },
+                });
+            }
+            Self::NonZero => {
+                return rust_nonzero_value_path(root).map(|value_path| {
+                    ValueLayout::ProjectedValue {
+                        value_path,
+                        presentation: ProjectedValuePresentation::Transparent,
+                    }
+                });
+            }
+            Self::PathReference => validate_indirect_sequence_layout(
+                root,
+                field_path(&["data_ptr"]),
+                field_path(&["length"]),
+                IndirectSequenceKind::OpaqueByteString,
+            ),
+            Self::StrReference => validate_indirect_sequence_layout(
+                root,
+                field_path(&["data_ptr"]),
+                field_path(&["length"]),
+                IndirectSequenceKind::Utf8String,
+            ),
+            Self::SliceReference => validate_indirect_sequence_layout(
+                root,
+                field_path(&["data_ptr"]),
+                field_path(&["length"]),
+                IndirectSequenceKind::PointerTarget,
+            ),
+            Self::BoxStr => validate_indirect_sequence_layout(
+                root,
+                field_path(&["data_ptr"]),
+                field_path(&["length"]),
+                IndirectSequenceKind::Utf8String,
+            ),
+            Self::String => rust_string_layout(root),
+            Self::OsString => rust_os_string_layout(root),
+            Self::PathBuf => rust_path_buf_layout(root),
+            Self::Vec => rust_vec_layout(root),
+            Self::VecDeque => rust_vec_deque_layout(root),
+        };
+
+        layout.map(ValueLayout::IndirectSequence)
     }
 
-    // rustc's bundled GDB printers have treated slice-like DWARF values as
-    // `data_ptr` plus `length` since Rust 1.0, without field-name compatibility
-    // branches. Older printers also removed explicit `'static` lifetimes before
-    // classifying references. These are rustc debuginfo conventions, not Rust
-    // ABI guarantees, so retain the language and structural checks around them.
-    // See rust-lang/rust's `src/etc/gdb_rust_pretty_printing.py` and
-    // `src/etc/gdb_providers.py`.
-    let sequence = if is_std_path_ref_name(name) {
-        // Rust's LLDB provider renders Path as its underlying platform bytes.
-        // GDB classifies the same identity but does not currently register a
-        // provider. Only current DWARF with explicit fat-pointer metadata can
-        // satisfy this validator; older Path* DIEs remain native DWARF.
-        validate_indirect_sequence_layout(
-            &current.summary,
-            field_path(&["data_ptr"]),
-            field_path(&["length"]),
-            IndirectSequenceKind::OpaqueByteString,
-        )
-    } else if matches!(
-        name.as_str(),
-        "&str" | "&mut str" | "&'static str" | "&'static mut str"
-    ) {
-        validate_indirect_sequence_layout(
-            &current.summary,
-            field_path(&["data_ptr"]),
-            field_path(&["length"]),
-            IndirectSequenceKind::Utf8String,
-        )
-    } else if is_slice_name(name) {
-        validate_indirect_sequence_layout(
-            &current.summary,
-            field_path(&["data_ptr"]),
-            field_path(&["length"]),
-            IndirectSequenceKind::PointerTarget,
-        )
-    } else if is_std_box_str(name, dwarf_qualified_name) {
-        // Rust 1.96 and older rust-gdb scripts had no Box<str> provider. The
-        // current provider has no version fallback and reads data_ptr/length.
-        // Accept the pre-allocator generic spelling when DWARF emits it, but
-        // derive every physical detail from the concrete DIE.
-        validate_indirect_sequence_layout(
-            &current.summary,
-            field_path(&["data_ptr"]),
-            field_path(&["length"]),
-            IndirectSequenceKind::Utf8String,
-        )
-    // rustc commonly stores only `String` in DW_AT_name and represents
-    // `alloc::string` with enclosing namespace DIEs. GDB presents the
-    // reconstructed qualified name to its Rust printer. Trust the equivalent
-    // TypeId-backed name from the analyzer for identity; the member checks
-    // below remain responsible only for version-specific physical layout.
-    } else if is_std_string(name, dwarf_qualified_name) {
-        rust_string_layout(&current.summary)
-    } else if is_std_os_string(name, dwarf_qualified_name) {
-        rust_os_string_layout(&current.summary)
-    } else if is_std_path_buf(name, dwarf_qualified_name) {
-        rust_path_buf_layout(&current.summary)
-    } else if is_std_vec(name, dwarf_qualified_name) {
-        rust_vec_layout(&current.summary)
-    } else if is_std_vec_deque(name, dwarf_qualified_name) {
-        rust_vec_deque_layout(&current.summary)
-    } else {
-        None
-    };
-
-    sequence.map(ValueLayout::IndirectSequence)
+    fn layout_rejection_reason(self) -> &'static str {
+        match self {
+            Self::BTreeMap | Self::BTreeSet => concat!(
+                "expected non-overlapping `root` and unsigned 4/8-byte `length` ",
+                "members in the DWARF-described B-Tree map wrapper"
+            ),
+            Self::HashMap | Self::HashSet => concat!(
+                "expected a supported std/hashbrown table path with byte control ",
+                "pointer, pointer-width unsigned length and mask, and ",
+                "non-overlapping metadata"
+            ),
+            Self::Rc { .. } | Self::Arc { .. } => concat!(
+                "expected `ptr.pointer` to resolve to a supported thin or fat ",
+                "allocation pointer whose target exposes value, strong, and weak ",
+                "members with DWARF-derived widths"
+            ),
+            Self::Ref | Self::RefMut => concat!(
+                "expected non-overlapping `value` and `borrow` wrappers with ",
+                "matching 4/8-byte pointers and the rust-gdb borrow-state path"
+            ),
+            Self::RefCell => concat!(
+                "expected non-overlapping `value` and signed `borrow` projections ",
+                "within the root, with a supported 1/2/4/8/16-byte borrow width"
+            ),
+            Self::Cell => concat!(
+                "expected two single-member wrappers ending in a known DWARF ",
+                "value whose range is contained in the root"
+            ),
+            Self::NonZero => concat!(
+                "expected one or two single-member wrappers ending in a nonzero-width ",
+                "signed or unsigned DWARF integer contained in the root"
+            ),
+            Self::PathReference | Self::SliceReference => concat!(
+                "expected non-overlapping `data_ptr` and unsigned `length` members ",
+                "with equal nonzero DWARF widths and in-bounds ranges"
+            ),
+            Self::StrReference | Self::BoxStr => concat!(
+                "expected non-overlapping `data_ptr` and unsigned `length` members ",
+                "with equal nonzero widths and a one-byte unsigned pointer target"
+            ),
+            Self::String => concat!(
+                "expected `vec.buf[.inner].ptr` and `vec.len` through supported ",
+                "single-member pointer wrappers, with pointer-width unsigned ",
+                "length and a one-byte unsigned target"
+            ),
+            Self::OsString => concat!(
+                "expected a supported Unix or Windows OsString Vec path with ",
+                "pointer-width unsigned length and one-byte storage"
+            ),
+            Self::PathBuf => concat!(
+                "expected `inner` to contain a supported OsString Vec path with ",
+                "pointer-width unsigned length and one-byte storage"
+            ),
+            Self::Vec => concat!(
+                "expected `buf[.inner].ptr` and `len` through supported pointer ",
+                "wrappers, with equal nonzero pointer and unsigned length widths"
+            ),
+            Self::VecDeque => concat!(
+                "expected a supported head/len or tail/head ring layout with a ",
+                "DWARF pointer and non-overlapping pointer-width unsigned metadata"
+            ),
+        }
+    }
 }
 
 fn is_slice_name(name: &str) -> bool {
@@ -3171,6 +3338,13 @@ mod tests {
         });
 
         assert_eq!(resolve_value_layout(&current, None), None);
+        let ValueLayoutResolution::Rejected { adapter, reason } =
+            diagnose_value_layout(&current, None)
+        else {
+            panic!("recognized &str layout must report a rejection")
+        };
+        assert_eq!(adapter, "&str");
+        assert!(reason.contains("equal nonzero widths"));
     }
 
     #[test]
@@ -3243,6 +3417,13 @@ mod tests {
                 .offset,
             16
         );
+
+        let ValueLayoutResolution::Applied { adapter, .. } =
+            diagnose_value_layout(&current, Some("alloc::string::String"))
+        else {
+            panic!("valid std String layout must be applied")
+        };
+        assert_eq!(adapter, "String");
     }
 
     #[test]
@@ -3305,6 +3486,10 @@ mod tests {
         let current = rust_string_type("String", SourceLanguage::Rust, 8, true, true);
 
         assert_eq!(resolve_value_layout(&current, Some("app::String")), None);
+        assert_eq!(
+            diagnose_value_layout(&current, Some("app::String")),
+            ValueLayoutResolution::NotApplicable
+        );
     }
 
     #[test]

--- a/ghostscope-dwarf/src/lib.rs
+++ b/ghostscope-dwarf/src/lib.rs
@@ -51,10 +51,11 @@ pub use semantics::{
     ProjectedViewField, ProjectedViewFieldCapture, RegisterRecoveryPlan, ResolvedType,
     RingSequenceLength, RuntimeComputedExpr, RuntimeComputedKind, RustcVersion, SemanticType,
     SourceLanguage, SyntheticTypeKind, TypeIdentity, TypeLayoutError, TypeOrigin, TypeProjection,
-    TypeProjectionLayout, UnwindDiagnostic, UnwindDiagnosticKind, ValueCapturePlan, ValueReadPlan,
-    VariableAccessPath, VariableAccessSegment, VariableLoweringKind, VariableLoweringPlan,
-    VariableMaterialization, VariableMaterializationPlan, VariablePlan, VariableQueryDiagnostic,
-    VariableReadPlan, VisibleVariable, VisibleVariablesResult,
+    TypeProjectionLayout, UnwindDiagnostic, UnwindDiagnosticKind, ValueAdapterOutcome,
+    ValueAdapterReport, ValueAdapterStage, ValueCapturePlan, ValueReadPlan, VariableAccessPath,
+    VariableAccessSegment, VariableLoweringKind, VariableLoweringPlan, VariableMaterialization,
+    VariableMaterializationPlan, VariablePlan, VariableQueryDiagnostic, VariableReadPlan,
+    VisibleVariable, VisibleVariablesResult,
 };
 
 pub use semantics::{

--- a/ghostscope-dwarf/src/semantics/mod.rs
+++ b/ghostscope-dwarf/src/semantics/mod.rs
@@ -40,7 +40,7 @@ pub use unwind_plan::{
 pub use value::{
     BTreeArrayCapture, BTreeEdgesCapture, HashTableBucketSource, ProjectedValueRead,
     ProjectedValueStep, ProjectedViewField, ProjectedViewFieldCapture, RingSequenceLength,
-    ValueCapturePlan, ValueReadPlan,
+    ValueAdapterOutcome, ValueAdapterReport, ValueAdapterStage, ValueCapturePlan, ValueReadPlan,
 };
 pub(crate) use variable_plan::PlanError;
 pub use variable_plan::{

--- a/ghostscope-dwarf/src/semantics/value.rs
+++ b/ghostscope-dwarf/src/semantics/value.rs
@@ -1,7 +1,7 @@
 //! Semantic capture plans for values whose source-language meaning is not
 //! represented by their physical DWARF aggregate alone.
 
-use super::TypeProjection;
+use super::{ProducerInfo, RustcVersion, SourceLanguage, TypeProjection};
 use ghostscope_protocol::ValuePresentation;
 
 /// A language-selected presentation and the physical reads needed to produce
@@ -10,6 +10,46 @@ use ghostscope_protocol::ValuePresentation;
 pub struct ValueReadPlan {
     pub presentation: ValuePresentation,
     pub capture: ValueCapturePlan,
+}
+
+/// Stage at which a recognized source-language value adapter was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueAdapterStage {
+    /// The root type did not satisfy the adapter's physical DWARF constraints.
+    LayoutValidation,
+    /// The root layout was valid, but dependent DWARF could not form a plan.
+    ReadPlanConstruction,
+}
+
+/// Result of selecting and constructing a source-language value adapter.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueAdapterOutcome {
+    /// The type is outside every known adapter identity.
+    NotApplicable,
+    /// The adapter was fully validated and produced a capture plan.
+    Applied { plan: Box<ValueReadPlan> },
+    /// The type identity matched, but its target DWARF was insufficient.
+    Rejected {
+        stage: ValueAdapterStage,
+        reason: String,
+    },
+}
+
+/// Structured explanation of source-language value adapter selection.
+///
+/// Producer information is diagnostic metadata only. An adapter is applied
+/// only after the concrete target DWARF satisfies its identity and layout
+/// constraints.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValueAdapterReport {
+    pub source_language: SourceLanguage,
+    pub type_name: String,
+    pub qualified_type_name: Option<String>,
+    pub adapter: Option<String>,
+    pub producer: Option<ProducerInfo>,
+    pub rustc_version: Option<RustcVersion>,
+    pub dwarf_version: Option<u16>,
+    pub outcome: ValueAdapterOutcome,
 }
 
 /// Runtime source of a ring sequence's logical element count.

--- a/ghostscope-ui/tests/ansi_color_test.rs
+++ b/ghostscope-ui/tests/ansi_color_test.rs
@@ -153,3 +153,40 @@ fn test_trace_results_mixed_colors() {
         "Expected red color for 1 failed, got: {result}"
     );
 }
+
+#[test]
+fn test_trace_results_preserve_multiline_failure_diagnostics() {
+    let emoji_config = EmojiConfig::new(false);
+    let error = concat!(
+        "Variable 'value' has no concrete DWARF size\n\n",
+        "Rust value adapter diagnostic:\n",
+        "  adapter: String\n",
+        "  rejected at: layout-validation",
+    );
+    let compilation_details = ScriptCompilationDetails {
+        total_count: 1,
+        success_count: 0,
+        failed_count: 1,
+        results: vec![ScriptExecutionResult {
+            target_name: "observe_value".to_string(),
+            binary_path: "/path/to/binary".to_string(),
+            pc_address: 0x1000,
+            status: ExecutionStatus::Failed(error.to_string()),
+            source_file: None,
+            source_line: None,
+            is_inline: None,
+        }],
+        trace_ids: vec![],
+    };
+
+    let result = ScriptEditor::format_compilation_results(
+        &compilation_details,
+        Some("trace observe_value"),
+        &emoji_config,
+    );
+
+    assert!(
+        result.contains(error),
+        "multiline diagnostic was lost: {result}"
+    );
+}

--- a/scripts/e2e/try_rust_adapter_diagnostic.sh
+++ b/scripts/e2e/try_rust_adapter_diagnostic.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-1.88.0}"
+BUILD_DIR="${CARGO_TARGET_DIR:-${TMPDIR:-/tmp}/ghostscope-diagnostic-target}"
+RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ghostscope-diagnostic.XXXXXX")"
+TARGET_BINARY="$RUN_DIR/rust-adapter-rejection"
+OUTPUT_FILE="$RUN_DIR/ghostscope-output.log"
+TARGET_PID=""
+
+cleanup() {
+  if [[ -n "$TARGET_PID" ]]; then
+    kill "$TARGET_PID" 2>/dev/null || true
+    wait "$TARGET_PID" 2>/dev/null || true
+  fi
+  rm -rf "$RUN_DIR"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "rustup is required to compile the Rust fixture" >&2
+  exit 1
+fi
+
+if [[ "${GHOSTSCOPE_NO_SUDO:-0}" != "1" ]] \
+  && [[ "$(id -u)" -ne 0 ]] \
+  && ! command -v sudo >/dev/null 2>&1; then
+  echo "sudo is required unless GHOSTSCOPE_NO_SUDO=1 is set" >&2
+  exit 1
+fi
+
+export CARGO_TARGET_DIR="$BUILD_DIR"
+
+echo "Building GhostScope in $BUILD_DIR"
+cargo build \
+  --manifest-path "$REPO_DIR/Cargo.toml" \
+  -p ghostscope \
+  --all-features
+
+echo "Compiling the rejection fixture with Rust $RUST_TOOLCHAIN"
+rustup run "$RUST_TOOLCHAIN" rustc \
+  --edition=2018 \
+  -g \
+  -C opt-level=0 \
+  -C link-dead-code \
+  "$REPO_DIR/e2e-tests/tests/fixtures/rust_adapter_rejection_program/alloc.rs" \
+  -o "$TARGET_BINARY"
+
+"$TARGET_BINARY" &
+TARGET_PID=$!
+sleep 0.3
+if ! kill -0 "$TARGET_PID" 2>/dev/null; then
+  echo "the Rust fixture exited before GhostScope started" >&2
+  exit 1
+fi
+
+GHOSTSCOPE=("$BUILD_DIR/debug/ghostscope")
+if [[ "${GHOSTSCOPE_NO_SUDO:-0}" != "1" ]] && [[ "$(id -u)" -ne 0 ]]; then
+  GHOSTSCOPE=(sudo "${GHOSTSCOPE[@]}")
+fi
+
+TRACE_SCRIPT='trace observe_adapter_rejection {
+    print "value={}", G_REJECTED_STRING;
+}'
+
+echo "Running GhostScope against target PID $TARGET_PID"
+set +e
+"${GHOSTSCOPE[@]}" \
+  -p "$TARGET_PID" \
+  --no-log \
+  --no-status \
+  -s "$TRACE_SCRIPT" \
+  2>&1 | tee "$OUTPUT_FILE"
+GHOSTSCOPE_STATUS=${PIPESTATUS[0]}
+set -e
+
+if [[ "$GHOSTSCOPE_STATUS" -eq 0 ]]; then
+  echo "GhostScope unexpectedly accepted the rejected fixture" >&2
+  exit 1
+fi
+
+if ! grep -Fq \
+  "Rust value adapter diagnostic (ordinary DWARF fallback also failed):" \
+  "$OUTPUT_FILE"; then
+  echo "GhostScope failed without the expected adapter diagnostic" >&2
+  exit 1
+fi
+
+echo
+echo "Rust adapter rejection diagnostic reproduced successfully."


### PR DESCRIPTION
## Summary

- expose structured Rust value-adapter diagnostics
- preserve rejection context when ordinary DWARF fallback also fails
- add CLI/TUI coverage and a one-command reproduction script

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- compiler and UI tests
- targeted CLI e2e