### PR TITLE
refactor: extract language-neutral value adapter core

### DIFF
--- a/e2e-tests/tests/common/runner.rs
+++ b/e2e-tests/tests/common/runner.rs
@@ -14,7 +14,10 @@
 use super::sandbox::SandboxHandle;
 use super::targets::ensure_target_binary_ready_for_default_sandbox;
 use super::targets::TargetHandle;
-use super::termination::{terminate_tokio_child_gracefully, GRACEFUL_TERMINATION_TIMEOUT};
+use super::termination::{
+    terminate_tokio_child_with_escalation, FORCEFUL_TERMINATION_TIMEOUT,
+    GRACEFUL_TERMINATION_TIMEOUT,
+};
 use anyhow::{Context, Result};
 use ghostscope_process::is_shared_object;
 use std::env;
@@ -39,7 +42,9 @@ const GHOSTSCOPE_PID_BOOTSTRAP_PREFIX: &str = "__GHOSTSCOPE_PID__ ";
 const GHOSTSCOPE_READY_MARKER: &str = "__GHOSTSCOPE_READY__";
 const CHILD_CONTAINER_TIMEOUT_SLACK_SECS: u64 = 45;
 const CHILD_CONTAINER_POST_READY_CALLBACK_SLACK_SECS: u64 = 45;
-const CONTAINER_TOPOLOGY_SETUP_SLACK_SECS: u64 = 10;
+// CI commonly starts four BPF-heavy tests together. Leave enough headroom for
+// their verifier work before treating a missing ready marker as a stalled load.
+const CONTAINER_TOPOLOGY_SETUP_SLACK_SECS: u64 = 30;
 
 pub struct GhostscopeRunner {
     script_content: String,
@@ -56,6 +61,7 @@ pub struct GhostscopeRunner {
     sandbox: Option<SandboxHandle>,
     config_content: Option<String>,
     extra_args: Vec<OsString>,
+    startup_timeout_secs: Option<u64>,
 }
 
 impl Default for GhostscopeRunner {
@@ -75,6 +81,7 @@ impl Default for GhostscopeRunner {
             sandbox: None,
             config_content: None,
             extra_args: Vec::new(),
+            startup_timeout_secs: None,
         }
     }
 }
@@ -114,6 +121,12 @@ impl GhostscopeRunner {
 
     pub fn timeout_secs(mut self, secs: u64) -> Self {
         self.timeout_secs = secs;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn startup_timeout_secs(mut self, secs: u64) -> Self {
+        self.startup_timeout_secs = Some(secs);
         self
     }
 
@@ -421,22 +434,31 @@ impl GhostscopeRunner {
                             setup_timeout_secs
                         );
                     }
-                    if let Some(pid) = managed_ghostscope_pid {
-                        sandbox.terminate_pid(pid).with_context(|| {
-                            format!(
-                                "failed to terminate startup-stalled GhostScope pid {} in {}",
-                                pid,
-                                sandbox.label()
-                            )
-                        })?;
-                    } else {
-                        let _ = terminate_tokio_child_gracefully(
-                            &mut child,
-                            "ghostscope runner child",
-                            GRACEFUL_TERMINATION_TIMEOUT,
-                        )
-                        .await?;
-                    }
+                    let termination_result = terminate_runner_process(
+                        &sandbox,
+                        managed_ghostscope_pid,
+                        &mut child,
+                        "startup-stalled GhostScope",
+                    )
+                    .await;
+                    finish_output_readers(stdout_task, stderr_task).await;
+                    drain_output_channel(
+                        &mut output_rx,
+                        &mut stdout_content,
+                        &mut stderr_content,
+                        ready_marker.as_deref(),
+                        runner_debug,
+                        &sandbox,
+                    );
+                    termination_result?;
+                    anyhow::bail!(
+                        "timed out waiting for ready marker '{}' from {} after {}s. stderr={} stdout={}",
+                        ready_marker.as_deref().unwrap_or("<none>"),
+                        sandbox.label(),
+                        setup_timeout_secs,
+                        stderr_content,
+                        stdout_content
+                    );
                 }
             }
         }
@@ -473,26 +495,29 @@ impl GhostscopeRunner {
                                 post_ready_callback_timeout_secs
                             );
                         }
-                        if let Some(pid) = managed_ghostscope_pid {
-                            sandbox.terminate_pid(pid).with_context(|| {
-                                format!(
-                                    "failed to terminate GhostScope pid {} after post-ready callback timeout in {}",
-                                    pid,
-                                    sandbox.label()
-                                )
-                            })?;
-                        } else {
-                            let _ = terminate_tokio_child_gracefully(
-                                &mut child,
-                                "ghostscope runner child",
-                                GRACEFUL_TERMINATION_TIMEOUT,
-                            )
-                            .await?;
-                        }
+                        let termination_result = terminate_runner_process(
+                            &sandbox,
+                            managed_ghostscope_pid,
+                            &mut child,
+                            "GhostScope after post-ready callback timeout",
+                        )
+                        .await;
+                        finish_output_readers(stdout_task, stderr_task).await;
+                        drain_output_channel(
+                            &mut output_rx,
+                            &mut stdout_content,
+                            &mut stderr_content,
+                            ready_marker.as_deref(),
+                            runner_debug,
+                            &sandbox,
+                        );
+                        termination_result?;
                         anyhow::bail!(
-                            "timed out waiting for post-ready callback after ready marker '{}' in {}",
+                            "timed out waiting for post-ready callback after ready marker '{}' in {}. stderr={} stdout={}",
                             ready_marker.as_deref().unwrap_or("<none>"),
-                            sandbox.label()
+                            sandbox.label(),
+                            stderr_content,
+                            stdout_content
                         );
                     }
                 }
@@ -549,45 +574,29 @@ impl GhostscopeRunner {
             false
         };
 
-        let mut exit_code = match child.try_wait() {
-            Ok(Some(status)) => status.code().unwrap_or(-1),
+        let exit_code_result = match child.try_wait() {
+            Ok(Some(status)) => Ok(status.code().unwrap_or(-1)),
             _ => {
                 if timed_out {
-                    if let Some(pid) = managed_ghostscope_pid {
-                        sandbox.terminate_pid(pid).with_context(|| {
-                            format!(
-                                "failed to terminate timed-out GhostScope pid {} in {}",
-                                pid,
-                                sandbox.label()
-                            )
-                        })?;
-                        match timeout(GRACEFUL_TERMINATION_TIMEOUT, child.wait()).await {
-                            Ok(Ok(status)) => status.code().unwrap_or(-1),
-                            _ => -1,
-                        }
-                    } else {
-                        match terminate_tokio_child_gracefully(
-                            &mut child,
-                            "ghostscope runner child",
-                            GRACEFUL_TERMINATION_TIMEOUT,
-                        )
-                        .await?
-                        {
-                            Some(status) => status.code().unwrap_or(-1),
-                            None => -1,
-                        }
-                    }
+                    terminate_runner_process(
+                        &sandbox,
+                        managed_ghostscope_pid,
+                        &mut child,
+                        "timed-out GhostScope",
+                    )
+                    .await
+                    .map(|status| status.and_then(|status| status.code()).unwrap_or(-1))
                 } else {
                     match timeout(Duration::from_secs(2), child.wait()).await {
-                        Ok(Ok(status)) => status.code().unwrap_or(-1),
-                        _ => -1,
+                        Ok(Ok(status)) => Ok(status.code().unwrap_or(-1)),
+                        Ok(Err(err)) => Err(err.into()),
+                        Err(_) => Ok(-1),
                     }
                 }
             }
         };
 
-        let _ = stdout_task.await;
-        let _ = stderr_task.await;
+        finish_output_readers(stdout_task, stderr_task).await;
         drain_output_channel(
             &mut output_rx,
             &mut stdout_content,
@@ -597,6 +606,7 @@ impl GhostscopeRunner {
             &sandbox,
         );
 
+        let mut exit_code = exit_code_result?;
         if exit_code == -1 && (!stdout_content.is_empty() || !stderr_content.is_empty()) {
             exit_code = 0;
         }
@@ -653,6 +663,10 @@ impl GhostscopeRunner {
     }
 
     fn setup_timeout_secs(&self) -> u64 {
+        if let Some(timeout_secs) = self.startup_timeout_secs {
+            return timeout_secs;
+        }
+
         let mut timeout_secs = self.timeout_secs.max(15);
         let docker_topology = [ENV_E2E_GHOSTSCOPE_SANDBOX, ENV_E2E_TARGET_SANDBOX]
             .into_iter()
@@ -729,6 +743,72 @@ where
             }
         }
     })
+}
+
+async fn terminate_runner_process(
+    sandbox: &SandboxHandle,
+    managed_pid: Option<u32>,
+    child: &mut tokio::process::Child,
+    label: &str,
+) -> Result<Option<std::process::ExitStatus>> {
+    let managed_result = managed_pid
+        .map(|pid| {
+            sandbox.terminate_pid(pid).with_context(|| {
+                format!(
+                    "failed to terminate {label} pid {} in {}",
+                    pid,
+                    sandbox.label()
+                )
+            })
+        })
+        .transpose();
+    let child_result = if managed_pid.is_some() {
+        match timeout(GRACEFUL_TERMINATION_TIMEOUT, child.wait()).await {
+            Ok(result) => result.map(Some).map_err(Into::into),
+            Err(_) => {
+                terminate_tokio_child_with_escalation(
+                    child,
+                    "ghostscope runner child",
+                    GRACEFUL_TERMINATION_TIMEOUT,
+                    FORCEFUL_TERMINATION_TIMEOUT,
+                )
+                .await
+            }
+        }
+    } else {
+        terminate_tokio_child_with_escalation(
+            child,
+            "ghostscope runner child",
+            GRACEFUL_TERMINATION_TIMEOUT,
+            FORCEFUL_TERMINATION_TIMEOUT,
+        )
+        .await
+    };
+
+    match (managed_result, child_result) {
+        (Ok(_), Ok(status)) => Ok(status),
+        (Err(err), Ok(_)) | (Ok(_), Err(err)) => Err(err),
+        (Err(managed_err), Err(child_err)) => {
+            anyhow::bail!("{managed_err:#}; host runner process cleanup also failed: {child_err:#}")
+        }
+    }
+}
+
+async fn finish_output_readers(stdout_task: JoinHandle<()>, stderr_task: JoinHandle<()>) {
+    tokio::join!(
+        finish_output_reader(stdout_task),
+        finish_output_reader(stderr_task)
+    );
+}
+
+async fn finish_output_reader(mut task: JoinHandle<()>) {
+    if timeout(FORCEFUL_TERMINATION_TIMEOUT, &mut task)
+        .await
+        .is_err()
+    {
+        task.abort();
+        let _ = task.await;
+    }
 }
 
 fn handle_output_line(

--- a/e2e-tests/tests/common/termination.rs
+++ b/e2e-tests/tests/common/termination.rs
@@ -100,10 +100,11 @@ pub(crate) fn terminate_std_child_gracefully(
     }
 }
 
