### PR TITLE
docs: highlight Rust tracing support

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -20,7 +20,7 @@
 
 GhostScope 是一个 **面向源码语义的用户态追踪器**。有 DWARF 调试信息时，它可以在不由调试器控制目标暂停的前提下，按函数、源码行或指令粒度设点，打印真正重要的信息，并输出源码感知的调用栈。
 
-支持范围以及可信输出所依赖的不变量，统一定义在[设计保证与可信性模型](docs/zh/design-contract.md)中。
+C 的端到端覆盖最完整。对于 Rust 目标，GhostScope 为常用值提供定向支持，并会对应用、标准库和 inline backtrace 栈帧中的符号进行 demangle。准确的支持边界见[源语言支持现状](docs/zh/scripting.md#源语言支持现状)和[使用限制](docs/zh/limitations.md#1-语言支持)。
 
 > *"The most effective debugging tool is still careful thought, coupled with judiciously placed print statements."* — Brian Kernighan
 
@@ -180,9 +180,9 @@ GhostScope 把编译后的二进制重新变成“可观测系统”。在 TUI �
       <td align="center" width="25%">
         <img src="https://raw.githubusercontent.com/swananan/ghostscope/main/assets/icons/rust.svg" width="60" alt="Rust"/>
         <br />
-        <strong>Rust 构建</strong>
+        <strong>Rust 目标支持</strong>
         <br />
-        <sub>内存安全且极速</sub>
+        <sub>定向值支持与 demangle 栈帧</sub>
       </td>
     </tr>
   </table>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 GhostScope is a **source-aware userspace tracer** for live Linux processes. With DWARF debug info, it lets you attach at function, source-line, or instruction granularity, print the values that matter, and emit source-aware call stacks without debugger-controlled suspension of the target.
 
-The supported operating envelope and the invariants behind trustworthy output are defined in [Design Guarantees and Trust Model](docs/design-contract.md).
+C has the strongest end-to-end coverage. For Rust targets, GhostScope provides targeted support for common values and demangles application, standard-library, and inline backtrace frames. See [Source Language Support](docs/scripting.md#source-language-support) and [Limitations](docs/limitations.md#1-language-support) for the exact boundaries.
 
 > *"The most effective debugging tool is still careful thought, coupled with judiciously placed print statements."* — Brian Kernighan
 
@@ -185,9 +185,9 @@ With this map in hand, GhostScope leverages **eBPF and uprobe** technology to sa
       <td align="center" width="25%">
         <img src="https://raw.githubusercontent.com/swananan/ghostscope/main/assets/icons/rust.svg" width="60" alt="Rust"/>
         <br />
-        <strong>Built with Rust</strong>
+        <strong>Rust-Aware Tracing</strong>
         <br />
-        <sub>Memory safe & blazing fast</sub>
+        <sub>Targeted values & demangled frames</sub>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
## Summary

- advertise targeted Rust value and demangled backtrace support in both READMEs
- link to the exact source-language and limitation boundaries
- keep design contract references in the reliability and documentation sections instead of the opening overview

## Validation

- `git diff --check`
- Rust and e2e tests not run (README-only change)