### PR TITLE
fix: prefer script variables over DWARF symbols

### DIFF
--- a/e2e-tests/tests/globals_execution.rs
+++ b/e2e-tests/tests/globals_execution.rs
@@ -485,6 +485,40 @@ trace tick_once {
 }
 
 #[tokio::test]
+async fn test_script_variables_shadow_dwarf_types_in_ordered_comparisons() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("globals_program")?;
+    let target = spawn_globals_program(&binary_path).await?;
+
+    // These names collide with an aggregate in the executable and a pointer in
+    // libgvars.so. The concrete script variables must win type resolution.
+    let script = r#"
+trace globals_program.c:32 {
+    print "DWARF_COLLISION:{}:{}", G_STATE.counter, LIB_AMBIGUOUS_DYNAMIC[0].want;
+    let G_STATE = 100;
+    let LIB_AMBIGUOUS_DYNAMIC = 200;
+    print "SCRIPT_SHADOW:{}:{}", G_STATE < 101, LIB_AMBIGUOUS_DYNAMIC < 201;
+}
+"#;
+
+    let (exit_code, stdout, stderr) =
+        run_ghostscope_with_script_for_target(script, 3, &target).await?;
+    target.terminate().await?;
+    assert_eq!(exit_code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(
+        Regex::new(r"DWARF_COLLISION:-?\d+:-?\d+")?.is_match(&stdout),
+        "Expected the colliding DWARF symbols to resolve before shadowing. STDOUT: {stdout}"
+    );
+    assert!(
+        stdout.contains("SCRIPT_SHADOW:true:true"),
+        "Expected script variables to shadow DWARF symbol types. STDOUT: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_unknown_member_on_global_reports_members() -> anyhow::Result<()> {
     // Friendly error when accessing a non-existent member of a global struct
     init();

--- a/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
+++ b/ghostscope-compiler/src/ebpf/dwarf_bridge.rs
@@ -1428,13 +1428,21 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
         let expanded = self.expand_dwarf_aliases(expr)?;
         match &expanded {
-            Expr::Variable(var_name) => self.query_dwarf_for_variable_plan(var_name),
+            Expr::Variable(var_name) => {
+                if self.variable_exists(var_name) {
+                    return Ok(None);
+                }
+                self.query_dwarf_for_variable_plan(var_name)
+            }
             Expr::MemberAccess(_, _)
             | Expr::TupleAccess(_, _)
             | Expr::ArrayAccess(_, _)
             | Expr::ChainAccess(_)
             | Expr::PointerDeref(_) => {
                 if let Some((base, access_path)) = Self::access_path_from_expr(&expanded)? {
+                    if self.variable_exists(&base) {
+                        return Ok(None);
+                    }
                     self.query_dwarf_for_pc_access_plan(&base, &access_path)
                 } else {
                     Ok(None)
@@ -1527,6 +1535,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
 
     /// Query DWARF for variable information
     pub fn query_dwarf_for_variable(&mut self, var_name: &str) -> Result<Option<VariableReadPlan>> {
+        // Script names occupy the namespace before DWARF names. Alias-aware callers
+        // should use query_dwarf_for_complex_expr so the alias target is expanded.
+        if self.alias_variable_exists(var_name) || self.variable_exists(var_name) {
+            return Ok(None);
+        }
+
         let context = self.get_compile_time_context()?;
         let pc_address = context.pc_address;
 
@@ -1905,6 +1919,32 @@ mod tests {
             EbpfContext::<'static, 'static>::access_path_to_string(&base, &path),
             "request.current.*.state"
         );
+    }
+
+    #[test]
+    fn dwarf_queries_skip_concrete_script_variables() {
+        let llctx = LlvmContext::create();
+        let opts = crate::CompileOptions::default();
+        let mut ctx = EbpfContext::new(&llctx, "script_var_priority", Some(0), &opts).expect("ctx");
+        ctx.create_basic_ebpf_function("f").expect("fn");
+        ctx.store_variable("value", llctx.i64_type().const_int(7, false).into())
+            .expect("store script variable");
+
+        let variable = Expr::Variable("value".to_string());
+        assert!(ctx
+            .query_dwarf_for_complex_expr_plan(&variable)
+            .expect("script variable query")
+            .is_none());
+        assert!(ctx
+            .query_dwarf_for_variable("value")
+            .expect("direct script variable query")
+            .is_none());
+
+        let member = Expr::MemberAccess(Box::new(variable), "field".to_string());
+        assert!(ctx
+            .query_dwarf_for_complex_expr_plan(&member)
+            .expect("script-rooted member query")
+            .is_none());
     }
 
     #[test]

--- a/ghostscope-compiler/src/ebpf/expression/casts.rs
+++ b/ghostscope-compiler/src/ebpf/expression/casts.rs
@@ -1,6 +1,6 @@
 use super::{DynamicLvalue, DynamicTypeInfo, IndexableElementInfo};
 use crate::ebpf::context::{CodeGenError, EbpfContext, Result, RuntimeAddress};
-use crate::script::Expr;
+use crate::script::{Expr, VarType};
 use ghostscope_dwarf::{TypeInfo as DwarfType, TypeProjectionLayout, VariableAccessSegment};
 use inkwell::values::{BasicValueEnum, IntValue};
 use inkwell::AddressSpace;
@@ -15,6 +15,15 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                 .is_some_and(|ty| ghostscope_dwarf::is_aggregate_type(&ty));
         }
 
+        if let Expr::Variable(name) = expr {
+            // Match compile_expr's name-resolution order: aliases first, then concrete
+            // script variables, and only then DWARF variables. Script variables cannot
+            // hold aggregate values.
+            if !self.alias_variable_exists(name) && self.variable_exists(name) {
+                return false;
+            }
+        }
+
         if let Ok(Some(var)) = self.query_dwarf_for_complex_expr(expr) {
             if let Some(ref ty) = var.dwarf_type {
                 return ghostscope_dwarf::is_aggregate_type(ty);
@@ -27,6 +36,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     /// Returns true for:
     /// - Explicit address-of forms (&expr)
     /// - Script string literals (compile to pointer data)
+    /// - Script string variables
     /// - Alias variables bound to addresses
     /// - DWARF-backed expressions whose type is pointer or array
     pub(in crate::ebpf) fn is_pointer_like_expr(&mut self, expr: &Expr) -> bool {
@@ -51,6 +61,9 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             E::Variable(name) => {
                 if self.alias_variable_exists(name) {
                     return true;
+                }
+                if self.variable_exists(name) {
+                    return matches!(self.get_variable_type(name), Some(VarType::String));
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary

- make aggregate and pointer DWARF probes respect script name resolution
- prevent same-named DWARF globals from changing concrete script variable types
- cover aggregate and pointer collisions with unit and deterministic e2e tests

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p ghostscope-compiler dwarf_queries_skip_concrete_script_variables`
- runner: `test_script_variables_shadow_dwarf_types_in_ordered_comparisons`
- runner: `test_cross_type_comparisons_local` in full host-to-host e2e
- runner: `test_o3_local_int_array_decay_pointer_addition_and_memcmp`

## Full-suite notes

- A GCC 13.3/DWARF ready-marker timeout reproduced on the pre-Rust-change
  `e921985` baseline; the targeted case passes with this fix.
- A separate full run missed a short-lived assertion window in
  `test_complex_o3_pointer_members_after_volatile_path`; its targeted rerun
  passed.
- Container-topology e2e was not run because this change does not affect
  container or PID namespace behavior.
