### PR TITLE
fix: preserve same-value frame pointers

### DIFF
--- a/e2e-tests/tests/backtrace_execution.rs
+++ b/e2e-tests/tests/backtrace_execution.rs
@@ -698,6 +698,51 @@ trace register_ra_leaf {
 }
 
 #[tokio::test]
+async fn test_hot_backtrace_preserves_same_value_frame_pointer_rule() -> anyhow::Result<()> {
+    init();
+
+    let script = r#"
+trace same_value_rbp_leaf {
+    print "SAME_VALUE_RBP_STACK";
+    bt full;
+}
+"#;
+
+    let (count, stdout, stderr) = run_hot_backtrace_with_depth(script, 4).await?;
+    if count == 0 && stderr.contains("BPF_PROG_LOAD") {
+        return Ok(());
+    }
+
+    let block = matching_backtrace_block_with_ordered_patterns_after(
+        &stdout,
+        &stderr,
+        "SAME_VALUE_RBP_STACK",
+        4,
+        "a stack carrying a DW_CFA_same_value frame pointer",
+        &[
+            "#0 same_value_rbp_leaf",
+            "#1 same_value_rbp_caller",
+            "#2 same_value_rbp_outer",
+            "#3 main",
+        ],
+    )?;
+    assert!(
+        block.contains("backtrace: truncated, 4 frames (max 4)"),
+        "same-value RBP should reach main without a false memory recovery\nBLOCK:\n{block}\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    );
+    assert!(
+        !block.contains("stopped: invalid frame")
+            && !block.contains("stopped: read error")
+            && !block.contains("stopped: unsupported CFI")
+            && !block.contains("stopped: no unwind rows for PC"),
+        "same-value RBP stack should not stop on an unwind error\nBLOCK:\n{block}\nSTDERR:\n{stderr}"
+    );
+    assert_no_adjacent_duplicate_frame_locations(&block)?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_hot_backtrace_undefined_return_address_completes() -> anyhow::Result<()> {
     init();
 

--- a/e2e-tests/tests/fixtures/backtrace_hot_program/Makefile
+++ b/e2e-tests/tests/fixtures/backtrace_hot_program/Makefile
@@ -4,19 +4,23 @@ CFLAGS ?= $(BASE_CFLAGS) -O0 -fomit-frame-pointer
 BINARY ?= backtrace_hot_program
 OBJ ?= $(BINARY).o
 REGISTER_RA_OBJ ?= backtrace_register_ra.o
+SAME_VALUE_RBP_OBJ ?= backtrace_same_value_rbp.o
 UNDEFINED_RA_OBJ ?= backtrace_undefined_ra.o
 UNDEFINED_RBP_OBJ ?= backtrace_undefined_rbp.o
 UNSUPPORTED_CFI_OBJ ?= backtrace_unsupported_cfi.o
 
 all: $(BINARY)
 
-$(BINARY): $(OBJ) $(REGISTER_RA_OBJ) $(UNDEFINED_RA_OBJ) $(UNDEFINED_RBP_OBJ) $(UNSUPPORTED_CFI_OBJ)
+$(BINARY): $(OBJ) $(REGISTER_RA_OBJ) $(SAME_VALUE_RBP_OBJ) $(UNDEFINED_RA_OBJ) $(UNDEFINED_RBP_OBJ) $(UNSUPPORTED_CFI_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^
 
 $(OBJ): backtrace_hot_program.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(REGISTER_RA_OBJ): backtrace_register_ra.S
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(SAME_VALUE_RBP_OBJ): backtrace_same_value_rbp.S
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(UNDEFINED_RA_OBJ): backtrace_undefined_ra.S
@@ -28,7 +32,7 @@ $(UNDEFINED_RBP_OBJ): backtrace_undefined_rbp.S
 $(UNSUPPORTED_CFI_OBJ): backtrace_unsupported_cfi.S
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-backtrace_hot_program_nopie: backtrace_hot_program_nopie.o $(REGISTER_RA_OBJ) $(UNDEFINED_RA_OBJ) $(UNDEFINED_RBP_OBJ) $(UNSUPPORTED_CFI_OBJ)
+backtrace_hot_program_nopie: backtrace_hot_program_nopie.o $(REGISTER_RA_OBJ) $(SAME_VALUE_RBP_OBJ) $(UNDEFINED_RA_OBJ) $(UNDEFINED_RBP_OBJ) $(UNSUPPORTED_CFI_OBJ)
 	$(CC) $(BASE_CFLAGS) -no-pie -o $@ $^
 
 backtrace_hot_program_nopie.o: backtrace_hot_program.c

--- a/e2e-tests/tests/fixtures/backtrace_hot_program/backtrace_hot_program.c
+++ b/e2e-tests/tests/fixtures/backtrace_hot_program/backtrace_hot_program.c
@@ -103,6 +103,14 @@ __attribute__((noinline)) static void register_ra_loop(uint64_t value)
     register_ra_caller(value + 1);
 }
 
+__attribute__((noinline)) void same_value_rbp_leaf(uint64_t value)
+{
+    hot_sink += value;
+    asm volatile("" ::: "memory");
+}
+
+extern void same_value_rbp_outer(uint64_t value);
+
 __attribute__((noinline)) void undefined_ra_inline_leaf(uint64_t value)
 {
     hot_sink += value;
@@ -229,6 +237,7 @@ int main(void)
     for (uint64_t i = 0; keep_running; i++) {
         hot_bt_probe(i);
         register_ra_loop(i);
+        same_value_rbp_outer(i);
         undefined_ra_inline_caller(i);
         undefined_ra_tail_caller(i);
         undefined_rbp_inline_outer(i);

--- a/e2e-tests/tests/fixtures/backtrace_hot_program/backtrace_same_value_rbp.S
+++ b/e2e-tests/tests/fixtures/backtrace_hot_program/backtrace_same_value_rbp.S
@@ -1,0 +1,43 @@
+	.text
+	.globl same_value_rbp_caller
+	.type same_value_rbp_caller, @function
+same_value_rbp_caller:
+	.cfi_startproc
+	# The outer frame arranges RSP=RBP+16 before this call. Keep its RBP
+	# unchanged while using it as this frame's CFA base.
+	.cfi_def_cfa %rbp, 16
+	.cfi_offset %rip, -8
+	.cfi_same_value %rbp
+	subq $8, %rsp
+	# A shape-based RBP recovery reads this poison value instead of honoring
+	# DW_CFA_same_value, so the following outer-frame unwind fails.
+	movq $1, (%rsp)
+	call same_value_rbp_leaf
+	addq $8, %rsp
+	ret
+	.cfi_endproc
+	.size same_value_rbp_caller, .-same_value_rbp_caller
+
+	.globl same_value_rbp_outer
+	.type same_value_rbp_outer, @function
+same_value_rbp_outer:
+	.cfi_startproc
+	pushq %rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	subq $32, %rsp
+	.cfi_def_cfa_offset 48
+	movq %rsp, %rbp
+	.cfi_def_cfa %rbp, 48
+	# Put the caller's entry RSP at RBP+8 while retaining ABI call alignment.
+	addq $16, %rsp
+	call same_value_rbp_caller
+	leaq 40(%rbp), %rsp
+	.cfi_def_cfa %rsp, 8
+	movq -8(%rsp), %rbp
+	.cfi_restore %rbp
+	ret
+	.cfi_endproc
+	.size same_value_rbp_outer, .-same_value_rbp_outer
+
+	.section .note.GNU-stack,"",@progbits

--- a/ghostscope-dwarf/src/semantics/unwind_plan.rs
+++ b/ghostscope-dwarf/src/semantics/unwind_plan.rs
@@ -139,19 +139,6 @@ impl CompactUnwindRow {
                 offset: 0,
             },
         };
-        let rbp = if cfa_register == X86_64_DWARF_RBP
-            && cfa_offset == 16
-            && rbp.kind == BpfRecoveryKind::SameValue
-        {
-            BpfRecoveryPlan {
-                kind: BpfRecoveryKind::AtCfaOffset,
-                register: X86_64_DWARF_RBP,
-                offset: -16,
-            }
-        } else {
-            rbp
-        };
-
         Ok(BpfUnwindRowPlan {
             pc_start: self.pc_start,
             pc_end: self.pc_end,
@@ -388,24 +375,32 @@ mod tests {
     }
 
     #[test]
-    fn bpf_fast_path_plan_normalizes_frame_pointer_call_frames() {
-        let mut row = compact_row(RegisterRecoveryPlan::AtCfaOffset { offset: -8 });
-        row.cfa = CfaRulePlan::RegPlusOffset {
-            register: X86_64_DWARF_RBP,
-            offset: 16,
-        };
-
-        let plan = row
-            .bpf_fast_path_plan()
-            .expect("frame-pointer call frame is supported");
-        assert_eq!(
-            plan.rbp,
-            BpfRecoveryPlan {
-                kind: BpfRecoveryKind::AtCfaOffset,
+    fn bpf_fast_path_plan_preserves_same_value_frame_pointer() {
+        for rbp in [
+            None,
+            Some(RegisterRecoveryPlan::SameValue {
                 register: X86_64_DWARF_RBP,
-                offset: -16,
-            }
-        );
+            }),
+        ] {
+            let mut row = compact_row(RegisterRecoveryPlan::AtCfaOffset { offset: -8 });
+            row.cfa = CfaRulePlan::RegPlusOffset {
+                register: X86_64_DWARF_RBP,
+                offset: 16,
+            };
+            row.rbp = rbp;
+
+            let plan = row
+                .bpf_fast_path_plan()
+                .expect("frame-pointer call frame is supported");
+            assert_eq!(
+                plan.rbp,
+                BpfRecoveryPlan {
+                    kind: BpfRecoveryKind::SameValue,
+                    register: X86_64_DWARF_RBP,
+                    offset: 0,
+                }
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve DW_CFA_same_value semantics for RBP instead of inferring a stack slot from the CFA shape
- cover implicit and explicit SameValue rules in the BPF unwind-plan unit tests
- add an assembly-backed e2e fixture that poisons the inferred slot and verifies unwinding still reaches main

## Validation

- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p ghostscope-dwarf --lib (289 passed)
- focused SameValue e2e via runner job 442c11125d9c (passed)
- standard host-to-host e2e runner job 217807c54798: all 30 backtrace tests passed, including the new regression; the run later stopped on unrelated complex_types_execution::test_cross_type_comparisons_local, which rejects an ordered pointer comparison before backtrace/CFI handling
- focused rerun of the earlier cross-module t-mode fluctuation via runner job 1a8214e390ee (passed)

Container-topology e2e was intentionally skipped because this change does not affect containers, PID namespaces, or runner topology.