### PR TITLE
perf: cache parsed DWARF units

### DIFF
--- a/ghostscope-dwarf/src/objfile/loaded.rs
+++ b/ghostscope-dwarf/src/objfile/loaded.rs
@@ -12,12 +12,88 @@ use crate::{
 };
 use object::{Object, ObjectSegment};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     path::PathBuf,
     sync::{Arc, Mutex, RwLock},
 };
 
 type FunctionRangeCacheKey = (u64, u64);
+
+const PARSED_UNIT_CACHE_MAX_ENTRIES: usize = 64;
+
+type ParsedUnit = Arc<gimli::Unit<DwarfReader>>;
+
+/// A bounded insertion-order cache.
+///
+/// Cache hits take only a shared lock; maintaining strict LRU order would turn
+/// every hot lookup into a write operation.
+#[derive(Debug)]
+pub(super) struct ParsedUnitCache {
+    entries: HashMap<gimli::DebugInfoOffset, ParsedUnit>,
+    insertion_order: VecDeque<gimli::DebugInfoOffset>,
+    max_entries: usize,
+}
+
+impl Default for ParsedUnitCache {
+    fn default() -> Self {
+        Self::new(PARSED_UNIT_CACHE_MAX_ENTRIES)
+    }
+}
+
+impl ParsedUnitCache {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            max_entries,
+        }
+    }
+
+    fn get(&self, offset: gimli::DebugInfoOffset) -> Option<ParsedUnit> {
+        self.entries.get(&offset).map(Arc::clone)
+    }
+
+    fn insert(&mut self, offset: gimli::DebugInfoOffset, unit: ParsedUnit) -> ParsedUnit {
+        if let Some(existing) = self.entries.get(&offset) {
+            return Arc::clone(existing);
+        }
+        if self.max_entries == 0 {
+            return unit;
+        }
+
+        while self.entries.len() >= self.max_entries {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+
+        self.entries.insert(offset, Arc::clone(&unit));
+        self.insertion_order.push_back(offset);
+        unit
+    }
+}
+
+fn load_parsed_unit(
+    cache: &RwLock<ParsedUnitCache>,
+    dwarf: &gimli::Dwarf<DwarfReader>,
+    offset: gimli::DebugInfoOffset,
+) -> Result<ParsedUnit> {
+    if let Some(unit) = cache
+        .read()
+        .expect("parsed unit cache lock poisoned")
+        .get(offset)
+    {
+        return Ok(unit);
+    }
+
+    let header = dwarf.unit_header(offset)?;
+    let parsed = Arc::new(dwarf.unit(header)?);
+    Ok(cache
+        .write()
+        .expect("parsed unit cache lock poisoned")
+        .insert(offset, parsed))
+}
 
 /// Complete DWARF data for a single loaded object file.
 #[derive(Debug)]
