### PR TITLE
fix: handle overlapping compilation unit ranges

### DIFF
--- a/e2e-tests/tests/dwarf_index_regressions.rs
+++ b/e2e-tests/tests/dwarf_index_regressions.rs
@@ -4,10 +4,10 @@ use anyhow::Context;
 use common::{fixture_compiler_available, init, FixtureCompiler, OptimizationLevel, FIXTURES};
 use gimli::write::{
     Address, AttributeValue as WriteAttributeValue, DebugInfoRef as WriteDebugInfoRef,
-    Dwarf as WriteDwarf, EndianVec, LineProgram, Sections, Unit,
+    Dwarf as WriteDwarf, EndianVec, LineProgram, LineString, Sections, Unit,
 };
 use gimli::Reader;
-use gimli::{Format, SectionId};
+use gimli::{Format, LineEncoding, SectionId};
 use object::{Object, ObjectSection, ObjectSymbol};
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -21,6 +21,14 @@ use tempfile::TempPath;
 // Keep these on the executable inline-body lines in inline_callsite_program.c.
 const INLINE_TRACE_LINE: u32 = 43;
 const COMPLEX_DUPLICATE_PC_LINE: u32 = 20;
+const OVERLAPPING_CU_OUTER_START: u64 = 0x501000;
+const OVERLAPPING_CU_OUTER_ROW_ADDRESS: u64 = 0x501020;
+const OVERLAPPING_CU_INNER_START: u64 = 0x501040;
+const OVERLAPPING_CU_INNER_LINE_END: u64 = 0x501060;
+const OVERLAPPING_CU_TARGET_ADDRESS: u64 = 0x501080;
+const OVERLAPPING_CU_INNER_END: u64 = 0x5010c0;
+const OVERLAPPING_CU_OUTER_END: u64 = 0x501100;
+const OVERLAPPING_CU_TARGET_LINE: u32 = 42;
 
 type TestReader = gimli::EndianArcSlice<gimli::RunTimeEndian>;
 
@@ -1036,6 +1044,176 @@ fn build_cross_cu_ref_addr_binary(out_dir: &Path) -> anyhow::Result<Option<PathB
     Ok(Some(binary))
 }
 
