### PR TITLE
fix: support Rust char formatting

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -146,6 +146,10 @@ That matrix records audited DWARF layouts rather than version gates: coverage is
 adapter-specific, so not every value family is validated on every listed
 release, and unmatched older layouts fall back to native DWARF presentation.
 
+Rust `char` values emitted as four-byte `DW_ATE_UTF` scalars use Rust-style
+single-quoted formatting, including Unicode output and debug escapes such as
+`'中'` and `'\n'`.
+
 The currently supported value families are:
 
 - UTF-8 strings: `&str`, `&mut str`, `String`, and `Box<str>`;

--- a/e2e-tests/tests/fixtures/rust_global_program/src/main.rs
+++ b/e2e-tests/tests/fixtures/rust_global_program/src/main.rs
@@ -20,6 +20,10 @@ pub static mut G_COUNTER: i32 = 0;
 pub static G_MESSAGE: &str = "hello from rust";
 pub static G_EMPTY_MESSAGE: &str = "";
 pub static G_NUL_MESSAGE: &str = "left\0right";
+pub static G_CHAR_ASCII: char = 'A';
+pub static G_CHAR_UNICODE: char = '中';
+pub static G_CHAR_ESCAPE: char = '\n';
+pub static G_CHAR_ARRAY: [char; 3] = [G_CHAR_ASCII, G_CHAR_UNICODE, G_CHAR_ESCAPE];
 pub static mut G_OWNED_MESSAGE: String = String::new();
 pub static mut G_EMPTY_OWNED: String = String::new();
 pub static mut G_NUL_OWNED: String = String::new();