@@ -31,6 +107,7 @@ pub(crate) struct LoadedObjfile {
     pub(super) indexed_line_cus: Mutex<HashSet<gimli::DebugInfoOffset>>,
     pub(super) unwind_info: ModuleUnwindInfo,
     pub(super) dwarf: gimli::Dwarf<DwarfReader>,
+    pub(super) parsed_unit_cache: RwLock<ParsedUnitCache>,
     pub(super) detailed_parser: DetailedParser,
     pub(super) _dwarf_mapped_file: Arc<MappedFile>,
     pub(super) _binary_mapped_file: Arc<MappedFile>,
@@ -167,6 +244,10 @@ impl LoadedObjfile {
 
     pub(super) fn dwarf(&self) -> &gimli::Dwarf<DwarfReader> {
         &self.dwarf
+    }
+
+    pub(super) fn unit(&self, offset: gimli::DebugInfoOffset) -> Result<ParsedUnit> {
+        load_parsed_unit(&self.parsed_unit_cache, &self.dwarf, offset)
     }
 
     pub(super) fn ensure_debug_info_for_symbol(
@@ -393,5 +474,133 @@ impl LoadedObjfile {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binary::dwarf_reader_from_arc;
+    use gimli::write::{Dwarf as WriteDwarf, EndianVec, LineProgram, Sections, Unit};
+    use gimli::{Format, LittleEndian};
+
+    fn dwarf_fixture() -> gimli::Dwarf<DwarfReader> {
+        let encoding = gimli::Encoding {
+            format: Format::Dwarf32,
+            version: 5,
+            address_size: 8,
+        };
+        let mut fixture = WriteDwarf::new();
+        fixture.units.add(Unit::new(encoding, LineProgram::none()));
+        let mut sections = Sections::new(EndianVec::new(LittleEndian));
+        fixture
+            .write(&mut sections)
+            .expect("DWARF fixture should serialize");
+
+        gimli::Dwarf::load(|id| {
+            let data = sections
+                .get(id)
+                .map(|section| section.slice().to_vec())
+                .unwrap_or_default();
+            Ok::<_, gimli::Error>(dwarf_reader_from_arc(Arc::<[u8]>::from(data)))
+        })
+        .expect("DWARF fixture should load")
+    }
+
+    #[test]
+    fn parsed_unit_cache_reuses_loaded_unit() {
+        let dwarf = dwarf_fixture();
+        let cache = RwLock::new(ParsedUnitCache::new(2));
+        let offset = gimli::DebugInfoOffset(0);
+
+        let first = load_parsed_unit(&cache, &dwarf, offset).expect("unit should load");
+        let second = load_parsed_unit(&cache, &dwarf, offset).expect("unit should be cached");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            cache
+                .read()
+                .expect("parsed unit cache lock poisoned")
+                .entries
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn parsed_unit_cache_concurrent_misses_share_unit() {
+        const THREAD_COUNT: usize = 8;
+
+        let dwarf = Arc::new(dwarf_fixture());
+        let cache = Arc::new(RwLock::new(ParsedUnitCache::new(2)));
+        let barrier = Arc::new(std::sync::Barrier::new(THREAD_COUNT));
+        let handles = (0..THREAD_COUNT)
+            .map(|_| {
+                let dwarf = Arc::clone(&dwarf);
+                let cache = Arc::clone(&cache);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    load_parsed_unit(&cache, &dwarf, gimli::DebugInfoOffset(0))
+                        .expect("unit should load")
+                })
+            })
+            .collect::<Vec<_>>();
+        let units = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("cache worker should not panic"))
+            .collect::<Vec<_>>();
+
+        assert!(units
+            .iter()
+            .skip(1)
+            .all(|unit| Arc::ptr_eq(&units[0], unit)));
+        assert_eq!(
+            cache
+                .read()
+                .expect("parsed unit cache lock poisoned")
+                .entries
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn parsed_unit_cache_evicts_oldest_entry() {
+        let dwarf = dwarf_fixture();
+        let unit = load_parsed_unit(
+            &RwLock::new(ParsedUnitCache::new(0)),
+            &dwarf,
+            gimli::DebugInfoOffset(0),
+        )
+        .expect("unit should load");
+        let mut cache = ParsedUnitCache::new(2);
+        let first = gimli::DebugInfoOffset(1);
+        let second = gimli::DebugInfoOffset(2);
+        let third = gimli::DebugInfoOffset(3);
+
+        cache.insert(first, Arc::clone(&unit));
+        cache.insert(second, Arc::clone(&unit));
+        cache.insert(third, unit);
+
+        assert!(cache.get(first).is_none());
+        assert!(cache.get(second).is_some());
+        assert!(cache.get(third).is_some());
+        assert_eq!(cache.entries.len(), 2);
+    }
+
+    #[test]
+    fn parsed_unit_cache_does_not_cache_errors() {
+        let dwarf = dwarf_fixture();
+        let cache = RwLock::new(ParsedUnitCache::new(2));
+        let invalid_offset = gimli::DebugInfoOffset(usize::MAX);
+
+        assert!(load_parsed_unit(&cache, &dwarf, invalid_offset).is_err());
+        assert!(load_parsed_unit(&cache, &dwarf, invalid_offset).is_err());
+        assert!(cache
+            .read()
+            .expect("parsed unit cache lock poisoned")
+            .entries
+            .is_empty());
     }
 }

--- a/ghostscope-dwarf/src/objfile/loading.rs
+++ b/ghostscope-dwarf/src/objfile/loading.rs
@@ -387,6 +387,7 @@ impl LoadedObjfile {
             indexed_line_cus: Mutex::new(HashSet::new()),
             unwind_info,
             dwarf,
+            parsed_unit_cache: RwLock::new(Default::default()),
             detailed_parser,
             block_index: std::sync::RwLock::new(BlockIndex::new()),
             type_name_index: RwLock::new(type_name_index),

--- a/ghostscope-dwarf/src/objfile/variables.rs
+++ b/ghostscope-dwarf/src/objfile/variables.rs
@@ -93,10 +93,7 @@ impl LoadedObjfile {
         variable.declaration = Some(die_ref(module, cu_offset, die_offset));
 
         let dwarf = self.dwarf();
-        let Ok(header) = dwarf.unit_header(cu_offset) else {
-            return;
-        };
-        let Ok(unit) = dwarf.unit(header) else {
+        let Ok(unit) = self.unit(cu_offset) else {
             return;
         };
         let Ok(entry) = unit.entry(die_offset) else {
@@ -234,15 +231,10 @@ impl LoadedObjfile {
             .cloned()?;
 
         if let Some(inline_idx) = Self::find_innermost_inline_node(&func, address) {
-            let dwarf = self.dwarf();
-            if let Ok(header) = dwarf.unit_header(func.cu_offset) {
-                if let Ok(unit) = dwarf.unit(header) {
-                    if let Some(off) = func.nodes[inline_idx].die_offset {
-                        if let Ok(entry) = unit.entry(off) {
-                            return Some(
-                                entry.tag() == gimli::constants::DW_TAG_inlined_subroutine,
-                            );
-                        }
+            if let Ok(unit) = self.unit(func.cu_offset) {
+                if let Some(off) = func.nodes[inline_idx].die_offset {
+                    if let Ok(entry) = unit.entry(off) {
+                        return Some(entry.tag() == gimli::constants::DW_TAG_inlined_subroutine);
                     }
                 }
             }
@@ -352,8 +344,7 @@ impl LoadedObjfile {
     ) -> Result<Vec<crate::parser::ParsedVariable>> {
         let mut vars = Vec::with_capacity(items.len());
         for (cu_off, die_off, scope_depth) in items.iter().cloned() {
-            let header = self.dwarf.unit_header(cu_off)?;
-            let unit = self.dwarf.unit(header)?;
+            let unit = self.unit(cu_off)?;
             let entry = unit.entry(die_off)?;
             if let Some(v) = self.detailed_parser.parse_variable_entry_with_mode(
                 &entry,
@@ -409,30 +400,26 @@ impl LoadedObjfile {
             .find_typedef(name);
         if let Some(td) = typedef {
             let dwarf = self.dwarf();
-            if let Ok(header) = dwarf.unit_header(td.cu_offset) {
-                if let Ok(unit) = dwarf.unit(header) {
-                    if let Ok(entry) = unit.entry(td.die_offset) {
-                        if let Ok(Some(type_loc)) =
-                            resolve_type_ref_with_origins(dwarf, &entry, &unit)
-                        {
-                            let ty =
-                                self.detailed_shallow_type(type_loc.cu_off, type_loc.die_off)?;
-                            return Some((ty, type_loc));
-                        }
-                        let ty = crate::parser::DetailedParser::resolve_type_shallow_at_offset(
-                            dwarf,
-                            &unit,
-                            td.die_offset,
-                            self.compilation_unit_language(td.cu_offset, &unit),
-                        )?;
-                        return Some((
-                            ty,
-                            TypeLoc {
-                                cu_off: td.cu_offset,
-                                die_off: td.die_offset,
-                            },
-                        ));
+            if let Ok(unit) = self.unit(td.cu_offset) {
+                if let Ok(entry) = unit.entry(td.die_offset) {
+                    if let Ok(Some(type_loc)) = resolve_type_ref_with_origins(dwarf, &entry, &unit)
+                    {
+                        let ty = self.detailed_shallow_type(type_loc.cu_off, type_loc.die_off)?;
+                        return Some((ty, type_loc));
                     }
+                    let ty = crate::parser::DetailedParser::resolve_type_shallow_at_offset(
+                        dwarf,
+                        &unit,
+                        td.die_offset,
+                        self.compilation_unit_language(td.cu_offset, &unit),
+                    )?;
+                    return Some((
+                        ty,
+                        TypeLoc {
+                            cu_off: td.cu_offset,
+                            die_off: td.die_offset,
+                        },
+                    ));
                 }
             }
         }
@@ -547,8 +534,7 @@ impl LoadedObjfile {
         let cu_off = gimli::DebugInfoOffset(function.declaration.cu.0 as usize);
         let die_off = gimli::UnitOffset(function.declaration.offset as usize);
         let dwarf = self.dwarf();
-        let header = dwarf.unit_header(cu_off)?;
-        let unit = dwarf.unit(header)?;
+        let unit = self.unit(cu_off)?;
         let entry = unit.entry(die_off)?;
 
         let params = self.direct_function_parameters(dwarf, &unit, &entry)?;
@@ -631,8 +617,7 @@ impl LoadedObjfile {
 
     fn variable_name_for_ref(&self, var_ref: &VarRef) -> Option<String> {
         let dwarf = self.dwarf();
-        let header = dwarf.unit_header(var_ref.cu_offset).ok()?;
-        let unit = dwarf.unit(header).ok()?;
+        let unit = self.unit(var_ref.cu_offset).ok()?;
         let entry = unit.entry(var_ref.die_offset).ok()?;
         resolve_name_with_origins(dwarf, &unit, &entry)
             .ok()
@@ -655,8 +640,7 @@ impl LoadedObjfile {
         pc: u64,
     ) -> Option<crate::core::CfaResult> {
         let dwarf = self.dwarf();
-        let header = dwarf.unit_header(func.cu_offset).ok()?;
-        let unit = dwarf.unit(header).ok()?;
+        let unit = self.unit(func.cu_offset).ok()?;
         let path = func.block_path_for_pc(pc);
         let mut candidates: Vec<gimli::UnitOffset> = Vec::new();
         for &idx in path.iter().rev() {
@@ -744,8 +728,7 @@ impl LoadedObjfile {
         die_off: gimli::UnitOffset,
     ) -> Option<crate::TypeInfo> {
         let dwarf = self.dwarf();
-        let header = dwarf.unit_header(cu_off).ok()?;
-        let unit = dwarf.unit(header).ok()?;
+        let unit = self.unit(cu_off).ok()?;
         let entry = unit.entry(die_off).ok()?;
         let definition = complete_aggregate_declaration_entry(
             dwarf,
@@ -757,8 +740,7 @@ impl LoadedObjfile {
             &entry,
         );
         if let Some((def_cu_off, def_die_off)) = definition {
-            let def_header = dwarf.unit_header(def_cu_off).ok()?;
-            let def_unit = dwarf.unit(def_header).ok()?;
+            let def_unit = self.unit(def_cu_off).ok()?;
             return crate::parser::DetailedParser::resolve_type_shallow_at_offset(
                 dwarf,
                 &def_unit,
@@ -781,8 +763,7 @@ impl LoadedObjfile {
         die_off: gimli::UnitOffset,
     ) -> Option<crate::TypeInfo> {
         let dwarf = self.dwarf();
-        let header = dwarf.unit_header(cu_off).ok()?;
-        let unit = dwarf.unit(header).ok()?;
+        let unit = self.unit(cu_off).ok()?;
         let entry = unit.entry(die_off).ok()?;
         match resolve_type_ref_with_origins(dwarf, &entry, &unit) {
             Ok(Some(type_loc)) => self.detailed_shallow_type(type_loc.cu_off, type_loc.die_off),


### PR DESCRIPTION
## Summary

- reuse immutable parsed DWARF units through a bounded per-objfile cache
- keep hot cache hits on a shared lock and cap retained units at 64 entries
- route variable, type, frame-base, identity, and diagnostic lookups through the cache
- cover reuse, eviction, concurrent misses, and parse-error behavior with fixture-based tests

## Performance

- query-hotspot average: 1.615 ms -> 0.621 ms (61.5% faster)
- query-hotspot p95: 1.755 ms -> 0.701 ms (60.0% faster)
- parse-stress steady-state average: 2.118 ms -> 1.673 ms (21.0% faster)
- Callgrind instructions: 1.117B -> 378.4M (66.1% fewer)
- line-program header parses per 100 queries: 4,907 -> 8
- observed RSS delta: +41 KB (+0.23%, within run-to-run noise)

## Validation

- cargo fmt --all -- --check
- cargo test -p ghostscope-dwarf --all-features
- cargo test -p ghostscope-dwarf --release parsed_unit_cache --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- standard host-host e2e through runner service (job 8d3068a56bfb, exit 0)

Container-topology e2e was intentionally skipped because this change does not affect container or PID-namespace behavior.