-pub(crate) async fn terminate_tokio_child_gracefully(
+pub(crate) async fn terminate_tokio_child_with_escalation(
     child: &mut tokio::process::Child,
     label: &str,
-    wait_timeout: Duration,
+    graceful_timeout: Duration,
+    forceful_timeout: Duration,
 ) -> anyhow::Result<Option<std::process::ExitStatus>> {
     if let Some(status) = child.try_wait()? {
         return Ok(Some(status));
@@ -114,7 +115,15 @@ pub(crate) async fn terminate_tokio_child_gracefully(
         .context("child process does not have an OS pid for SIGTERM")?;
     send_sigterm(pid, label)?;
 
-    match tokio::time::timeout(wait_timeout, child.wait()).await {
+    match tokio::time::timeout(graceful_timeout, child.wait()).await {
+        Ok(result) => return result.map(Some).map_err(Into::into),
+        Err(_) => {}
+    }
+
+    child
+        .start_kill()
+        .with_context(|| format!("failed to send SIGKILL to {label} pid {pid}"))?;
+    match tokio::time::timeout(forceful_timeout, child.wait()).await {
         Ok(result) => result.map(Some).map_err(Into::into),
         Err(_) => Ok(None),
     }

--- a/e2e-tests/tests/runner_lifecycle.rs
+++ b/e2e-tests/tests/runner_lifecycle.rs
@@ -1,0 +1,62 @@
+mod common;
+
+use anyhow::Context;
+use common::runner::GhostscopeRunner;
+use common::sandbox::SandboxHandle;
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::time::{timeout, Instant};
+
+#[tokio::test]
+async fn startup_timeout_does_not_wait_for_inherited_output_pipes() -> anyhow::Result<()> {
+    let temp_dir = tempdir()?;
+    let fake_ghostscope = temp_dir.path().join("fake-ghostscope");
+    fs::write(
+        &fake_ghostscope,
+        "#!/bin/bash\ntrap '' TERM\nsleep 10 &\nwait\n",
+    )?;
+    let mut permissions = fs::metadata(&fake_ghostscope)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_ghostscope, permissions)?;
+
+    let previous_bin = env::var_os("GHOSTSCOPE_TEST_BIN");
+    env::set_var("GHOSTSCOPE_TEST_BIN", &fake_ghostscope);
+    let _restore_bin = scopeguard::guard(previous_bin, |previous_bin| {
+        if let Some(previous_bin) = previous_bin {
+            env::set_var("GHOSTSCOPE_TEST_BIN", previous_bin);
+        } else {
+            env::remove_var("GHOSTSCOPE_TEST_BIN");
+        }
+    });
+
+    let sandbox = SandboxHandle::host();
+    let started = Instant::now();
+    let result = timeout(
+        Duration::from_secs(8),
+        GhostscopeRunner::new()
+            .with_script("trace unused {}")
+            .with_pid(std::process::id())
+            .in_sandbox(&sandbox)
+            .startup_timeout_secs(1)
+            .run(),
+    )
+    .await
+    .context("runner hung while cleaning up a startup timeout")?;
+
+    let error = result.expect_err("fake GhostScope should time out before its ready marker");
+    assert!(
+        error
+            .to_string()
+            .contains("timed out waiting for ready marker"),
+        "unexpected startup timeout error: {error:#}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(8),
+        "startup timeout cleanup exceeded its bounded deadline"
+    );
+
+    Ok(())
+}

--- a/ghostscope-dwarf/src/analyzer/type_context.rs
+++ b/ghostscope-dwarf/src/analyzer/type_context.rs
@@ -2,10 +2,9 @@ use super::DwarfAnalyzer;
 use crate::{
     indexable_element_layout, member_layout, semantics::PlanError, strip_type_aliases,
     CompilationUnitMetadata, CuId, MemberLayout, ModuleId, PcContext, ProjectedValueRead,
-    ProjectedValueStep, ProjectedViewField, ProjectedViewFieldCapture, ResolvedType, Result,
-    SemanticType, StructMember, TypeId, TypeIdentity, TypeInfo, TypeLayoutError, TypeOrigin,
-    TypeProjection, TypeProjectionLayout, ValueAdapterOutcome, ValueAdapterReport,
-    ValueAdapterStage, ValueCapturePlan, ValueReadPlan, VariableAccessSegment, VariableReadPlan,
+    ProjectedValueStep, ResolvedType, Result, SemanticType, TypeId, TypeIdentity, TypeInfo,
+    TypeLayoutError, TypeOrigin, TypeProjection, TypeProjectionLayout, ValueAdapterOutcome,
+    ValueAdapterReport, ValueAdapterStage, ValueReadPlan, VariableAccessSegment, VariableReadPlan,
 };
 use std::path::Path;
 
@@ -295,6 +294,7 @@ impl DwarfAnalyzer {
                 tracing::debug!(
                     target: "ghostscope_dwarf::value_adapter",
                     adapter = report.adapter.as_deref().unwrap_or("unknown"),
+                    source_language = ?report.source_language,
                     type_name = report.type_name,
                     qualified_type_name = ?report.qualified_type_name,
                     producer = ?report.producer.as_ref().map(|producer| producer.raw.as_str()),
@@ -302,7 +302,7 @@ impl DwarfAnalyzer {
                     dwarf_version = ?report.dwarf_version,
                     ?stage,
                     %reason,
-                    "Rust value adapter rejected target DWARF; using DWARF presentation"
+                    "Source-language value adapter rejected target DWARF; using DWARF presentation"
                 );
                 Ok(None)
             }
@@ -358,7 +358,12 @@ impl DwarfAnalyzer {
             }
         };
         report.adapter = Some(adapter.to_string());
-        report.outcome = match self.build_value_read_plan(current, type_module_path, layout)? {
+        report.outcome = match crate::language::build_value_read_plan(
+            self,
+            current,
+            type_module_path,
+            layout,
+        )? {
             Some(plan) => ValueAdapterOutcome::Applied {
                 plan: Box::new(plan),
             },
@@ -373,297 +378,6 @@ impl DwarfAnalyzer {
             },
         };
         Ok(report)
-    }
-
-    fn build_value_read_plan(
-        &self,
-        current: &ResolvedType,
-        type_module_path: Option<&Path>,
-        layout: crate::language::ValueLayout,
-    ) -> Result<Option<ValueReadPlan>> {
-        let layout = match layout {
-            crate::language::ValueLayout::ProjectedValue {
-                value_path,
-                presentation,
-            } => {
-                let value =
-                    self.project_resolved_member_path(current, &value_path, type_module_path)?;
-                let presentation = match presentation {
-                    crate::language::ProjectedValuePresentation::Transparent => {
-                        crate::ValuePresentation::Dwarf
-                    }
-                    crate::language::ProjectedValuePresentation::SingleField {
-                        type_name,
-                        field_name,
-                    } => crate::ValuePresentation::SingleField {
-                        type_name: type_name.to_string(),
-                        field_name: field_name.to_string(),
-                    },
-                };
-                return Ok(Some(ValueReadPlan {
-                    presentation,
-                    capture: ValueCapturePlan::ProjectedValue { value },
-                }));
-            }
-            crate::language::ValueLayout::ProjectedStruct(layout) => {
-                let root_size = current.summary.size();
-                let mut members = Vec::with_capacity(layout.fields.len());
-                for field in layout.fields {
-                    let projected = self.project_resolved_member_path(
-                        current,
-                        &field.value_path,
-                        type_module_path,
-                    )?;
-                    let TypeProjectionLayout::Member { offset } = projected.layout else {
-                        return Err(anyhow::anyhow!(
-                            "semantic struct field produced a non-member projection"
-                        ));
-                    };
-                    let member_type = projected.resolved_type.summary;
-                    let member_end = offset
-                        .checked_add(member_type.size())
-                        .ok_or_else(|| anyhow::anyhow!("semantic struct field end overflow"))?;
-                    if member_end > root_size {
-                        return Err(anyhow::anyhow!(
-                            "semantic struct field '{}' exceeds its DWARF root",
-                            field.name
-                        ));
-                    }
-                    members.push(StructMember {
-                        name: field.name.to_string(),
-                        member_type,
-                        offset,
-                        bit_offset: None,
-                        bit_size: None,
-                    });
-                }
-                let presentation = projected_struct_presentation(layout.presentation);
-                let output_type = TypeInfo::StructType {
-                    name: layout.type_name.to_string(),
-                    size: root_size,
-                    members,
-                };
-                return Ok(Some(ValueReadPlan {
-                    presentation,
-                    capture: ValueCapturePlan::InlineView { output_type },
-                }));
-            }
-            crate::language::ValueLayout::CompositeStruct(layout) => {
-                let mut members = Vec::with_capacity(layout.fields.len());
-                let mut fields = Vec::with_capacity(layout.fields.len());
-                let mut output_size = 0u64;
-                for field in layout.fields {
-                    if members
-                        .iter()
-                        .any(|member: &StructMember| member.name == field.name)
-                    {
-                        return Err(anyhow::anyhow!(
-                            "duplicate semantic struct field '{}'",
-                            field.name
-                        ));
-                    }
-                    let value = self.project_resolved_value_path(
-                        current,
-                        &field.value_path,
-                        type_module_path,
-                        matches!(
-                            field.capture,
-                            crate::language::CompositeStructFieldCapture::Address
-                        ),
-                    )?;
-                    let Some(value) = value else {
-                        return Ok(None);
-                    };
-                    let (member_type, capture) = match field.capture {
-                        crate::language::CompositeStructFieldCapture::Value(requirement) => {
-                            if !projected_value_satisfies(requirement, &value) {
-                                return Ok(None);
-                            }
-                            (
-                                value.resolved_type.summary.clone(),
-                                ProjectedViewFieldCapture::Value,
-                            )
-                        }
-                        crate::language::CompositeStructFieldCapture::Address => {
-                            let Some(member_type) = projected_address_type(&value) else {
-                                return Ok(None);
-                            };
-                            (member_type, ProjectedViewFieldCapture::Address)
-                        }
-                    };
-                    let output_offset = output_size;
-                    output_size = output_size
-                        .checked_add(member_type.size())
-                        .ok_or_else(|| anyhow::anyhow!("semantic struct size overflow"))?;
-                    members.push(StructMember {
-                        name: field.name.to_string(),
-                        member_type,
-                        offset: output_offset,
-                        bit_offset: None,
-                        bit_size: None,
-                    });
-                    fields.push(ProjectedViewField {
-                        output_offset,
-                        value,
-                        capture,
-                    });
-                }
-                let output_type = TypeInfo::StructType {
-                    name: layout.type_name.to_string(),
-                    size: output_size,
-                    members,
-                };
-                return Ok(Some(ValueReadPlan {
-                    presentation: projected_struct_presentation(layout.presentation),
-                    capture: ValueCapturePlan::ProjectedView {
-                        output_type,
-                        fields,
-                    },
-                }));
-            }
-            crate::language::ValueLayout::BTree(layout) => {
-                return crate::language::btree_value_read_plan(
-                    self,
-                    current,
-                    layout,
-                    type_module_path,
-                );
-            }
-            crate::language::ValueLayout::HashTable(layout) => {
-                return crate::language::hash_table_value_read_plan(
-                    self,
-                    current,
-                    layout,
-                    type_module_path,
-                );
-            }
-            crate::language::ValueLayout::IndirectSequence(layout) => layout,
-        };
-        let data =
-            self.project_resolved_member_path(current, &layout.data_path, type_module_path)?;
-
-        let (presentation, element_stride) = match layout.kind {
-            crate::language::IndirectSequenceKind::Utf8String => {
-                (crate::ValuePresentation::Utf8String, None)
-            }
-            crate::language::IndirectSequenceKind::ByteString
-            | crate::language::IndirectSequenceKind::OpaqueByteString => {
-                (crate::ValuePresentation::ByteString, None)
-            }
-            crate::language::IndirectSequenceKind::PointerTarget => {
-                let TypeInfo::PointerType { target_type, .. } =
-                    strip_type_aliases(&data.resolved_type.summary)
-                else {
-                    return Ok(None);
-                };
-                let element_type = target_type.as_ref().clone();
-                if matches!(
-                    strip_type_aliases(&element_type),
-                    TypeInfo::UnknownType { .. } | TypeInfo::OptimizedOut { .. }
-                ) {
-                    return Ok(None);
-                }
-                let element_stride = element_type.size();
-                (
-                    crate::ValuePresentation::Sequence {
-                        element_type: Box::new(element_type),
-                        element_stride,
-                    },
-                    Some(element_stride),
-                )
-            }
-            crate::language::IndirectSequenceKind::TypeParameter { index } => {
-                let Some(type_id) = current.identity.layout_dwarf_id() else {
-                    return Ok(None);
-                };
-                let Some(element) = self.template_type_parameter(type_id, index)? else {
-                    return Ok(None);
-                };
-                if matches!(
-                    strip_type_aliases(&element.summary),
-                    TypeInfo::UnknownType { .. } | TypeInfo::OptimizedOut { .. }
-                ) {
-                    return Ok(None);
-                }
-                let element_stride = element.summary.size();
-                (
-                    crate::ValuePresentation::Sequence {
-                        element_type: Box::new(element.summary),
-                        element_stride,
-                    },
-                    Some(element_stride),
-                )
-            }
-        };
-
-        let capture = match layout.addressing {
-            crate::language::IndirectSequenceAddressing::Contiguous { length_path } => {
-                let length =
-                    self.project_resolved_member_path(current, &length_path, type_module_path)?;
-                match element_stride {
-                    Some(element_stride) => ValueCapturePlan::IndirectSequence {
-                        data,
-                        length,
-                        element_stride,
-                    },
-                    None => ValueCapturePlan::IndirectBytes { data, length },
-                }
-            }
-            crate::language::IndirectSequenceAddressing::Ring {
-                start_path,
-                length_path,
-                length_kind,
-                capacity_path,
-            } => {
-                let Some(element_stride) = element_stride else {
-                    return Ok(None);
-                };
-                let length =
-                    self.project_resolved_member_path(current, &length_path, type_module_path)?;
-                if element_stride == 0
-                    && matches!(
-                        length_kind,
-                        crate::language::RingSequenceLengthKind::Explicit
-                    )
-                {
-                    // Physical order is unobservable for zero-sized elements.
-                    // Avoid depending on a producer-specific capacity encoding.
-                    ValueCapturePlan::IndirectSequence {
-                        data,
-                        length,
-                        element_stride,
-                    }
-                } else {
-                    let start =
-                        self.project_resolved_member_path(current, &start_path, type_module_path)?;
-                    let capacity = self.project_resolved_member_path(
-                        current,
-                        &capacity_path,
-                        type_module_path,
-                    )?;
-                    let length = Box::new(match length_kind {
-                        crate::language::RingSequenceLengthKind::Explicit => {
-                            crate::RingSequenceLength::Explicit(length)
-                        }
-                        crate::language::RingSequenceLengthKind::End => {
-                            crate::RingSequenceLength::End(length)
-                        }
-                    });
-                    ValueCapturePlan::IndirectRingSequence {
-                        data,
-                        start,
-                        length,
-                        capacity,
-                        element_stride,
-                    }
-                }
-            }
-        };
-
-        Ok(Some(ValueReadPlan {
-            presentation,
-            capture,
-        }))
     }
 
     fn project_resolved_member_path(
@@ -972,7 +686,7 @@ impl DwarfAnalyzer {
     }
 }
 
-impl crate::language::RustPlanContext for DwarfAnalyzer {
+impl crate::language::ValueAdapterContext for DwarfAnalyzer {
     fn project_type(
         &self,
         current: &ResolvedType,
@@ -989,6 +703,16 @@ impl crate::language::RustPlanContext for DwarfAnalyzer {
         type_module_path: Option<&Path>,
     ) -> Result<TypeProjection> {
         self.project_resolved_member_path(current, path, type_module_path)
+    }
+
+    fn project_value_path(
+        &self,
+        current: &ResolvedType,
+        path: &[crate::language::ProjectedPathSegment],
+        type_module_path: Option<&Path>,
+        capture_address: bool,
+    ) -> Result<Option<ProjectedValueRead>> {
+        self.project_resolved_value_path(current, path, type_module_path, capture_address)
     }
 
     fn template_type_parameter(
@@ -1049,220 +773,5 @@ impl crate::language::RustPlanContext for DwarfAnalyzer {
             )));
         }
         Ok(None)
-    }
-}
-
-fn projected_struct_presentation(
-    presentation: crate::language::ProjectedStructPresentation,
-) -> crate::ValuePresentation {
-    match presentation {
-        crate::language::ProjectedStructPresentation::SignedState {
-            state_field,
-            non_negative_label,
-            negative_label,
-        } => crate::ValuePresentation::SignedStateStruct {
-            state_field: state_field.to_string(),
-            non_negative_label: non_negative_label.to_string(),
-            negative_label: negative_label.to_string(),
-        },
-        crate::language::ProjectedStructPresentation::ReferenceCounted {
-            strong_field,
-            weak_field,
-            implicit_weak,
-        } => crate::ValuePresentation::ReferenceCountedStruct {
-            strong_field: strong_field.to_string(),
-            weak_field: weak_field.to_string(),
-            implicit_weak,
-        },
-    }
-}
-
-fn projected_address_type(value: &ProjectedValueRead) -> Option<TypeInfo> {
-    if matches!(
-        strip_type_aliases(&value.resolved_type.summary),
-        TypeInfo::UnknownType { .. } | TypeInfo::OptimizedOut { .. }
-    ) {
-        return None;
-    }
-    let pointer_size = value.steps.iter().rev().find_map(|step| match step {
-        ProjectedValueStep::Dereference { pointer_size } => Some(*pointer_size),
-        ProjectedValueStep::Member { .. } => None,
-    })?;
-    matches!(pointer_size, 4 | 8).then(|| TypeInfo::PointerType {
-        target_type: Box::new(value.resolved_type.summary.clone()),
-        size: pointer_size,
-    })
-}
-
-fn projected_value_satisfies(
-    requirement: crate::language::ProjectedValueRequirement,
-    value: &ProjectedValueRead,
-) -> bool {
-    let value_type = strip_type_aliases(&value.resolved_type.summary);
-    match requirement {
-        crate::language::ProjectedValueRequirement::KnownSizedOrZst => match value_type {
-            TypeInfo::UnknownType { .. }
-            | TypeInfo::OptimizedOut { .. }
-            | TypeInfo::ArrayType {
-                total_size: None, ..
-            } => false,
-            TypeInfo::BaseType { name, size: 0, .. } => name == "()",
-            TypeInfo::StructType { size: 0, .. }
-            | TypeInfo::UnionType { size: 0, .. }
-            | TypeInfo::ArrayType {
-                total_size: Some(0),
-                ..
-            } => true,
-            type_info => type_info.size() > 0,
-        },
-        crate::language::ProjectedValueRequirement::SignedPointerSizedInteger => {
-            let TypeInfo::BaseType { size, encoding, .. } = value_type else {
-                return false;
-            };
-            let signed = *encoding == gimli::DW_ATE_signed.0 as u16
-                || *encoding == gimli::DW_ATE_signed_char.0 as u16;
-            let pointer_size = value.steps.iter().rev().find_map(|step| match step {
-                ProjectedValueStep::Dereference { pointer_size } => Some(*pointer_size),
-                ProjectedValueStep::Member { .. } => None,
-            });
-            signed && matches!(*size, 4 | 8) && pointer_size == Some(*size)
-        }
-        crate::language::ProjectedValueRequirement::UnsignedPointerSizedInteger => {
-            let TypeInfo::BaseType { size, encoding, .. } = value_type else {
-                return false;
-            };
-            let unsigned = *encoding == gimli::DW_ATE_unsigned.0 as u16
-                || *encoding == gimli::DW_ATE_unsigned_char.0 as u16;
-            let pointer_size = value.steps.iter().rev().find_map(|step| match step {
-                ProjectedValueStep::Dereference { pointer_size } => Some(*pointer_size),
-                ProjectedValueStep::Member { .. } => None,
-            });
-            unsigned && matches!(*size, 4 | 8) && pointer_size == Some(*size)
-        }
-    }
-}
-
-#[cfg(test)]
-mod projected_value_tests {
-    use super::*;
-
-    fn projected_value(summary: TypeInfo, pointer_size: Option<u64>) -> ProjectedValueRead {
-        let steps = pointer_size
-            .map(|pointer_size| ProjectedValueStep::Dereference { pointer_size })
-            .into_iter()
-            .collect();
-        ProjectedValueRead {
-            steps,
-            resolved_type: ResolvedType::new(summary, TypeIdentity::Unknown, None),
-        }
-    }
-
-    #[test]
-    fn known_sized_requirement_distinguishes_zst_from_unknown_layout() {
-        let requirement = crate::language::ProjectedValueRequirement::KnownSizedOrZst;
-        let unit = projected_value(
-            TypeInfo::BaseType {
-                name: "()".to_string(),
-                size: 0,
-                encoding: gimli::DW_ATE_unsigned.0 as u16,
-            },
-            Some(8),
-        );
-        let unknown = projected_value(
-            TypeInfo::UnknownType {
-                name: "T".to_string(),
-            },
-            Some(8),
-        );
-
-        assert!(projected_value_satisfies(requirement, &unit));
-        assert!(!projected_value_satisfies(requirement, &unknown));
-    }
-
-    #[test]
-    fn projected_address_uses_the_dwarf_pointer_width() {
-        let target = TypeInfo::ArrayType {
-            element_type: Box::new(TypeInfo::BaseType {
-                name: "u8".to_string(),
-                size: 1,
-                encoding: gimli::DW_ATE_unsigned.0 as u16,
-            }),
-            element_count: None,
-            total_size: None,
-        };
-        let value = projected_value(target.clone(), Some(8));
-        assert_eq!(
-            projected_address_type(&value),
-            Some(TypeInfo::PointerType {
-                target_type: Box::new(target),
-                size: 8,
-            })
-        );
-        assert_eq!(
-            projected_address_type(&projected_value(value.resolved_type.summary, None)),
-            None
-        );
-    }
-
-    #[test]
-    fn signed_state_requirement_uses_dwarf_encoding_and_pointer_width() {
-        let requirement = crate::language::ProjectedValueRequirement::SignedPointerSizedInteger;
-        let signed = |size, pointer_size| {
-            projected_value(
-                TypeInfo::BaseType {
-                    name: "isize".to_string(),
-                    size,
-                    encoding: gimli::DW_ATE_signed.0 as u16,
-                },
-                pointer_size,
-            )
-        };
-        assert!(projected_value_satisfies(requirement, &signed(8, Some(8))));
-        assert!(!projected_value_satisfies(requirement, &signed(4, Some(8))));
-        assert!(!projected_value_satisfies(requirement, &signed(8, None)));
-
-        let unsigned = projected_value(
-            TypeInfo::BaseType {
-                name: "usize".to_string(),
-                size: 8,
-                encoding: gimli::DW_ATE_unsigned.0 as u16,
-            },
-            Some(8),
-        );
-        assert!(!projected_value_satisfies(requirement, &unsigned));
-    }
-
-    #[test]
-    fn unsigned_counter_requirement_uses_dwarf_encoding_and_pointer_width() {
-        let requirement = crate::language::ProjectedValueRequirement::UnsignedPointerSizedInteger;
-        let unsigned = |size, pointer_size| {
-            projected_value(
-                TypeInfo::BaseType {
-                    name: "usize".to_string(),
-                    size,
-                    encoding: gimli::DW_ATE_unsigned.0 as u16,
-                },
-                pointer_size,
-            )
-        };
-        assert!(projected_value_satisfies(
-            requirement,
-            &unsigned(8, Some(8))
-        ));
-        assert!(!projected_value_satisfies(
-            requirement,
-            &unsigned(4, Some(8))
-        ));
-        assert!(!projected_value_satisfies(requirement, &unsigned(8, None)));
-
-        let signed = projected_value(
-            TypeInfo::BaseType {
-                name: "isize".to_string(),
-                size: 8,
-                encoding: gimli::DW_ATE_signed.0 as u16,
-            },
-            Some(8),
-        );
-        assert!(!projected_value_satisfies(requirement, &signed));
     }
 }

--- a/ghostscope-dwarf/src/language/adapter.rs
+++ b/ghostscope-dwarf/src/language/adapter.rs
@@ -1,0 +1,719 @@
+//! Language-neutral contracts for semantic value adapters.
+
+use crate::{
+    strip_type_aliases, MemberLayout, ProjectedValueRead, ProjectedValueStep, ProjectedViewField,
+    ProjectedViewFieldCapture, ResolvedType, Result, StructMember, TypeId, TypeInfo,
+    TypeProjection, TypeProjectionLayout, ValueCapturePlan, ValueReadPlan, VariableAccessSegment,
+};
+use std::path::Path;
+
+/// Result of asking one source-language adapter for a semantic value layout.
+///
+/// Recognition establishes only a candidate type identity. `Applied` means
+/// the concrete target DWARF also passed layout validation. `Rejected` keeps
+/// identity mismatch separate from an unsafe or unsupported layout so callers
+/// can preserve the ordinary DWARF fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValueLayoutResolution<L> {
+    NotApplicable,
+    Applied {
+        adapter: &'static str,
+        layout: L,
+    },
+    Rejected {
+        adapter: &'static str,
+        reason: &'static str,
+    },
+}
+
+impl<L> ValueLayoutResolution<L> {
+    pub(crate) fn map_layout<U>(self, map: impl FnOnce(L) -> U) -> ValueLayoutResolution<U> {
+        match self {
+            Self::NotApplicable => ValueLayoutResolution::NotApplicable,
+            Self::Applied { adapter, layout } => ValueLayoutResolution::Applied {
+                adapter,
+                layout: map(layout),
+            },
+            Self::Rejected { adapter, reason } => {
+                ValueLayoutResolution::Rejected { adapter, reason }
+            }
+        }
+    }
+}
+
+/// Common layouts plus an adapter-owned extension for language-specific plans.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValueLayout<E> {
+    IndirectSequence(IndirectSequenceLayout),
+    ProjectedValue {
+        value_path: Vec<String>,
+        presentation: ProjectedValuePresentation,
+    },
+    ProjectedStruct(ProjectedStructLayout),
+    CompositeStruct(CompositeStructLayout),
+    Extension(E),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectedValuePresentation {
+    Transparent,
+    SingleField {
+        type_name: &'static str,
+        field_name: &'static str,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectedStructLayout {
+    pub(crate) type_name: &'static str,
+    pub(crate) fields: Vec<ProjectedStructField>,
+    pub(crate) presentation: ProjectedStructPresentation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectedStructField {
+    pub(crate) name: &'static str,
+    pub(crate) value_path: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectedStructPresentation {
+    SignedState {
+        state_field: &'static str,
+        non_negative_label: &'static str,
+        negative_label: &'static str,
+    },
+    ReferenceCounted {
+        strong_field: &'static str,
+        weak_field: &'static str,
+        implicit_weak: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompositeStructLayout {
+    pub(crate) type_name: &'static str,
+    pub(crate) fields: Vec<CompositeStructField>,
+    pub(crate) presentation: ProjectedStructPresentation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompositeStructField {
+    pub(crate) name: &'static str,
+    pub(crate) value_path: Vec<ProjectedPathSegment>,
+    pub(crate) capture: CompositeStructFieldCapture,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompositeStructFieldCapture {
+    Value(ProjectedValueRequirement),
+    Address,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProjectedPathSegment {
+    Member(String),
+    SoleMember,
+    UnwrapScalar,
+    Dereference,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectedValueRequirement {
+    KnownSizedOrZst,
+    SignedPointerSizedInteger,
+    UnsignedPointerSizedInteger,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IndirectSequenceLayout {
+    pub(crate) data_path: Vec<String>,
+    pub(crate) addressing: IndirectSequenceAddressing,
+    pub(crate) kind: IndirectSequenceKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IndirectSequenceAddressing {
+    Contiguous {
+        length_path: Vec<String>,
+    },
+    Ring {
+        start_path: Vec<String>,
+        length_path: Vec<String>,
+        length_kind: RingSequenceLengthKind,
+        capacity_path: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RingSequenceLengthKind {
+    Explicit,
+    End,
+}
+
+impl IndirectSequenceLayout {
+    pub(crate) fn contiguous(
+        data_path: Vec<String>,
+        length_path: Vec<String>,
+        kind: IndirectSequenceKind,
+    ) -> Self {
+        Self {
+            data_path,
+            addressing: IndirectSequenceAddressing::Contiguous { length_path },
+            kind,
+        }
+    }
+
+    pub(crate) fn ring(
+        data_path: Vec<String>,
+        start_path: Vec<String>,
+        length_path: Vec<String>,
+        length_kind: RingSequenceLengthKind,
+        capacity_path: Vec<String>,
+        kind: IndirectSequenceKind,
+    ) -> Self {
+        Self {
+            data_path,
+            addressing: IndirectSequenceAddressing::Ring {
+                start_path,
+                length_path,
+                length_kind,
+                capacity_path,
+            },
+            kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IndirectSequenceKind {
+    Utf8String,
+    ByteString,
+    OpaqueByteString,
+    PointerTarget,
+    TypeParameter { index: usize },
+}
+
+/// DWARF operations available to every source-language value adapter.
+///
+/// Implementations keep object-file storage in the analyzer while adapters
+/// own source-language identities, producer conventions, and layout checks.
+pub(crate) trait ValueAdapterContext {
+    fn project_type(
+        &self,
+        current: &ResolvedType,
+        segment: &VariableAccessSegment,
+        type_module_path: Option<&Path>,
+    ) -> Result<TypeProjection>;
+
+    fn project_member_path(
+        &self,
+        current: &ResolvedType,
+        path: &[String],
+        type_module_path: Option<&Path>,
+    ) -> Result<TypeProjection>;
+
+    fn project_value_path(
+        &self,
+        current: &ResolvedType,
+        path: &[ProjectedPathSegment],
+        type_module_path: Option<&Path>,
+        capture_address: bool,
+    ) -> Result<Option<ProjectedValueRead>>;
+
+    fn template_type_parameter(
+        &self,
+        type_id: TypeId,
+        index: usize,
+    ) -> Result<Option<ResolvedType>>;
+
+    fn type_alignment(&self, type_id: TypeId) -> Result<Option<u64>>;
+
+    fn tuple_member_layout(
+        &self,
+        type_id: TypeId,
+        aggregate_type: &TypeInfo,
+        index: u32,
+    ) -> Result<MemberLayout>;
+
+    fn resolve_aggregate_type_in_module(
+        &self,
+        anchor: TypeId,
+        lookup_names: &[&str],
+        exact_qualified_name: Option<&str>,
+    ) -> Result<Option<ResolvedType>>;
+}
+
+pub(crate) fn build_value_read_plan<E, F>(
+    context: &dyn ValueAdapterContext,
+    current: &ResolvedType,
+    type_module_path: Option<&Path>,
+    layout: ValueLayout<E>,
+    build_extension: F,
+) -> Result<Option<ValueReadPlan>>
+where
+    F: FnOnce(
+        &dyn ValueAdapterContext,
+        &ResolvedType,
+        Option<&Path>,
+        E,
+    ) -> Result<Option<ValueReadPlan>>,
+{
+    let layout = match layout {
+        ValueLayout::ProjectedValue {
+            value_path,
+            presentation,
+        } => {
+            let value = context.project_member_path(current, &value_path, type_module_path)?;
+            let presentation = match presentation {
+                ProjectedValuePresentation::Transparent => crate::ValuePresentation::Dwarf,
+                ProjectedValuePresentation::SingleField {
+                    type_name,
+                    field_name,
+                } => crate::ValuePresentation::SingleField {
+                    type_name: type_name.to_string(),
+                    field_name: field_name.to_string(),
+                },
+            };
+            return Ok(Some(ValueReadPlan {
+                presentation,
+                capture: ValueCapturePlan::ProjectedValue { value },
+            }));
+        }
+        ValueLayout::ProjectedStruct(layout) => {
+            let root_size = current.summary.size();
+            let mut members = Vec::with_capacity(layout.fields.len());
+            for field in layout.fields {
+                let projected =
+                    context.project_member_path(current, &field.value_path, type_module_path)?;
+                let TypeProjectionLayout::Member { offset } = projected.layout else {
+                    return Err(anyhow::anyhow!(
+                        "semantic struct field produced a non-member projection"
+                    ));
+                };
+                let member_type = projected.resolved_type.summary;
+                let member_end = offset
+                    .checked_add(member_type.size())
+                    .ok_or_else(|| anyhow::anyhow!("semantic struct field end overflow"))?;
+                if member_end > root_size {
+                    return Err(anyhow::anyhow!(
+                        "semantic struct field '{}' exceeds its DWARF root",
+                        field.name
+                    ));
+                }
+                members.push(StructMember {
+                    name: field.name.to_string(),
+                    member_type,
+                    offset,
+                    bit_offset: None,
+                    bit_size: None,
+                });
+            }
+            let presentation = projected_struct_presentation(layout.presentation);
+            let output_type = TypeInfo::StructType {
+                name: layout.type_name.to_string(),
+                size: root_size,
+                members,
+            };
+            return Ok(Some(ValueReadPlan {
+                presentation,
+                capture: ValueCapturePlan::InlineView { output_type },
+            }));
+        }
+        ValueLayout::CompositeStruct(layout) => {
+            let mut members = Vec::with_capacity(layout.fields.len());
+            let mut fields = Vec::with_capacity(layout.fields.len());
+            let mut output_size = 0u64;
+            for field in layout.fields {
+                if members
+                    .iter()
+                    .any(|member: &StructMember| member.name == field.name)
+                {
+                    return Err(anyhow::anyhow!(
+                        "duplicate semantic struct field '{}'",
+                        field.name
+                    ));
+                }
+                let value = context.project_value_path(
+                    current,
+                    &field.value_path,
+                    type_module_path,
+                    matches!(field.capture, CompositeStructFieldCapture::Address),
+                )?;
+                let Some(value) = value else {
+                    return Ok(None);
+                };
+                let (member_type, capture) = match field.capture {
+                    CompositeStructFieldCapture::Value(requirement) => {
+                        if !projected_value_satisfies(requirement, &value) {
+                            return Ok(None);
+                        }
+                        (
+                            value.resolved_type.summary.clone(),
+                            ProjectedViewFieldCapture::Value,
+                        )
+                    }
+                    CompositeStructFieldCapture::Address => {
+                        let Some(member_type) = projected_address_type(&value) else {
+                            return Ok(None);
+                        };
+                        (member_type, ProjectedViewFieldCapture::Address)
+                    }
+                };
+                let output_offset = output_size;
+                output_size = output_size
+                    .checked_add(member_type.size())
+                    .ok_or_else(|| anyhow::anyhow!("semantic struct size overflow"))?;
+                members.push(StructMember {
+                    name: field.name.to_string(),
+                    member_type,
+                    offset: output_offset,
+                    bit_offset: None,
+                    bit_size: None,
+                });
+                fields.push(ProjectedViewField {
+                    output_offset,
+                    value,
+                    capture,
+                });
+            }
+            let output_type = TypeInfo::StructType {
+                name: layout.type_name.to_string(),
+                size: output_size,
+                members,
+            };
+            return Ok(Some(ValueReadPlan {
+                presentation: projected_struct_presentation(layout.presentation),
+                capture: ValueCapturePlan::ProjectedView {
+                    output_type,
+                    fields,
+                },
+            }));
+        }
+        ValueLayout::Extension(extension) => {
+            return build_extension(context, current, type_module_path, extension);
+        }
+        ValueLayout::IndirectSequence(layout) => layout,
+    };
+
+    let data = context.project_member_path(current, &layout.data_path, type_module_path)?;
+    let (presentation, element_stride) = match layout.kind {
+        IndirectSequenceKind::Utf8String => (crate::ValuePresentation::Utf8String, None),
+        IndirectSequenceKind::ByteString | IndirectSequenceKind::OpaqueByteString => {
+            (crate::ValuePresentation::ByteString, None)
+        }
+        IndirectSequenceKind::PointerTarget => {
+            let TypeInfo::PointerType { target_type, .. } =
+                strip_type_aliases(&data.resolved_type.summary)
+            else {
+                return Ok(None);
+            };
+            let element_type = target_type.as_ref().clone();
+            if matches!(
+                strip_type_aliases(&element_type),
+                TypeInfo::UnknownType { .. } | TypeInfo::OptimizedOut { .. }
+            ) {
+                return Ok(None);
+            }
+            let element_stride = element_type.size();
+            (
+                crate::ValuePresentation::Sequence {
+                    element_type: Box::new(element_type),
+                    element_stride,
+                },
+                Some(element_stride),
+            )
+        }
+        IndirectSequenceKind::TypeParameter { index } => {
+            let Some(type_id) = current.identity.layout_dwarf_id() else {
+                return Ok(None);
+            };
+            let Some(element) = context.template_type_parameter(type_id, index)? else {
+                return Ok(None);
+            };
+            if matches!(
+                strip_type_aliases(&element.summary),
+                TypeInfo::UnknownType { .. } | TypeInfo::OptimizedOut { .. }
+            ) {
+                return Ok(None);
+            }
+            let element_stride = element.summary.size();
+            (
+                crate::ValuePresentation::Sequence {
+                    element_type: Box::new(element.summary),
+                    element_stride,
+                },
+                Some(element_stride),
+            )
+        }
+    };
+
+    let capture = match layout.addressing {
+        IndirectSequenceAddressing::Contiguous { length_path } => {
+            let length = context.project_member_path(current, &length_path, type_module_path)?;
+            match element_stride {
+                Some(element_stride) => ValueCapturePlan::IndirectSequence {
+                    data,
+                    length,
+                    element_stride,
+                },
+                None => ValueCapturePlan::IndirectBytes { data, length },
+            }
+        }
+        IndirectSequenceAddressing::Ring {
+            start_path,
+            length_path,
+            length_kind,
+            capacity_path,
+        } => {
+            let Some(element_stride) = element_stride else {
+                return Ok(None);
+            };
+            let length = context.project_member_path(current, &length_path, type_module_path)?;
+            if element_stride == 0 && matches!(length_kind, RingSequenceLengthKind::Explicit) {
+                // Physical order is unobservable for zero-sized elements.
+                // Avoid depending on a producer-specific capacity encoding.
+                ValueCapturePlan::IndirectSequence {
+                    data,
+                    length,
+                    element_stride,
+                }
+            } else {
+                let start = context.project_member_path(current, &start_path, type_module_path)?;
+                let capacity =
+                    context.project_member_path(current, &capacity_path, type_module_path)?;
+                let length = Box::new(match length_kind {
+                    RingSequenceLengthKind::Explicit => crate::RingSequenceLength::Explicit(length),
+                    RingSequenceLengthKind::End => crate::RingSequenceLength::End(length),
+                });
+                ValueCapturePlan::IndirectRingSequence {
+                    data,
+                    start,
+                    length,
+                    capacity,
+                    element_stride,
+                }
+            }
+        }
+    };
+
+    Ok(Some(ValueReadPlan {
+        presentation,
+        capture,
+    }))
+}
+
+fn projected_struct_presentation(
+    presentation: ProjectedStructPresentation,
+) -> crate::ValuePresentation {
+    match presentation {
+        ProjectedStructPresentation::SignedState {
+            state_field,
+            non_negative_label,
+            negative_label,
+        } => crate::ValuePresentation::SignedStateStruct {
+            state_field: state_field.to_string(),
+            non_negative_label: non_negative_label.to_string(),
+            negative_label: negative_label.to_string(),
+        },
+        ProjectedStructPresentation::ReferenceCounted {
+            strong_field,
+            weak_field,
+            implicit_weak,
+        } => crate::ValuePresentation::ReferenceCountedStruct {
+            strong_field: strong_field.to_string(),
+            weak_field: weak_field.to_string(),
+            implicit_weak,
+        },
+    }
+}
+
+fn projected_address_type(value: &ProjectedValueRead) -> Option<TypeInfo> {
+    if matches!(
+        strip_type_aliases(&value.resolved_type.summary),
+        TypeInfo::UnknownType { .. } | TypeInfo::OptimizedOut { .. }
+    ) {
+        return None;
+    }
+    let pointer_size = value.steps.iter().rev().find_map(|step| match step {
+        ProjectedValueStep::Dereference { pointer_size } => Some(*pointer_size),
+        ProjectedValueStep::Member { .. } => None,
+    })?;
+    matches!(pointer_size, 4 | 8).then(|| TypeInfo::PointerType {
+        target_type: Box::new(value.resolved_type.summary.clone()),
+        size: pointer_size,
+    })
+}
+
+fn projected_value_satisfies(
+    requirement: ProjectedValueRequirement,
+    value: &ProjectedValueRead,
+) -> bool {
+    let value_type = strip_type_aliases(&value.resolved_type.summary);
+    match requirement {
+        ProjectedValueRequirement::KnownSizedOrZst => match value_type {
+            TypeInfo::UnknownType { .. }
+            | TypeInfo::OptimizedOut { .. }
+            | TypeInfo::ArrayType {
+                total_size: None, ..
+            } => false,
+            TypeInfo::BaseType { name, size: 0, .. } => name == "()",
+            TypeInfo::StructType { size: 0, .. }
+            | TypeInfo::UnionType { size: 0, .. }
+            | TypeInfo::ArrayType {
+                total_size: Some(0),
+                ..
+            } => true,
+            type_info => type_info.size() > 0,
+        },
+        ProjectedValueRequirement::SignedPointerSizedInteger => {
+            let TypeInfo::BaseType { size, encoding, .. } = value_type else {
+                return false;
+            };
+            let signed = *encoding == gimli::DW_ATE_signed.0 as u16
+                || *encoding == gimli::DW_ATE_signed_char.0 as u16;
+            signed && matches!(*size, 4 | 8) && projected_pointer_size(value) == Some(*size)
+        }
+        ProjectedValueRequirement::UnsignedPointerSizedInteger => {
+            let TypeInfo::BaseType { size, encoding, .. } = value_type else {
+                return false;
+            };
+            let unsigned = *encoding == gimli::DW_ATE_unsigned.0 as u16
+                || *encoding == gimli::DW_ATE_unsigned_char.0 as u16;
+            unsigned && matches!(*size, 4 | 8) && projected_pointer_size(value) == Some(*size)
+        }
+    }
+}
+
+fn projected_pointer_size(value: &ProjectedValueRead) -> Option<u64> {
+    value.steps.iter().rev().find_map(|step| match step {
+        ProjectedValueStep::Dereference { pointer_size } => Some(*pointer_size),
+        ProjectedValueStep::Member { .. } => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TypeIdentity;
+
+    fn projected_value(summary: TypeInfo, pointer_size: Option<u64>) -> ProjectedValueRead {
+        let steps = pointer_size
+            .map(|pointer_size| ProjectedValueStep::Dereference { pointer_size })
+            .into_iter()
+            .collect();
+        ProjectedValueRead {
+            steps,
+            resolved_type: ResolvedType::new(summary, TypeIdentity::Unknown, None),
+        }
+    }
+
+    #[test]
+    fn known_sized_requirement_distinguishes_zst_from_unknown_layout() {
+        let requirement = ProjectedValueRequirement::KnownSizedOrZst;
+        let unit = projected_value(
+            TypeInfo::BaseType {
+                name: "()".to_string(),
+                size: 0,
+                encoding: gimli::DW_ATE_unsigned.0 as u16,
+            },
+            Some(8),
+        );
+        let unknown = projected_value(
+            TypeInfo::UnknownType {
+                name: "T".to_string(),
+            },
+            Some(8),
+        );
+
+        assert!(projected_value_satisfies(requirement, &unit));
+        assert!(!projected_value_satisfies(requirement, &unknown));
+    }
+
+    #[test]
+    fn projected_address_uses_the_dwarf_pointer_width() {
+        let target = TypeInfo::ArrayType {
+            element_type: Box::new(TypeInfo::BaseType {
+                name: "u8".to_string(),
+                size: 1,
+                encoding: gimli::DW_ATE_unsigned.0 as u16,
+            }),
+            element_count: None,
+            total_size: None,
+        };
+        let value = projected_value(target.clone(), Some(8));
+        assert_eq!(
+            projected_address_type(&value),
+            Some(TypeInfo::PointerType {
+                target_type: Box::new(target),
+                size: 8,
+            })
+        );
+        assert_eq!(
+            projected_address_type(&projected_value(value.resolved_type.summary, None)),
+            None
+        );
+    }
+
+    #[test]
+    fn signed_state_requirement_uses_dwarf_encoding_and_pointer_width() {
+        let requirement = ProjectedValueRequirement::SignedPointerSizedInteger;
+        let signed = |size, pointer_size| {
+            projected_value(
+                TypeInfo::BaseType {
+                    name: "isize".to_string(),
+                    size,
+                    encoding: gimli::DW_ATE_signed.0 as u16,
+                },
+                pointer_size,
+            )
+        };
+        assert!(projected_value_satisfies(requirement, &signed(8, Some(8))));
+        assert!(!projected_value_satisfies(requirement, &signed(4, Some(8))));
+        assert!(!projected_value_satisfies(requirement, &signed(8, None)));
+
+        let unsigned = projected_value(
+            TypeInfo::BaseType {
+                name: "usize".to_string(),
+                size: 8,
+                encoding: gimli::DW_ATE_unsigned.0 as u16,
+            },
+            Some(8),
+        );
+        assert!(!projected_value_satisfies(requirement, &unsigned));
+    }
+
+    #[test]
+    fn unsigned_counter_requirement_uses_dwarf_encoding_and_pointer_width() {
+        let requirement = ProjectedValueRequirement::UnsignedPointerSizedInteger;
+        let unsigned = |size, pointer_size| {
+            projected_value(
+                TypeInfo::BaseType {
+                    name: "usize".to_string(),
+                    size,
+                    encoding: gimli::DW_ATE_unsigned.0 as u16,
+                },
+                pointer_size,
+            )
+        };
+        assert!(projected_value_satisfies(
+            requirement,
+            &unsigned(8, Some(8))
+        ));
+        assert!(!projected_value_satisfies(
+            requirement,
+            &unsigned(4, Some(8))
+        ));
+        assert!(!projected_value_satisfies(requirement, &unsigned(8, None)));
+
+        let signed = projected_value(
+            TypeInfo::BaseType {
+                name: "isize".to_string(),
+                size: 8,
+                encoding: gimli::DW_ATE_signed.0 as u16,
+            },
+            Some(8),
+        );
+        assert!(!projected_value_satisfies(requirement, &signed));
+    }
+}

--- a/ghostscope-dwarf/src/language/mod.rs
+++ b/ghostscope-dwarf/src/language/mod.rs
@@ -1,31 +1,73 @@
 //! Source-language dispatch for semantic DWARF projections.
 
+mod adapter;
 mod rust;
 
 use crate::{semantics::PlanError, SourceLanguage, TypeOrigin, VariableAccessSegment};
+use std::path::Path;
 
-pub(crate) use rust::{
-    btree_value_read_plan, hash_table_value_read_plan, CompositeStructFieldCapture,
-    IndirectSequenceAddressing, IndirectSequenceKind, ProjectedPathSegment,
-    ProjectedStructPresentation, ProjectedValuePresentation, ProjectedValueRequirement,
-    RingSequenceLengthKind, RustPlanContext, ValueLayout, ValueLayoutResolution,
-};
+pub(crate) use adapter::{ProjectedPathSegment, ValueAdapterContext};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValueLayout {
+    Rust(rust::ValueLayout),
+}
+
+pub(crate) type ValueLayoutResolution = adapter::ValueLayoutResolution<ValueLayout>;
+
+/// Select an adapter only after dispatching on the type's DWARF language.
+///
+/// This boundary prevents C, C++, and unknown-language values from entering
+/// Rust standard-library recognition or plan construction.
 pub(crate) fn resolve_value_layout(
     current: &crate::ResolvedType,
     dwarf_qualified_name: Option<&str>,
 ) -> ValueLayoutResolution {
-    rust::resolve_value_layout(current, dwarf_qualified_name)
+    match source_language(current) {
+        SourceLanguage::Rust => {
+            rust::resolve_value_layout(current, dwarf_qualified_name).map_layout(ValueLayout::Rust)
+        }
+        SourceLanguage::C
+        | SourceLanguage::Cpp
+        | SourceLanguage::Other(_)
+        | SourceLanguage::Unknown => ValueLayoutResolution::NotApplicable,
+    }
 }
 
 pub(crate) fn requires_dwarf_qualified_name(current: &crate::ResolvedType) -> bool {
-    rust::requires_dwarf_qualified_name(current)
+    match source_language(current) {
+        SourceLanguage::Rust => rust::requires_dwarf_qualified_name(current),
+        SourceLanguage::C
+        | SourceLanguage::Cpp
+        | SourceLanguage::Other(_)
+        | SourceLanguage::Unknown => false,
+    }
+}
+
+pub(crate) fn build_value_read_plan(
+    context: &dyn ValueAdapterContext,
+    current: &crate::ResolvedType,
+    type_module_path: Option<&Path>,
+    layout: ValueLayout,
+) -> crate::Result<Option<crate::ValueReadPlan>> {
+    match layout {
+        ValueLayout::Rust(layout) => {
+            rust::build_value_read_plan(context, current, layout, type_module_path)
+        }
+    }
 }
 
 pub(crate) fn annotate_type_info(language: SourceLanguage, type_info: &mut crate::TypeInfo) {
     if language == SourceLanguage::Rust {
         rust::annotate_type_info(type_info);
     }
+}
+
+fn source_language(current: &crate::ResolvedType) -> SourceLanguage {
+    current
+        .origin
+        .as_ref()
+        .map_or(SourceLanguage::Unknown, |origin| origin.language)
 }
 
 pub(crate) fn resolve_access_segment(
@@ -48,7 +90,7 @@ pub(crate) fn resolve_access_segment(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CuId, ModuleId};
+    use crate::{CuId, ModuleId, ResolvedType, TypeIdentity, TypeInfo};
 
     fn origin(language: SourceLanguage) -> TypeOrigin {
         TypeOrigin {
@@ -82,5 +124,24 @@ mod tests {
         assert!(error
             .to_string()
             .contains("not supported for source language C"));
+    }
+
+    #[test]
+    fn non_rust_values_bypass_rust_adapters() {
+        let current = ResolvedType::new(
+            TypeInfo::StructType {
+                name: "&str".to_string(),
+                size: 0,
+                members: Vec::new(),
+            },
+            TypeIdentity::Unknown,
+            Some(origin(SourceLanguage::C)),
+        );
+
+        assert_eq!(
+            resolve_value_layout(&current, None),
+            ValueLayoutResolution::NotApplicable
+        );
+        assert!(!requires_dwarf_qualified_name(&current));
     }
 }

--- a/ghostscope-dwarf/src/language/rust/mod.rs
+++ b/ghostscope-dwarf/src/language/rust/mod.rs
@@ -3,12 +3,7 @@ mod plan;
 mod value;
 mod variant;
 
-pub(crate) use plan::{btree_value_read_plan, hash_table_value_read_plan, RustPlanContext};
-pub(crate) use value::{
-    CompositeStructFieldCapture, IndirectSequenceAddressing, IndirectSequenceKind,
-    ProjectedPathSegment, ProjectedStructPresentation, ProjectedValuePresentation,
-    ProjectedValueRequirement, RingSequenceLengthKind, ValueLayout, ValueLayoutResolution,
-};
+pub(super) use value::{ValueLayout, ValueLayoutResolution};
 
 pub(super) fn resolve_tuple_index(index: u32) -> crate::VariableAccessSegment {
     access::resolve_tuple_index(index)
@@ -27,4 +22,13 @@ pub(super) fn resolve_value_layout(
 
 pub(super) fn requires_dwarf_qualified_name(current: &crate::ResolvedType) -> bool {
     value::requires_dwarf_qualified_name(current)
+}
+
+pub(super) fn build_value_read_plan(
+    context: &dyn crate::language::adapter::ValueAdapterContext,
+    current: &crate::ResolvedType,
+    layout: ValueLayout,
+    type_module_path: Option<&std::path::Path>,
+) -> crate::Result<Option<crate::ValueReadPlan>> {
+    plan::build_value_read_plan(context, current, layout, type_module_path)
 }

--- a/ghostscope-dwarf/src/language/rust/plan.rs
+++ b/ghostscope-dwarf/src/language/rust/plan.rs
@@ -1,11 +1,14 @@
 use crate::{
     strip_type_aliases, BTreeArrayCapture, BTreeEdgesCapture, BTreeEntryPresentation,
     BTreeFieldPresentation, HashTableBucketOrder, HashTableBucketSource,
-    HashTableEntryPresentation, HashTableFieldPresentation, HashTableOccupancy, MemberLayout,
-    ResolvedType, Result, StructMember, TypeId, TypeInfo, TypeProjection, TypeProjectionLayout,
-    ValueCapturePlan, ValuePresentation, ValueReadPlan, VariableAccessSegment,
+    HashTableEntryPresentation, HashTableFieldPresentation, HashTableOccupancy, ResolvedType,
+    Result, StructMember, TypeInfo, TypeProjection, TypeProjectionLayout, ValueCapturePlan,
+    ValuePresentation, ValueReadPlan, VariableAccessSegment,
 };
 use std::path::Path;
+
+use super::value::{RustValueLayout, ValueLayout};
+use crate::language::adapter::{self, ValueAdapterContext};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BTreeLayout {
@@ -46,51 +49,30 @@ pub(crate) enum HashTableKind {
     Set,
 }
 
-/// Generic DWARF operations required by Rust-specific value planners.
-///
-/// The language layer owns producer conventions and standard-library layout
-/// validation. The analyzer implements these primitives without exposing its
-/// object-file storage to the language layer.
-pub(crate) trait RustPlanContext {
-    fn project_type(
-        &self,
-        current: &ResolvedType,
-        segment: &VariableAccessSegment,
-        type_module_path: Option<&Path>,
-    ) -> Result<TypeProjection>;
-
-    fn project_member_path(
-        &self,
-        current: &ResolvedType,
-        path: &[String],
-        type_module_path: Option<&Path>,
-    ) -> Result<TypeProjection>;
-
-    fn template_type_parameter(
-        &self,
-        type_id: TypeId,
-        index: usize,
-    ) -> Result<Option<ResolvedType>>;
-
-    fn type_alignment(&self, type_id: TypeId) -> Result<Option<u64>>;
-
-    fn tuple_member_layout(
-        &self,
-        type_id: TypeId,
-        aggregate_type: &TypeInfo,
-        index: u32,
-    ) -> Result<MemberLayout>;
-
-    fn resolve_aggregate_type_in_module(
-        &self,
-        anchor: TypeId,
-        lookup_names: &[&str],
-        exact_qualified_name: Option<&str>,
-    ) -> Result<Option<ResolvedType>>;
+pub(super) fn build_value_read_plan(
+    context: &dyn ValueAdapterContext,
+    current: &ResolvedType,
+    layout: ValueLayout,
+    type_module_path: Option<&Path>,
+) -> Result<Option<ValueReadPlan>> {
+    adapter::build_value_read_plan(
+        context,
+        current,
+        type_module_path,
+        layout,
+        |context, current, type_module_path, extension| match extension {
+            RustValueLayout::BTree(layout) => {
+                btree_value_read_plan(context, current, layout, type_module_path)
+            }
+            RustValueLayout::HashTable(layout) => {
+                hash_table_value_read_plan(context, current, layout, type_module_path)
+            }
+        },
+    )
 }
 
 pub(crate) fn hash_table_value_read_plan(
-    context: &dyn RustPlanContext,
+    context: &dyn ValueAdapterContext,
     current: &ResolvedType,
     layout: HashTableLayout,
     type_module_path: Option<&Path>,
@@ -196,7 +178,7 @@ pub(crate) fn hash_table_value_read_plan(
 }
 
 pub(crate) fn btree_value_read_plan<'a>(
-    context: &'a dyn RustPlanContext,
+    context: &'a dyn ValueAdapterContext,
     current: &ResolvedType,
     layout: BTreeLayout,
     type_module_path: Option<&'a Path>,
@@ -209,7 +191,7 @@ pub(crate) fn btree_value_read_plan<'a>(
 }
 
 struct BTreePlanner<'a> {
-    context: &'a dyn RustPlanContext,
+    context: &'a dyn ValueAdapterContext,
     type_module_path: Option<&'a Path>,
 }
 

--- a/ghostscope-dwarf/src/language/rust/value.rs
+++ b/ghostscope-dwarf/src/language/rust/value.rs
@@ -4,178 +4,22 @@ use crate::{
 };
 
 use super::plan::{BTreeKind, BTreeLayout, HashTableBucketLayout, HashTableKind, HashTableLayout};
+use crate::language::adapter::{
+    CompositeStructField, CompositeStructFieldCapture, CompositeStructLayout, IndirectSequenceKind,
+    IndirectSequenceLayout, ProjectedPathSegment, ProjectedStructField, ProjectedStructLayout,
+    ProjectedStructPresentation, ProjectedValuePresentation, ProjectedValueRequirement,
+    RingSequenceLengthKind, ValueLayout as AdapterValueLayout,
+    ValueLayoutResolution as AdapterValueLayoutResolution,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ValueLayout {
-    IndirectSequence(IndirectSequenceLayout),
-    ProjectedValue {
-        value_path: Vec<String>,
-        presentation: ProjectedValuePresentation,
-    },
-    ProjectedStruct(ProjectedStructLayout),
-    CompositeStruct(CompositeStructLayout),
+pub(crate) enum RustValueLayout {
     HashTable(HashTableLayout),
     BTree(BTreeLayout),
 }
 
-/// Result of asking the Rust adapter layer for a semantic value layout.
-///
-/// Recognition establishes only a candidate type identity. `Applied` means
-/// the concrete target DWARF also passed layout validation. `Rejected` keeps
-/// identity mismatch separate from an unsafe or unsupported layout so callers
-/// can preserve the ordinary DWARF fallback.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ValueLayoutResolution {
-    NotApplicable,
-    Applied {
-        adapter: &'static str,
-        layout: ValueLayout,
-    },
-    Rejected {
-        adapter: &'static str,
-        reason: &'static str,
-    },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProjectedValuePresentation {
-    Transparent,
-    SingleField {
-        type_name: &'static str,
-        field_name: &'static str,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ProjectedStructLayout {
-    pub(crate) type_name: &'static str,
-    pub(crate) fields: Vec<ProjectedStructField>,
-    pub(crate) presentation: ProjectedStructPresentation,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ProjectedStructField {
-    pub(crate) name: &'static str,
-    pub(crate) value_path: Vec<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProjectedStructPresentation {
-    SignedState {
-        state_field: &'static str,
-        non_negative_label: &'static str,
-        negative_label: &'static str,
-    },
-    ReferenceCounted {
-        strong_field: &'static str,
-        weak_field: &'static str,
-        implicit_weak: u64,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CompositeStructLayout {
-    pub(crate) type_name: &'static str,
-    pub(crate) fields: Vec<CompositeStructField>,
-    pub(crate) presentation: ProjectedStructPresentation,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CompositeStructField {
-    pub(crate) name: &'static str,
-    pub(crate) value_path: Vec<ProjectedPathSegment>,
-    pub(crate) capture: CompositeStructFieldCapture,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CompositeStructFieldCapture {
-    Value(ProjectedValueRequirement),
-    Address,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ProjectedPathSegment {
-    Member(String),
-    SoleMember,
-    UnwrapScalar,
-    Dereference,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProjectedValueRequirement {
-    KnownSizedOrZst,
-    SignedPointerSizedInteger,
-    UnsignedPointerSizedInteger,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct IndirectSequenceLayout {
-    pub(crate) data_path: Vec<String>,
-    pub(crate) addressing: IndirectSequenceAddressing,
-    pub(crate) kind: IndirectSequenceKind,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum IndirectSequenceAddressing {
-    Contiguous {
-        length_path: Vec<String>,
-    },
-    Ring {
-        start_path: Vec<String>,
-        length_path: Vec<String>,
-        length_kind: RingSequenceLengthKind,
-        capacity_path: Vec<String>,
-    },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RingSequenceLengthKind {
-    Explicit,
-    End,
-}
-
-impl IndirectSequenceLayout {
-    fn contiguous(
-        data_path: Vec<String>,
-        length_path: Vec<String>,
-        kind: IndirectSequenceKind,
-    ) -> Self {
-        Self {
-            data_path,
-            addressing: IndirectSequenceAddressing::Contiguous { length_path },
-            kind,
-        }
-    }
-
-    fn ring(
-        data_path: Vec<String>,
-        start_path: Vec<String>,
-        length_path: Vec<String>,
-        length_kind: RingSequenceLengthKind,
-        capacity_path: Vec<String>,
-        kind: IndirectSequenceKind,
-    ) -> Self {
-        Self {
-            data_path,
-            addressing: IndirectSequenceAddressing::Ring {
-                start_path,
-                length_path,
-                length_kind,
-                capacity_path,
-            },
-            kind,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum IndirectSequenceKind {
-    Utf8String,
-    ByteString,
-    OpaqueByteString,
-    PointerTarget,
-    TypeParameter { index: usize },
-}
+pub(crate) type ValueLayout = AdapterValueLayout<RustValueLayout>;
+pub(crate) type ValueLayoutResolution = AdapterValueLayoutResolution<ValueLayout>;
 
 pub(super) fn requires_dwarf_qualified_name(current: &ResolvedType) -> bool {
     current.origin.as_ref().is_some_and(|origin| {
@@ -216,6 +60,9 @@ pub(super) fn diagnose_value_layout(
     current: &ResolvedType,
     dwarf_qualified_name: Option<&str>,
 ) -> ValueLayoutResolution {
+    // The language dispatcher is the production boundary. Keep this check so
+    // direct internal calls cannot accidentally apply Rust identities to a
+    // value from another source language.
     if current.origin.as_ref().map(|origin| origin.language) != Some(SourceLanguage::Rust) {
         return ValueLayoutResolution::NotApplicable;
     }
@@ -360,18 +207,20 @@ impl RustValueAdapter {
     fn resolve(self, root: &TypeInfo) -> Option<ValueLayout> {
         let layout = match self {
             Self::BTreeMap => {
-                return rust_btree_layout(root, BTreeKind::Map).map(ValueLayout::BTree)
+                return rust_btree_layout(root, BTreeKind::Map)
+                    .map(|layout| ValueLayout::Extension(RustValueLayout::BTree(layout)))
             }
             Self::BTreeSet => {
-                return rust_btree_layout(root, BTreeKind::Set).map(ValueLayout::BTree)
+                return rust_btree_layout(root, BTreeKind::Set)
+                    .map(|layout| ValueLayout::Extension(RustValueLayout::BTree(layout)))
             }
             Self::HashMap => {
                 return rust_hash_table_layout(root, HashTableKind::Map)
-                    .map(ValueLayout::HashTable);
+                    .map(|layout| ValueLayout::Extension(RustValueLayout::HashTable(layout)));
             }
             Self::HashSet => {
                 return rust_hash_table_layout(root, HashTableKind::Set)
-                    .map(ValueLayout::HashTable);
+                    .map(|layout| ValueLayout::Extension(RustValueLayout::HashTable(layout)));
             }
             Self::Rc { pointee_is_str } => {
                 return rust_reference_counted_layout(root, "Rc", "value", pointee_is_str)
@@ -2165,6 +2014,7 @@ fn validate_indirect_sequence_layout(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::language::adapter::IndirectSequenceAddressing;
     use crate::{CuId, ModuleId, StructMember, TypeIdentity, TypeOrigin};
 
     struct RustStrLayout<'a> {
@@ -3980,16 +3830,18 @@ mod tests {
                 &current_map,
                 Some("std::collections::hash::map::HashMap<i32, u16>"),
             ),
-            Some(ValueLayout::HashTable(HashTableLayout {
-                entry_type_path: field_path(&["base", "table"]),
-                control_path: field_path(&["base", "table", "table", "ctrl", "pointer",]),
-                length_path: field_path(&["base", "table", "table", "items"]),
-                bucket_mask_path: field_path(&["base", "table", "table", "bucket_mask",]),
-                occupancy: HashTableOccupancy::ControlByteHighBitClear,
-                buckets: HashTableBucketLayout::ReverseFromControl,
-                bucket_order: HashTableBucketOrder::Reverse,
-                kind: HashTableKind::Map,
-            }))
+            Some(ValueLayout::Extension(RustValueLayout::HashTable(
+                HashTableLayout {
+                    entry_type_path: field_path(&["base", "table"]),
+                    control_path: field_path(&["base", "table", "table", "ctrl", "pointer",]),
+                    length_path: field_path(&["base", "table", "table", "items"]),
+                    bucket_mask_path: field_path(&["base", "table", "table", "bucket_mask",]),
+                    occupancy: HashTableOccupancy::ControlByteHighBitClear,
+                    buckets: HashTableBucketLayout::ReverseFromControl,
+                    bucket_order: HashTableBucketOrder::Reverse,
+                    kind: HashTableKind::Map,
+                },
+            )))
         );
 
         let legacy_map = rust_hash_collection_type(
@@ -4001,7 +3853,8 @@ mod tests {
             false,
             SourceLanguage::Rust,
         );
-        let Some(ValueLayout::HashTable(legacy_map)) = resolve_value_layout(&legacy_map, None)
+        let Some(ValueLayout::Extension(RustValueLayout::HashTable(legacy_map))) =
+            resolve_value_layout(&legacy_map, None)
         else {
             panic!("expected legacy HashMap layout")
         };
@@ -4031,7 +3884,8 @@ mod tests {
             false,
             SourceLanguage::Rust,
         );
-        let Some(ValueLayout::HashTable(current_set)) = resolve_value_layout(&current_set, None)
+        let Some(ValueLayout::Extension(RustValueLayout::HashTable(current_set))) =
+            resolve_value_layout(&current_set, None)
         else {
             panic!("expected current HashSet layout")
         };
@@ -4050,10 +3904,12 @@ mod tests {
             true,
             SourceLanguage::Rust,
         );
-        let Some(ValueLayout::HashTable(legacy_set)) = resolve_value_layout(
-            &legacy_set,
-            Some("std::collections::hash::set::HashSet<i32>"),
-        ) else {
+        let Some(ValueLayout::Extension(RustValueLayout::HashTable(legacy_set))) =
+            resolve_value_layout(
+                &legacy_set,
+                Some("std::collections::hash::set::HashSet<i32>"),
+            )
+        else {
             panic!("expected legacy HashSet layout")
         };
         assert_eq!(
@@ -4080,7 +3936,7 @@ mod tests {
             ),
         ] {
             let value = rust_135_hash_collection_type(name, kind, 8, SourceLanguage::Rust);
-            let Some(ValueLayout::HashTable(layout)) =
+            let Some(ValueLayout::Extension(RustValueLayout::HashTable(layout))) =
                 resolve_value_layout(&value, Some(qualified_name))
             else {
                 panic!("expected Rust 1.35 hash-table layout for {name}")
@@ -4231,12 +4087,14 @@ mod tests {
                 &map,
                 Some("alloc::collections::btree::map::BTreeMap<i32, u16>"),
             ),
-            Some(ValueLayout::BTree(BTreeLayout {
-                map_path: Vec::new(),
-                root_path: field_path(&["root"]),
-                length_path: field_path(&["length"]),
-                kind: BTreeKind::Map,
-            }))
+            Some(ValueLayout::Extension(RustValueLayout::BTree(
+                BTreeLayout {
+                    map_path: Vec::new(),
+                    root_path: field_path(&["root"]),
+                    length_path: field_path(&["length"]),
+                    kind: BTreeKind::Map,
+                },
+            )))
         );
 
         let set = rust_btree_collection_type(
@@ -4247,12 +4105,14 @@ mod tests {
         );
         assert_eq!(
             resolve_value_layout(&set, None),
-            Some(ValueLayout::BTree(BTreeLayout {
-                map_path: field_path(&["map"]),
-                root_path: field_path(&["map", "root"]),
-                length_path: field_path(&["map", "length"]),
-                kind: BTreeKind::Set,
-            }))
+            Some(ValueLayout::Extension(RustValueLayout::BTree(
+                BTreeLayout {
+                    map_path: field_path(&["map"]),
+                    root_path: field_path(&["map", "root"]),
+                    length_path: field_path(&["map", "length"]),
+                    kind: BTreeKind::Set,
+                },
+            )))
         );
     }
 


### PR DESCRIPTION
## Summary

- extract shared value-adapter layouts, resolution, DWARF projection context, and common read-plan construction into a language-neutral module
- dispatch on the DWARF source language before adapter recognition so C, C++, and unknown-language values never enter Rust standard-library adapter paths
- keep Rust-specific recognition and BTree/HashTable planning under the Rust language module
- preserve rejected-adapter diagnostics and ordinary DWARF fallback behavior

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p ghostscope-dwarf --lib` (252 passed)
- full host-host e2e through runner job `7d4017714210` (exit code 0)

Container-topology e2e was intentionally skipped because this refactor does not affect container, PID namespace, or runner topology behavior.