+fn add_overlapping_cu(
+    dwarf: &mut WriteDwarf,
+    encoding: gimli::Encoding,
+    source_name: &[u8],
+    function_name: &[u8],
+    range: std::ops::Range<u64>,
+    row_address: u64,
+    line_end: u64,
+    row_line: u32,
+) {
+    debug_assert!(range.start <= row_address);
+    debug_assert!(row_address < line_end);
+    debug_assert!(line_end <= range.end);
+
+    let source = LineString::String(source_name.to_vec());
+    let mut line_program = LineProgram::new(
+        encoding,
+        LineEncoding::default(),
+        LineString::String(b"/synthetic".to_vec()),
+        None,
+        source.clone(),
+        None,
+    );
+    let file = line_program.add_file(source, line_program.default_directory(), None);
+    line_program.begin_sequence(Some(Address::Constant(range.start)));
+    {
+        let row = line_program.row();
+        row.address_offset = row_address - range.start;
+        row.file = file;
+        row.line = u64::from(row_line);
+        row.is_statement = true;
+    }
+    line_program.generate_row();
+    line_program.end_sequence(line_end - range.start);
+
+    let unit_id = dwarf.units.add(Unit::new(encoding, line_program));
+    let unit = dwarf.units.get_mut(unit_id);
+    let root = unit.root();
+    let root_entry = unit.get_mut(root);
+    root_entry.set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(source_name.to_vec()),
+    );
+    root_entry.set(
+        gimli::constants::DW_AT_comp_dir,
+        WriteAttributeValue::String(b"/synthetic".to_vec()),
+    );
+    root_entry.set(
+        gimli::constants::DW_AT_low_pc,
+        WriteAttributeValue::Address(Address::Constant(range.start)),
+    );
+    root_entry.set(
+        gimli::constants::DW_AT_high_pc,
+        WriteAttributeValue::Udata(range.end - range.start),
+    );
+
+    let function = unit.add(root, gimli::constants::DW_TAG_subprogram);
+    let function_entry = unit.get_mut(function);
+    function_entry.set(
+        gimli::constants::DW_AT_name,
+        WriteAttributeValue::String(function_name.to_vec()),
+    );
+    function_entry.set(
+        gimli::constants::DW_AT_low_pc,
+        WriteAttributeValue::Address(Address::Constant(range.start)),
+    );
+    function_entry.set(
+        gimli::constants::DW_AT_high_pc,
+        WriteAttributeValue::Udata(range.end - range.start),
+    );
+}
+
+fn write_overlapping_cu_dwarf_sections(out_dir: &Path) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let encoding = gimli::Encoding {
+        format: Format::Dwarf32,
+        version: 5,
+        address_size: 8,
+    };
+    let mut dwarf = WriteDwarf::new();
+
+    add_overlapping_cu(
+        &mut dwarf,
+        encoding,
+        b"overlap_outer.c",
+        b"overlap_outer",
+        OVERLAPPING_CU_OUTER_START..OVERLAPPING_CU_OUTER_END,
+        OVERLAPPING_CU_OUTER_ROW_ADDRESS,
+        OVERLAPPING_CU_OUTER_END,
+        OVERLAPPING_CU_TARGET_LINE,
+    );
+    add_overlapping_cu(
+        &mut dwarf,
+        encoding,
+        b"overlap_inner.c",
+        b"overlap_inner",
+        OVERLAPPING_CU_INNER_START..OVERLAPPING_CU_INNER_END,
+        OVERLAPPING_CU_INNER_START,
+        OVERLAPPING_CU_INNER_LINE_END,
+        7,
+    );
+
+    let mut sections = Sections::new(EndianVec::new(gimli::LittleEndian));
+    dwarf.write(&mut sections)?;
+
+    let mut written = Vec::new();
+    for id in [
+        SectionId::DebugAbbrev,
+        SectionId::DebugInfo,
+        SectionId::DebugLine,
+        SectionId::DebugLineStr,
+        SectionId::DebugStr,
+    ] {
+        let data = sections
+            .get(id)
+            .map(|section| section.slice().to_vec())
+            .unwrap_or_default();
+        if data.is_empty() {
+            continue;
+        }
+        let path = out_dir.join(format!("overlap-{}.bin", id.name().trim_start_matches('.')));
+        fs::write(&path, data)?;
+        written.push((id.name().to_string(), path));
+    }
+    Ok(written)
+}
+
+fn build_overlapping_cu_binary(out_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let Some(cc) = preferred_c_compiler() else {
+        eprintln!("Skipping overlapping-CU e2e: no C compiler is available");
+        return Ok(None);
+    };
+    if !command_available("objcopy") {
+        eprintln!("Skipping overlapping-CU e2e: objcopy is unavailable");
+        return Ok(None);
+    }
+
+    let source = out_dir.join("overlapping_cu_stub.c");
+    let binary = out_dir.join("overlapping_cu_stub");
+    fs::write(&source, "int main(void) { return 0; }\n")?;
+    run_command(
+        StdCommand::new(cc).arg("-o").arg(&binary).arg(&source),
+        "compile overlapping-CU stub",
+    )?;
+
+    let sections = write_overlapping_cu_dwarf_sections(out_dir)?;
+    let mut objcopy = StdCommand::new("objcopy");
+    for (section_name, section_path) in &sections {
+        objcopy
+            .arg("--add-section")
+            .arg(format!("{section_name}={}", section_path.display()));
+    }
+    objcopy.arg(&binary);
+    run_command(&mut objcopy, "objcopy --add-section overlapping-CU DWARF")?;
+    Ok(Some(binary))
+}
+
+fn compilation_unit_ranges(binary_path: &Path) -> anyhow::Result<Vec<std::ops::Range<u64>>> {
+    let dwarf = load_dwarf_from_binary(binary_path)?;
+    let mut units = dwarf.units();
+    let mut ranges = Vec::new();
+    while let Some(header) = units.next()? {
+        let unit = dwarf.unit(header)?;
+        let mut unit_ranges = dwarf.unit_ranges(&unit)?;
+        while let Some(range) = unit_ranges.next()? {
+            ranges.push(range.begin..range.end);
+        }
+    }
+    Ok(ranges)
+}
+
 fn cross_cu_ref_addr_attrs(binary_path: &Path) -> anyhow::Result<HashSet<gimli::DwAt>> {
     let dwarf = load_dwarf_from_binary(binary_path)?;
     let mut found = HashSet::new();
@@ -1287,6 +1465,54 @@ async fn test_cross_cu_ref_addr_origin_and_spec_names_are_indexed() -> anyhow::R
         16,
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_overlapping_cu_inactive_line_row_does_not_hide_outer_source_location(
+) -> anyhow::Result<()> {
+    init();
+
+    let temp_dir = tempfile::tempdir()?;
+    let Some(binary_path) = build_overlapping_cu_binary(temp_dir.path())? else {
+        return Ok(());
+    };
+
+    let ranges = compilation_unit_ranges(&binary_path)?;
+    let outer_range = OVERLAPPING_CU_OUTER_START..OVERLAPPING_CU_OUTER_END;
+    let inner_range = OVERLAPPING_CU_INNER_START..OVERLAPPING_CU_INNER_END;
+    assert!(
+        ranges.contains(&outer_range),
+        "fixture is missing the outer CU range: {ranges:x?}"
+    );
+    assert!(
+        ranges.contains(&inner_range),
+        "fixture is missing the inner CU range: {ranges:x?}"
+    );
+    assert!(outer_range.contains(&OVERLAPPING_CU_TARGET_ADDRESS));
+    assert!(inner_range.contains(&OVERLAPPING_CU_TARGET_ADDRESS));
+    assert!(OVERLAPPING_CU_OUTER_ROW_ADDRESS < OVERLAPPING_CU_TARGET_ADDRESS);
+    assert!(OVERLAPPING_CU_INNER_LINE_END <= OVERLAPPING_CU_TARGET_ADDRESS);
+    let nearest_preceding = ranges
+        .iter()
+        .filter(|range| range.start <= OVERLAPPING_CU_TARGET_ADDRESS)
+        .max_by_key(|range| range.start)
+        .context("fixture has no CU range before the target address")?;
+    assert_eq!(nearest_preceding, &inner_range);
+
+    let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&binary_path).await?;
+    let location = analyzer
+        .lookup_source_location(&ghostscope_dwarf::ModuleAddress::new(
+            binary_path,
+            OVERLAPPING_CU_TARGET_ADDRESS,
+        ))
+        .context("outer CU source location should survive an intervening overlapping CU")?;
+    assert!(
+        location.file_path.ends_with("overlap_outer.c"),
+        "unexpected source file: {location:?}"
+    );
+    assert_eq!(location.line_number, OVERLAPPING_CU_TARGET_LINE);
+    assert_eq!(location.address, OVERLAPPING_CU_OUTER_ROW_ADDRESS);
     Ok(())
 }
 