@@ -671,6 +675,10 @@ fn touch_globals() -> i32 {
             + G_MESSAGE.len() as i64
             + G_EMPTY_MESSAGE.len() as i64
             + G_NUL_MESSAGE.len() as i64
+            + G_CHAR_ASCII as u32 as i64
+            + G_CHAR_UNICODE as u32 as i64
+            + G_CHAR_ESCAPE as u32 as i64
+            + G_CHAR_ARRAY[0] as u32 as i64
             + G_OWNED_MESSAGE.len() as i64
             + G_EMPTY_OWNED.len() as i64
             + G_NUL_OWNED.len() as i64

--- a/e2e-tests/tests/rust_script_execution.rs
+++ b/e2e-tests/tests/rust_script_execution.rs
@@ -3279,6 +3279,40 @@ trace do_stuff {
 }
 
 #[tokio::test]
+async fn test_rust_script_print_char_values() -> anyhow::Result<()> {
+    init();
+
+    let target = spawn_rust_global_program().await?;
+
+    let script = r#"
+trace do_stuff {
+    print "RCHAR:{}:{}:{}", G_CHAR_ASCII, G_CHAR_UNICODE, G_CHAR_ESCAPE;
+    print "RCHAR_ARRAY:{}", G_CHAR_ARRAY;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 9, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.contains("RCHAR:'A':'中':'\\n'")),
+        "Expected Rust char output. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.contains("RCHAR_ARRAY:['A', '中', '\\n']")),
+        "Expected Rust char array output. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_rust_script_print_globals() -> anyhow::Result<()> {
     init();
 

--- a/ghostscope-compiler/src/ebpf/codegen/print_variable_index.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/print_variable_index.rs
@@ -43,9 +43,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     ) -> Result<()> {
         // Determine data size based on type
         let data_size = match type_encoding {
-            TypeKind::U8 | TypeKind::I8 | TypeKind::Bool | TypeKind::Char => 1,
+            TypeKind::U8 | TypeKind::I8 | TypeKind::Bool => 1,
             TypeKind::U16 | TypeKind::I16 => 2,
-            TypeKind::U32 | TypeKind::I32 | TypeKind::F32 => 4,
+            TypeKind::U32 | TypeKind::I32 | TypeKind::F32 | TypeKind::Char => 4,
             TypeKind::U64 | TypeKind::I64 | TypeKind::F64 | TypeKind::Pointer => 8,
             _ => 8, // Default to 8 bytes for complex types
         };

--- a/ghostscope-compiler/src/ebpf/codegen/types.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/types.rs
@@ -61,6 +61,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     ) -> ghostscope_dwarf::TypeInfo {
         use ghostscope_dwarf::constants::{
             DW_ATE_boolean, DW_ATE_float, DW_ATE_signed, DW_ATE_signed_char, DW_ATE_unsigned,
+            DW_ATE_UTF,
         };
         use ghostscope_dwarf::TypeInfo as TI;
 
@@ -100,10 +101,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 size: 8,
                 encoding: DW_ATE_signed.0 as u16,
             },
-            TypeKind::U8 | TypeKind::Char => TI::BaseType {
+            TypeKind::U8 => TI::BaseType {
                 name: "u8".to_string(),
                 size: 1,
                 encoding: DW_ATE_unsigned.0 as u16,
+            },
+            TypeKind::Char => TI::BaseType {
+                name: "char".to_string(),
+                size: 4,
+                encoding: DW_ATE_UTF.0 as u16,
             },
             TypeKind::U16 => TI::BaseType {
                 name: "u16".to_string(),

--- a/ghostscope-protocol/src/format_printer.rs
+++ b/ghostscope-protocol/src/format_printer.rs
@@ -2299,7 +2299,19 @@ impl FormatPrinter {
 
     /// Format base type data using DWARF encoding information
     fn format_base_type_data(data: &[u8], size: u64, encoding: u16) -> String {
-        if encoding == gimli::constants::DW_ATE_boolean.0 as u16 {
+        if encoding == gimli::constants::DW_ATE_UTF.0 as u16 {
+            if size != 4 {
+                return format!("<UNSUPPORTED_UTF_SIZE_{size}>");
+            }
+            let Some(bytes) = data.get(..4).and_then(|bytes| bytes.try_into().ok()) else {
+                return "<INVALID_UTF_CHAR>".to_string();
+            };
+            let scalar = u32::from_le_bytes(bytes);
+            match char::from_u32(scalar) {
+                Some(character) => format!("{character:?}"),
+                None => format!("<INVALID_UNICODE_SCALAR_0x{scalar:08x}>"),
+            }
+        } else if encoding == gimli::constants::DW_ATE_boolean.0 as u16 {
             if data.is_empty() {
                 "<EMPTY_BOOL>".to_string()
             } else {
@@ -4742,6 +4754,50 @@ mod tests {
                 &trace_context,
             ),
             "values = <truncated>"
+        );
+    }
+
+    #[test]
+    fn formats_dwarf_utf_characters() {
+        let rust_char = TypeInfo::BaseType {
+            name: "char".to_string(),
+            size: 4,
+            encoding: gimli::constants::DW_ATE_UTF.0 as u16,
+        };
+
+        for (character, expected) in [
+            ('A', "'A'"),
+            ('中', "'中'"),
+            ('\n', "'\\n'"),
+            ('\'', "'\\''"),
+            ('\\', "'\\\\'"),
+        ] {
+            assert_eq!(
+                FormatPrinter::format_data_with_type_info(
+                    &(character as u32).to_le_bytes(),
+                    &rust_char,
+                ),
+                expected
+            );
+        }
+
+        assert_eq!(
+            FormatPrinter::format_data_with_type_info(&[0, 0xd8, 0, 0], &rust_char),
+            "<INVALID_UNICODE_SCALAR_0x0000d800>"
+        );
+        assert_eq!(
+            FormatPrinter::format_data_with_type_info(&[b'A', 0, 0], &rust_char),
+            "<INVALID_UTF_CHAR>"
+        );
+
+        let unsupported_width = TypeInfo::BaseType {
+            name: "char16_t".to_string(),
+            size: 2,
+            encoding: gimli::constants::DW_ATE_UTF.0 as u16,
+        };
+        assert_eq!(
+            FormatPrinter::format_data_with_type_info(&[b'A', 0], &unsupported_width),
+            "<UNSUPPORTED_UTF_SIZE_2>"
         );
     }
 

--- a/ghostscope-protocol/src/type_kind.rs
+++ b/ghostscope-protocol/src/type_kind.rs
@@ -18,6 +18,7 @@ pub enum TypeKind {
     F32 = 0x09,
     F64 = 0x0A,
     Bool = 0x0B,
+    /// Four-byte Unicode scalar represented by `DW_ATE_UTF`, including Rust `char`.
     Char = 0x0C,
 
     Pointer = 0x20,
@@ -97,9 +98,10 @@ impl From<&TypeInfo> for TypeKind {
                         8 => TypeKind::U64,
                         _ => TypeKind::U64, // Default to U64
                     },
-                    6 => TypeKind::I8, // DW_ATE_signed_char
-                    8 => TypeKind::U8, // DW_ATE_unsigned_char
-                    _ => TypeKind::U8, // Default to byte for unknown encoding
+                    6 => TypeKind::I8,                  // DW_ATE_signed_char
+                    8 => TypeKind::U8,                  // DW_ATE_unsigned_char
+                    16 if *size == 4 => TypeKind::Char, // DW_ATE_UTF Rust `char`
+                    _ => TypeKind::U8,                  // Default to byte for unknown encoding
                 }
             }
             TypeInfo::BitfieldType {
@@ -122,6 +124,22 @@ impl From<&TypeInfo> for TypeKind {
             TypeInfo::VariantType { .. } => TypeKind::Struct,
             TypeInfo::ScopedEnumType { base_type, .. } => TypeKind::from(base_type.as_ref()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_dwarf_utf_as_char() {
+        let rust_char = TypeInfo::BaseType {
+            name: "char".to_string(),
+            size: 4,
+            encoding: gimli::constants::DW_ATE_UTF.0 as u16,
+        };
+
+        assert_eq!(TypeKind::from(&rust_char), TypeKind::Char);
     }
 }
 


### PR DESCRIPTION
## Summary

- recognize four-byte DW_ATE_UTF values as Rust char data throughout classification and capture
- format valid scalars with Rust-style quoting and escapes, with explicit markers for invalid data
- add runtime e2e coverage for ASCII, Unicode, escaped chars, and char arrays, plus user documentation

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p ghostscope-protocol --all-features --lib (87 passed)
- cargo test -p ghostscope-compiler --all-features --lib (171 passed)
- runner e2e test_rust_script_print_char_values (job e542742c4d4e, passed)

The full standard host e2e run encountered the existing test_cross_type_comparisons_local failure. The same failure was reproduced with an isolated rerun on this branch and on a clean latest-main checkout (baseline job e9e9ea6134f1), so it is unrelated to this change.