--- a/ghostscope-dwarf/src/index/lightweight_index.rs
+++ b/ghostscope-dwarf/src/index/lightweight_index.rs
@@ -102,6 +102,15 @@ struct NameIndexShard {
     type_map: HashMap<String, Vec<usize>>,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct CuRange {
+    start: u64,
+    end: u64,
+    cu: DebugInfoOffset,
+    /// Largest end address in this entry and every preceding entry.
+    max_end: u64,
+}
+
 /// Cooked index - inspired by GDB's cooked_index design
 /// Contains lightweight entries for fast symbol lookup
 #[derive(Debug)]
@@ -118,8 +127,8 @@ pub struct LightweightIndex {
     total_functions: usize,
     total_variables: usize,
 
-    /// Optional fast PC→CU map built from aranges or representative-address fallback.
-    cu_range_map: BTreeMap<u64, (u64, DebugInfoOffset)>,
+    /// Sorted, overlap-aware PC→CU ranges built from aranges or DIE ranges.
+    cu_ranges: Vec<CuRange>,
     /// Optional per-CU function representative-address map (start -> entry idx)
     func_addr_by_cu: HashMap<DebugInfoOffset, BTreeMap<u64, usize>>,
     /// All function-like entries in each CU for correctness fallback scans.
@@ -138,7 +147,7 @@ impl LightweightIndex {
             address_map: BTreeMap::new(),
             total_functions: 0,
             total_variables: 0,
-            cu_range_map: BTreeMap::new(),
+            cu_ranges: Vec::new(),
             func_addr_by_cu: HashMap::new(),
             func_indices_by_cu: HashMap::new(),
             cu_maps_built: false,
@@ -424,25 +433,32 @@ impl LightweightIndex {
     }
 
     fn insert_cu_range(
-        cu_map: &mut BTreeMap<u64, (u64, DebugInfoOffset)>,
+        cu_ranges: &mut Vec<CuRange>,
         start: u64,
         end: u64,
         cu: DebugInfoOffset,
-    ) {
-        if start > end {
-            return;
+    ) -> bool {
+        if start >= end {
+            return false;
         }
 
-        match cu_map.get_mut(&start) {
-            Some((existing_end, existing_cu)) => {
-                if end > *existing_end {
-                    *existing_end = end;
-                    *existing_cu = cu;
-                }
-            }
-            None => {
-                cu_map.insert(start, (end, cu));
-            }
+        cu_ranges.push(CuRange {
+            start,
+            end,
+            cu,
+            max_end: 0,
+        });
+        true
+    }
+
+    fn finalize_cu_ranges(cu_ranges: &mut Vec<CuRange>) {
+        cu_ranges.sort_unstable_by_key(|range| (range.start, range.end, range.cu.0));
+        cu_ranges.dedup_by_key(|range| (range.start, range.end, range.cu.0));
+
+        let mut max_end = 0;
+        for range in cu_ranges {
+            max_end = max_end.max(range.end);
+            range.max_end = max_end;
         }
     }
 
@@ -473,7 +489,7 @@ impl LightweightIndex {
 
     /// Attach CU range map and per-CU function address map built from entries
     pub fn build_cu_maps(&mut self, dwarf: &gimli::Dwarf<DwarfReader>) {
-        let mut cu_map: BTreeMap<u64, (u64, DebugInfoOffset)> = BTreeMap::new();
+        let mut cu_ranges = Vec::new();
         let mut per_cu: HashMap<DebugInfoOffset, BTreeMap<u64, usize>> = HashMap::new();
 
         for (idx, entry) in self.entries.iter().enumerate() {
@@ -492,7 +508,7 @@ impl LightweightIndex {
             let root_ranges = Self::resolve_cu_root_ranges(dwarf, cu).unwrap_or_default();
             if !root_ranges.is_empty() {
                 for (start, end) in root_ranges {
-                    Self::insert_cu_range(&mut cu_map, start, end, cu);
+                    Self::insert_cu_range(&mut cu_ranges, start, end, cu);
                 }
                 continue;
             }
@@ -505,12 +521,13 @@ impl LightweightIndex {
                     continue;
                 };
                 for (start, end) in ranges {
-                    Self::insert_cu_range(&mut cu_map, start, end, cu);
+                    Self::insert_cu_range(&mut cu_ranges, start, end, cu);
                 }
             }
         }
 
-        self.cu_range_map = cu_map;
+        Self::finalize_cu_ranges(&mut cu_ranges);
+        self.cu_ranges = cu_ranges;
         self.func_addr_by_cu = per_cu;
         self.cu_maps_built = true;
     }
@@ -533,8 +550,8 @@ impl LightweightIndex {
                             Ok(Some(arange)) => {
                                 let start = arange.address();
                                 let end = arange.range().end;
-                                Self::insert_cu_range(&mut self.cu_range_map, start, end, cu_off);
-                                added_any = true;
+                                added_any |=
+                                    Self::insert_cu_range(&mut self.cu_ranges, start, end, cu_off);
                             }
                             Ok(None) => break,
                             Err(e) => {
@@ -554,6 +571,7 @@ impl LightweightIndex {
             }
         }
 
+        Self::finalize_cu_ranges(&mut self.cu_ranges);
         self.cu_maps_built = true;
         added_any
     }
@@ -564,22 +582,28 @@ impl LightweightIndex {
         let mut added_any = false;
         for cu in compilation_units {
             for (start, end) in Self::resolve_cu_root_ranges(dwarf, cu).unwrap_or_default() {
-                Self::insert_cu_range(&mut self.cu_range_map, start, end, cu);
-                added_any = true;
+                added_any |= Self::insert_cu_range(&mut self.cu_ranges, start, end, cu);
             }
         }
+        Self::finalize_cu_ranges(&mut self.cu_ranges);
         self.cu_maps_built = true;
         added_any
     }
 
-    /// Find compilation unit by address using CU range map
-    pub fn find_cu_by_address(&self, address: u64) -> Option<DebugInfoOffset> {
-        if let Some((_, (end, cu))) = self.cu_range_map.range(..=address).next_back() {
-            if address <= *end {
-                return Some(*cu);
-            }
-        }
-        None
+    /// Find every compilation unit whose half-open range contains `address`.
+    pub(crate) fn find_cus_by_address(
+        &self,
+        address: u64,
+    ) -> impl Iterator<Item = DebugInfoOffset> + '_ {
+        let end = self
+            .cu_ranges
+            .partition_point(|range| range.start <= address);
+        self.cu_ranges[..end]
+            .iter()
+            .rev()
+            .take_while(move |range| address < range.max_end)
+            .filter(move |range| range.start <= address && address < range.end)
+            .map(|range| range.cu)
     }
 
     /// Find the subprogram DIE that contains the given address.
@@ -596,7 +620,7 @@ impl LightweightIndex {
             "LightweightIndex::find_function_by_address requires build_cu_maps before address lookup"
         );
 
-        if let Some(cu) = self.find_cu_by_address(address) {
+        for cu in self.find_cus_by_address(address) {
             if let Some(map) = self.func_addr_by_cu.get(&cu) {
                 if let Some(entry) = self.find_matching_function_in_indices(
                     map.range(..=address).rev().map(|(_, &idx)| idx),
@@ -682,5 +706,54 @@ impl LightweightIndex {
 impl Default for LightweightIndex {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index_with_ranges(ranges: &[(u64, u64, usize)]) -> LightweightIndex {
+        let mut index = LightweightIndex::new();
+        for &(start, end, cu) in ranges {
+            LightweightIndex::insert_cu_range(
+                &mut index.cu_ranges,
+                start,
+                end,
+                DebugInfoOffset(cu),
+            );
+        }
+        LightweightIndex::finalize_cu_ranges(&mut index.cu_ranges);
+        index
+    }
+
+    #[test]
+    fn nested_cu_range_does_not_hide_outer_match() {
+        let index = index_with_ranges(&[(0x1000, 0x1100, 1), (0x1040, 0x1060, 2)]);
+
+        assert_eq!(
+            index.find_cus_by_address(0x1080).collect::<Vec<_>>(),
+            vec![DebugInfoOffset(1)]
+        );
+    }
+
+    #[test]
+    fn overlapping_cu_lookup_preserves_candidates_and_half_open_ends() {
+        let index = index_with_ranges(&[
+            (0x1000, 0x1100, 1),
+            (0x1040, 0x1060, 2),
+            (0x1040, 0x1080, 3),
+            (0x1080, 0x1080, 4),
+        ]);
+
+        assert_eq!(
+            index.find_cus_by_address(0x1050).collect::<Vec<_>>(),
+            vec![DebugInfoOffset(3), DebugInfoOffset(2), DebugInfoOffset(1)]
+        );
+        assert_eq!(
+            index.find_cus_by_address(0x1060).collect::<Vec<_>>(),
+            vec![DebugInfoOffset(3), DebugInfoOffset(1)]
+        );
+        assert!(index.find_cus_by_address(0x1100).next().is_none());
     }
 }

--- a/ghostscope-dwarf/src/index/line_mapping.rs
+++ b/ghostscope-dwarf/src/index/line_mapping.rs
@@ -6,6 +6,39 @@ use std::{
     ops::Bound,
 };
 
+/// Maximum row end seen at or before an address group.
+///
+/// `LineEntry::end_address == None` means that the row has no known upper
+/// bound, so every later prefix containing that row remains unbounded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PrefixMaxEnd {
+    Finite(u64),
+    Unbounded,
+}
+
+impl PrefixMaxEnd {
+    fn from_end_address(end_address: Option<u64>) -> Self {
+        match end_address {
+            Some(end_address) => Self::Finite(end_address),
+            None => Self::Unbounded,
+        }
+    }
+
+    fn include(self, end_address: Option<u64>) -> Self {
+        match (self, end_address) {
+            (Self::Unbounded, _) | (_, None) => Self::Unbounded,
+            (Self::Finite(current), Some(end_address)) => Self::Finite(current.max(end_address)),
+        }
+    }
+
+    fn can_cover(self, address: u64) -> bool {
+        match self {
+            Self::Finite(end_address) => address < end_address,
+            Self::Unbounded => true,
+        }
+    }
+}
+
 /// Pure line mapping table for fast address→line lookup
 #[derive(Debug)]
 pub struct LineMappingTable {
@@ -30,12 +63,25 @@ pub struct LineMappingTable {
     /// `address_group_addresses`.
     address_group_starts: Vec<usize>,
 
+    /// Maximum row end at or before each compact address group.
+    ///
+    /// This lets reverse lookups stop as soon as no earlier compact row can
+    /// cover the target address.
+    address_group_prefix_max_ends: Vec<PrefixMaxEnd>,
+
     /// Rows added after the compact base was built.
     ///
     /// Lazy line loading can append one compilation unit at a time. Keeping
     /// those rows in an incremental index avoids moving and re-indexing every
     /// previously loaded row on each append.
     incremental_entries: BTreeMap<u64, Vec<LineEntry>>,
+
+    /// Addresses and prefix maximum row ends for `incremental_entries`.
+    ///
+    /// These vectors keep miss lookups logarithmic without rebuilding the
+    /// compact base whenever another compilation unit is loaded.
+    incremental_group_addresses: Vec<u64>,
+    incremental_group_prefix_max_ends: Vec<PrefixMaxEnd>,
 
     /// Number of rows in `incremental_entries`.
     incremental_entry_count: usize,
@@ -92,31 +138,69 @@ impl LineMappingTable {
         // Stable sorting preserves insertion order for duplicate-address rows,
         // including the "last row is representative" behavior.
         entries.sort_by_key(|entry| entry.address);
-        let (address_group_addresses, address_group_starts) = Self::build_address_groups(&entries);
+        let (address_group_addresses, address_group_starts, address_group_prefix_max_ends) =
+            Self::build_address_groups(&entries);
 
         Self {
             entries,
             address_group_addresses,
             address_group_starts,
+            address_group_prefix_max_ends,
             incremental_entries: BTreeMap::new(),
+            incremental_group_addresses: Vec::new(),
+            incremental_group_prefix_max_ends: Vec::new(),
             incremental_entry_count: 0,
             path_line_to_addresses,
             basename_to_paths,
         }
     }
 
-    fn build_address_groups(entries: &[LineEntry]) -> (Vec<u64>, Vec<usize>) {
+    fn build_address_groups(entries: &[LineEntry]) -> (Vec<u64>, Vec<usize>, Vec<PrefixMaxEnd>) {
         let mut addresses = Vec::new();
         let mut starts = Vec::new();
+        let mut prefix_max_ends = Vec::new();
         let mut previous_address = None;
+        let mut prefix_max_end: Option<PrefixMaxEnd> = None;
         for (index, entry) in entries.iter().enumerate() {
+            prefix_max_end = Some(match prefix_max_end {
+                Some(prefix_max_end) => prefix_max_end.include(entry.end_address),
+                None => PrefixMaxEnd::from_end_address(entry.end_address),
+            });
+
             if previous_address != Some(entry.address) {
                 addresses.push(entry.address);
                 starts.push(index);
+                prefix_max_ends.push(prefix_max_end.expect("included current line entry"));
                 previous_address = Some(entry.address);
+            } else {
+                *prefix_max_ends
+                    .last_mut()
+                    .expect("duplicate address follows an address group") =
+                    prefix_max_end.expect("included current line entry");
             }
         }
-        (addresses, starts)
+        (addresses, starts, prefix_max_ends)
+    }
+
+    fn build_incremental_address_groups(
+        entries: &BTreeMap<u64, Vec<LineEntry>>,
+    ) -> (Vec<u64>, Vec<PrefixMaxEnd>) {
+        let mut addresses = Vec::with_capacity(entries.len());
+        let mut prefix_max_ends = Vec::with_capacity(entries.len());
+        let mut prefix_max_end: Option<PrefixMaxEnd> = None;
+
+        for (&address, entries) in entries {
+            for entry in entries {
+                prefix_max_end = Some(match prefix_max_end {
+                    Some(prefix_max_end) => prefix_max_end.include(entry.end_address),
+                    None => PrefixMaxEnd::from_end_address(entry.end_address),
+                });
+            }
+            addresses.push(address);
+            prefix_max_ends.push(prefix_max_end.expect("incremental address group is non-empty"));
+        }
+
+        (addresses, prefix_max_ends)
     }
 
     fn group_entries(&self, group_index: usize) -> &[LineEntry] {
@@ -238,8 +322,13 @@ impl LineMappingTable {
         merged.extend(compact_entries);
         merged.extend(incremental_entries);
         self.entries = merged;
-        (self.address_group_addresses, self.address_group_starts) =
-            Self::build_address_groups(&self.entries);
+        (
+            self.address_group_addresses,
+            self.address_group_starts,
+            self.address_group_prefix_max_ends,
+        ) = Self::build_address_groups(&self.entries);
+        self.incremental_group_addresses.clear();
+        self.incremental_group_prefix_max_ends.clear();
         self.incremental_entry_count = 0;
     }
 
@@ -285,6 +374,11 @@ impl LineMappingTable {
         // row participates in only logarithmically many full merges.
         if self.incremental_entry_count >= self.entries.len().max(1) {
             self.compact_incremental_entries();
+        } else {
+            (
+                self.incremental_group_addresses,
+                self.incremental_group_prefix_max_ends,
+            ) = Self::build_incremental_address_groups(&self.incremental_entries);
         }
     }
 
@@ -292,39 +386,101 @@ impl LineMappingTable {
         entries.last()
     }
 
-    /// Find best matching line (closest address <= target address)
+    fn active_representative_entry(entries: &[LineEntry], address: u64) -> Option<&LineEntry> {
+        entries
+            .iter()
+            .rev()
+            .find(|entry| entry.contains_address(address))
+    }
+
+    /// Find the closest active line row at or before the target address.
     pub(crate) fn lookup_line(&self, address: u64) -> Option<&LineEntry> {
-        let compact_candidate = self
+        let mut compact_group = self
             .address_group_addresses
-            .partition_point(|&candidate| candidate <= address)
-            .checked_sub(1);
-        let compact_candidate = compact_candidate.and_then(|group_index| {
-            Self::representative_entry(self.group_entries(group_index))
-                .map(|entry| (entry.address, entry))
-        });
-        let incremental_candidate = if self.incremental_entries.is_empty() {
-            None
-        } else {
-            self.incremental_entries
-                .range(..=address)
-                .next_back()
-                .and_then(|(&candidate_address, entries)| {
-                    Self::representative_entry(entries).map(|entry| (candidate_address, entry))
-                })
-        };
-        let result = match (compact_candidate, incremental_candidate) {
-            (Some((compact_address, compact)), Some((incremental_address, incremental))) => {
-                if compact_address > incremental_address {
-                    Some(compact)
-                } else {
-                    Some(incremental)
-                }
+            .partition_point(|&candidate| candidate <= address);
+        let mut incremental_group = self
+            .incremental_group_addresses
+            .partition_point(|&candidate| candidate <= address);
+        let mut incremental = self.incremental_entries.range(..=address).rev();
+
+        // Rows from overlapping compilation units can interleave by start
+        // address. A later row whose sequence already ended must not hide an
+        // earlier row that still covers the target. Prefix maximum ends let
+        // each store drop out as soon as none of its remaining rows can cover
+        // the target, keeping sequence-gap misses bounded.
+        let result = loop {
+            if compact_group > 0
+                && !self.address_group_prefix_max_ends[compact_group - 1].can_cover(address)
+            {
+                compact_group = 0;
             }
-            (Some((_, compact)), None) => Some(compact),
-            (None, Some((_, incremental))) => Some(incremental),
-            (None, None) => None,
-        }
-        .filter(|entry| entry.contains_address(address));
+            if incremental_group > 0
+                && !self.incremental_group_prefix_max_ends[incremental_group - 1].can_cover(address)
+            {
+                incremental_group = 0;
+            }
+
+            let compact_group_index = compact_group.checked_sub(1);
+            let compact_address =
+                compact_group_index.map(|group_index| self.address_group_addresses[group_index]);
+            let incremental_address = incremental_group
+                .checked_sub(1)
+                .map(|group_index| self.incremental_group_addresses[group_index]);
+
+            match (compact_address, incremental_address) {
+                (Some(compact_address), Some(incremental_address))
+                    if compact_address > incremental_address =>
+                {
+                    compact_group -= 1;
+                    if let Some(entry) = Self::active_representative_entry(
+                        self.group_entries(compact_group),
+                        address,
+                    ) {
+                        break Some(entry);
+                    }
+                }
+                (Some(compact_address), Some(incremental_address))
+                    if compact_address == incremental_address =>
+                {
+                    compact_group -= 1;
+                    incremental_group -= 1;
+                    let (actual_address, incremental_entries) =
+                        incremental.next().expect("indexed incremental line group");
+                    debug_assert_eq!(*actual_address, incremental_address);
+                    if let Some(entry) =
+                        Self::active_representative_entry(incremental_entries, address).or_else(
+                            || {
+                                Self::active_representative_entry(
+                                    self.group_entries(compact_group),
+                                    address,
+                                )
+                            },
+                        )
+                    {
+                        break Some(entry);
+                    }
+                }
+                (_, Some(incremental_address)) => {
+                    incremental_group -= 1;
+                    let (actual_address, entries) =
+                        incremental.next().expect("indexed incremental line group");
+                    debug_assert_eq!(*actual_address, incremental_address);
+                    if let Some(entry) = Self::active_representative_entry(entries, address) {
+                        break Some(entry);
+                    }
+                }
+                (Some(_), None) => {
+                    compact_group -= 1;
+                    if let Some(entry) = Self::active_representative_entry(
+                        self.group_entries(compact_group),
+                        address,
+                    ) {
+                        break Some(entry);
+                    }
+                }
+                (None, None) => break None,
+            }
+        };
 
         if let Some(entry) = result {
             tracing::debug!(
@@ -798,6 +954,144 @@ mod tests {
         assert!(table.lookup_line(0x1010).is_none());
         assert!(table.lookup_line(0x1fff).is_none());
         assert_eq!(table.lookup_line(0x2000).map(|entry| entry.line), Some(20));
+    }
+
+    #[test]
+    fn lookup_line_scans_past_inactive_row_from_overlapping_sequence() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let mut outer = line_entry(0x1000, "/src/outer.c", 10, true);
+        outer.end_address = Some(0x1100);
+        let mut inner = line_entry(0x1040, "/src/inner.c", 20, true);
+        inner.end_address = Some(0x1060);
+        let table = LineMappingTable::from_entries_with_scoped_manager(vec![outer, inner], &scoped);
+
+        let entry = table
+            .lookup_line(0x1080)
+            .expect("outer row should remain active after inner sequence ends");
+
+        assert_eq!(entry.file_path, "/src/outer.c");
+        assert_eq!(entry.address, 0x1000);
+    }
+
+    #[test]
+    fn lookup_line_scans_past_inactive_incremental_row() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let mut outer = line_entry(0x1000, "/src/outer.c", 10, true);
+        outer.end_address = Some(0x1100);
+        let mut unrelated = line_entry(0x2000, "/src/unrelated.c", 30, true);
+        unrelated.end_address = Some(0x2010);
+        let mut table =
+            LineMappingTable::from_entries_with_scoped_manager(vec![outer, unrelated], &scoped);
+        let mut inner = line_entry(0x1040, "/src/inner.c", 20, true);
+        inner.end_address = Some(0x1060);
+        table.extend(LineMappingTable::from_entries_with_scoped_manager(
+            vec![inner],
+            &scoped,
+        ));
+
+        let entry = table
+            .lookup_line(0x1080)
+            .expect("compact outer row should survive an inactive incremental row");
+
+        assert_eq!(entry.file_path, "/src/outer.c");
+        assert_eq!(entry.address, 0x1000);
+    }
+
+    #[test]
+    fn lookup_line_prefix_max_ends_bound_compact_and_incremental_misses() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let mut compact_first = line_entry(0x1000, "/src/base.c", 10, true);
+        compact_first.end_address = Some(0x1010);
+        let mut compact_duplicate = line_entry(0x1100, "/src/base.c", 11, true);
+        compact_duplicate.end_address = Some(0x1180);
+        let mut compact_longer_duplicate = line_entry(0x1100, "/src/base.c", 12, true);
+        compact_longer_duplicate.end_address = Some(0x1200);
+        let mut compact_later = line_entry(0x2000, "/src/base.c", 20, true);
+        compact_later.end_address = Some(0x2010);
+        let mut table = LineMappingTable::from_entries_with_scoped_manager(
+            vec![
+                compact_first,
+                compact_duplicate,
+                compact_longer_duplicate,
+                compact_later,
+            ],
+            &scoped,
+        );
+
+        let mut incremental_first = line_entry(0x1400, "/src/lazy.c", 14, true);
+        incremental_first.end_address = Some(0x1500);
+        let mut incremental_later = line_entry(0x1800, "/src/lazy.c", 18, true);
+        incremental_later.end_address = Some(0x1810);
+        table.extend(LineMappingTable::from_entries_with_scoped_manager(
+            vec![incremental_first, incremental_later],
+            &scoped,
+        ));
+
+        assert_eq!(
+            table.address_group_prefix_max_ends,
+            vec![
+                PrefixMaxEnd::Finite(0x1010),
+                PrefixMaxEnd::Finite(0x1200),
+                PrefixMaxEnd::Finite(0x2010),
+            ]
+        );
+        assert_eq!(
+            table.incremental_group_prefix_max_ends,
+            vec![PrefixMaxEnd::Finite(0x1500), PrefixMaxEnd::Finite(0x1810),]
+        );
+        assert!(table.lookup_line(0x1900).is_none());
+    }
+
+    #[test]
+    fn lookup_line_prefix_max_end_treats_unknown_end_as_unbounded() {
+        let scoped = crate::index::ScopedFileIndexManager::new();
+        let compact_unbounded = line_entry(0x1000, "/src/base.c", 10, true);
+        let mut compact_inactive = line_entry(0x1040, "/src/base.c", 11, true);
+        compact_inactive.end_address = Some(0x1060);
+        let mut compact_filler = line_entry(0x3000, "/src/base.c", 30, true);
+        compact_filler.end_address = Some(0x3010);
+        let mut compact_filler_later = line_entry(0x4000, "/src/base.c", 40, true);
+        compact_filler_later.end_address = Some(0x4010);
+        let mut table = LineMappingTable::from_entries_with_scoped_manager(
+            vec![
+                compact_unbounded,
+                compact_inactive,
+                compact_filler,
+                compact_filler_later,
+            ],
+            &scoped,
+        );
+
+        assert_eq!(
+            table.lookup_line(0x1080).map(|entry| entry.address),
+            Some(0x1000)
+        );
+        assert_eq!(
+            table.address_group_prefix_max_ends,
+            vec![
+                PrefixMaxEnd::Unbounded,
+                PrefixMaxEnd::Unbounded,
+                PrefixMaxEnd::Unbounded,
+                PrefixMaxEnd::Unbounded,
+            ]
+        );
+
+        let incremental_unbounded = line_entry(0x2000, "/src/lazy.c", 20, true);
+        let mut incremental_inactive = line_entry(0x2040, "/src/lazy.c", 21, true);
+        incremental_inactive.end_address = Some(0x2060);
+        table.extend(LineMappingTable::from_entries_with_scoped_manager(
+            vec![incremental_unbounded, incremental_inactive],
+            &scoped,
+        ));
+
+        assert_eq!(
+            table.incremental_group_prefix_max_ends,
+            vec![PrefixMaxEnd::Unbounded, PrefixMaxEnd::Unbounded]
+        );
+        assert_eq!(
+            table.lookup_line(0x2080).map(|entry| entry.address),
+            Some(0x2000)
+        );
     }
 
     #[test]

--- a/ghostscope-dwarf/src/index/native_gdb_index.rs
+++ b/ghostscope-dwarf/src/index/native_gdb_index.rs
@@ -116,6 +116,8 @@ pub(crate) struct GdbIndex {
     type_unit_count: usize,
     units: Vec<GdbUnit>,
     address_count: usize,
+    /// Largest end address in each address record and every preceding record.
+    address_prefix_max_end: Vec<u64>,
     symbol_slot_count: usize,
     symbol_names: OnceLock<GdbSymbolNames>,
 }
@@ -200,7 +202,7 @@ impl GdbIndex {
             anyhow::bail!(".gdb_index symbol table size is not a power of two");
         }
 
-        Ok(Self {
+        let mut index = Self {
             data,
             version,
             layout,
@@ -208,9 +210,22 @@ impl GdbIndex {
             type_unit_count,
             units,
             address_count,
+            address_prefix_max_end: Vec::with_capacity(address_count),
             symbol_slot_count,
             symbol_names: OnceLock::new(),
-        })
+        };
+        let mut previous_low = None;
+        let mut max_end = 0;
+        for address_index in 0..address_count {
+            let (low, high, _) = index.read_address(address_index)?;
+            if previous_low.is_some_and(|previous| low < previous) {
+                anyhow::bail!(".gdb_index address records are not ordered");
+            }
+            previous_low = Some(low);
+            max_end = max_end.max(high);
+            index.address_prefix_max_end.push(max_end);
+        }
+        Ok(index)
     }
 
     pub(crate) fn version(&self) -> u32 {
@@ -361,10 +376,7 @@ impl GdbIndex {
             .get(kind))
     }
 
-    pub(crate) fn find_cu_by_address(
-        &self,
-        address: u64,
-    ) -> Result<Option<gimli::DebugInfoOffset>> {
+    pub(crate) fn find_cus_by_address(&self, address: u64) -> Result<Vec<gimli::DebugInfoOffset>> {
         let mut left = 0usize;
         let mut right = self.address_count;
         while left < right {
@@ -377,16 +389,20 @@ impl GdbIndex {
             }
         }
 
+        let mut units = Vec::new();
         for index in (0..left).rev() {
-            let (low, high, cu_index) = self.read_address(index)?;
-            if low <= address && address < high {
-                return self.unit_offset(cu_index).map(Some);
-            }
-            if high <= address {
+            if self.address_prefix_max_end[index] <= address {
                 break;
             }
+            let (low, high, cu_index) = self.read_address(index)?;
+            if low <= address && address < high {
+                let unit = self.unit_offset(cu_index)?;
+                if !units.contains(&unit) {
+                    units.push(unit);
+                }
+            }
         }
-        Ok(None)
+        Ok(units)
     }
 
     fn validate_layout(
@@ -695,6 +711,43 @@ mod tests {
         fixture_with_symbol("target_function", 3 << 28, None)
     }
 
+    fn overlapping_address_fixture() -> Vec<u8> {
+        let mut bytes = vec![0; VERSION_9_HEADER_SIZE];
+        let cu_list = bytes.len();
+        for offset in [0x120, 0x220] {
+            push_u64(&mut bytes, offset);
+            push_u64(&mut bytes, 0x80);
+        }
+        let type_cu_list = bytes.len();
+        let address_area = bytes.len();
+        for (low, high, cu_index) in [(0x4000, 0x4100, 0), (0x4040, 0x4060, 1)] {
+            push_u64(&mut bytes, low);
+            push_u64(&mut bytes, high);
+            push_u32(&mut bytes, cu_index);
+        }
+        let symbol_table = bytes.len();
+        let shortcut_table = bytes.len();
+        push_u32(&mut bytes, 0);
+        push_u32(&mut bytes, 0);
+        let constant_pool = bytes.len();
+
+        write_u32(&mut bytes, 0, 9);
+        for (word, value) in [
+            cu_list,
+            type_cu_list,
+            address_area,
+            symbol_table,
+            shortcut_table,
+            constant_pool,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            write_u32(&mut bytes, (word + 1) * 4, u32::try_from(value).unwrap());
+        }
+        bytes
+    }
+
     fn parse(bytes: Vec<u8>) -> Result<GdbIndex> {
         GdbIndex::parse(dwarf_reader_from_arc_with_endian(
             Arc::from(bytes),
@@ -722,14 +775,32 @@ mod tests {
             .unwrap()
             .is_empty());
         assert_eq!(
-            index.find_cu_by_address(0x4080).unwrap(),
-            Some(gimli::DebugInfoOffset(0x120))
+            index
+                .find_cus_by_address(0x4080)
+                .unwrap()
+                .into_iter()
+                .next(),
+            Some(gimli::DebugInfoOffset(0x120)),
         );
-        assert_eq!(index.find_cu_by_address(0x4100).unwrap(), None);
+        assert!(index.find_cus_by_address(0x4100).unwrap().is_empty());
         assert_eq!(
             index.symbol_names(GdbSymbolKind::Function).unwrap(),
             &["target_function".to_string()]
         );
+    }
+
+    #[test]
+    fn overlapping_address_record_does_not_hide_outer_match() {
+        let index = parse(overlapping_address_fixture()).unwrap();
+        assert_eq!(
+            index.find_cus_by_address(0x4050).unwrap(),
+            vec![gimli::DebugInfoOffset(0x220), gimli::DebugInfoOffset(0x120)]
+        );
+        assert_eq!(
+            index.find_cus_by_address(0x4080).unwrap(),
+            vec![gimli::DebugInfoOffset(0x120)]
+        );
+        assert!(index.find_cus_by_address(0x4100).unwrap().is_empty());
     }
 
     #[test]

--- a/ghostscope-dwarf/src/objfile/loaded.rs
+++ b/ghostscope-dwarf/src/objfile/loaded.rs
@@ -271,22 +271,7 @@ impl LoadedObjfile {
         if !self.lazy_debug_info {
             return Ok(());
         }
-        let gdb_cu = self
-            .gdb_index
-            .as_ref()
-            .map(|index| index.find_cu_by_address(address))
-            .transpose()?
-            .flatten();
-        let cu_offset = gdb_cu.or_else(|| {
-            self.lightweight_index
-                .read()
-                .expect("lightweight index lock poisoned")
-                .find_cu_by_address(address)
-        });
-        let Some(cu_offset) = cu_offset else {
-            return Ok(());
-        };
-        self.ensure_debug_info_cus(std::iter::once(cu_offset))
+        self.ensure_debug_info_cus(self.compilation_units_for_address(address)?)
     }
 
     pub(super) fn ensure_debug_info_for_entries(
@@ -320,22 +305,23 @@ impl LoadedObjfile {
     }
 
     pub(super) fn ensure_line_info_for_address(&self, address: u64) -> Result<()> {
-        let gdb_cu = self
-            .gdb_index
-            .as_ref()
-            .map(|index| index.find_cu_by_address(address))
-            .transpose()?
-            .flatten();
-        let unit_offset = gdb_cu.or_else(|| {
-            self.lightweight_index
-                .read()
-                .expect("lightweight index lock poisoned")
-                .find_cu_by_address(address)
-        });
-        if let Some(unit_offset) = unit_offset {
-            self.ensure_line_info_for_unit(unit_offset)?;
+        self.ensure_line_info_cus(self.compilation_units_for_address(address)?)
+    }
+
+    fn compilation_units_for_address(&self, address: u64) -> Result<Vec<gimli::DebugInfoOffset>> {
+        if let Some(index) = &self.gdb_index {
+            let unit_offsets = index.find_cus_by_address(address)?;
+            if !unit_offsets.is_empty() {
+                return Ok(unit_offsets);
+            }
         }
-        Ok(())
+
+        Ok(self
+            .lightweight_index
+            .read()
+            .expect("lightweight index lock poisoned")
+            .find_cus_by_address(address)
+            .collect())
     }
 
     pub(super) fn ensure_line_info_for_source(&self, file_path: &str) -> Result<()> {

--- a/ghostscope-dwarf/src/objfile/variables.rs
+++ b/ghostscope-dwarf/src/objfile/variables.rs
@@ -138,14 +138,21 @@ impl LoadedObjfile {
             {
                 self.add_block_index_functions_if_missing(address, vec![fb]);
             }
-        } else if let Some(cu_off) = self
-            .lightweight_index
-            .read()
-            .expect("lightweight index lock poisoned")
-            .find_cu_by_address(address)
-        {
-            if let Some(funcs) = builder.build_for_unit(cu_off) {
-                self.add_block_index_functions_if_missing(address, funcs);
+        } else {
+            let compilation_units = self
+                .lightweight_index
+                .read()
+                .expect("lightweight index lock poisoned")
+                .find_cus_by_address(address)
+                .collect::<Vec<_>>();
+            let mut functions = Vec::new();
+            for cu_off in compilation_units {
+                if let Some(mut unit_functions) = builder.build_for_unit(cu_off) {
+                    functions.append(&mut unit_functions);
+                }
+            }
+            if !functions.is_empty() {
+                self.add_block_index_functions_if_missing(address, functions);
             }
         }
     }

--- a/ghostscope-dwarf/src/parser/fast_parser/tests.rs
+++ b/ghostscope-dwarf/src/parser/fast_parser/tests.rs
@@ -791,7 +791,10 @@ fn parse_debug_info_builds_fallback_cu_map_for_function_body_addresses() {
 
     assert_eq!(entry.name.as_ref(), "body_lookup");
     assert_eq!(
-        result.lightweight_index.find_cu_by_address(0x401020),
+        result
+            .lightweight_index
+            .find_cus_by_address(0x401020)
+            .next(),
         Some(entry.unit_offset),
         "fallback CU map should cover addresses inside the function body, not just the representative address"
     );


### PR DESCRIPTION
## Summary

- preserve every overlapping compilation-unit range in lightweight and native
  DWARF indexes
- load line tables for all matching units and scan past ended line sequences
- bound reverse line-table misses with prefix maximum row ends, treating unknown
  ends as unbounded
- add unit and synthetic-DWARF e2e regressions for nested compilation units

## Testing

- `cargo fmt --all`
- `cargo test -p ghostscope-dwarf --lib` (277 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- targeted host-to-host e2e runner job `4ed407f1c680`
- full host-to-host e2e runner job `f01e8bcde5cf`

Container topology was not run because this change does not affect container or
PID namespace behavior.