### PR TITLE
perf: avoid repeated streaming parser buffer shifts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +369,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -462,6 +501,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +594,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1091,6 +1172,7 @@ dependencies = [
  "aya",
  "aya-ebpf-bindings",
  "chrono",
+ "criterion",
  "ghostscope-platform",
  "gimli 0.33.0",
  "serde",
@@ -1131,6 +1213,17 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1492,10 +1585,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1837,6 +1950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2140,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2217,7 +2364,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
@@ -2282,7 +2429,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -2511,6 +2658,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2957,6 +3113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,7 +3384,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -3296,6 +3462,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3583,6 +3759,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/ghostscope-protocol/Cargo.toml
+++ b/ghostscope-protocol/Cargo.toml
@@ -24,5 +24,12 @@ gimli = { workspace = true }
 ghostscope-platform = { version = "0.1.6", path = "../ghostscope-platform" }
 zerocopy = { version = "0.8", features = ["derive"] }
 
+[dev-dependencies]
+criterion = { workspace = true }
+
 [features]
 aya-pod = ["dep:aya"]
+
+[[bench]]
+name = "streaming_parser"
+harness = false

--- a/ghostscope-protocol/benches/streaming_parser.rs
+++ b/ghostscope-protocol/benches/streaming_parser.rs
@@ -1,0 +1,133 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ghostscope_protocol::streaming_parser::StreamingTraceParser;
+use ghostscope_protocol::trace_event::{
+    EndInstructionData, InstructionHeader, InstructionType, PrintComplexVariableData,
+    TraceEventHeader, TraceEventMessage, VariableStatus,
+};
+use ghostscope_protocol::{TraceContext, TypeInfo};
+use std::hint::black_box;
+use std::mem::size_of;
+use zerocopy::IntoBytes;
+
+const EVENT_SIZE: usize = 32 * 1024;
+const INSTRUCTION_COUNTS: [usize; 3] = [1, 16, 128];
+
+fn append_instruction_header(buffer: &mut Vec<u8>, instruction_type: InstructionType, len: usize) {
+    buffer.push(instruction_type as u8);
+    buffer.extend_from_slice(
+        &u16::try_from(len)
+            .expect("benchmark instruction payload fits in u16")
+            .to_le_bytes(),
+    );
+    buffer.push(0);
+}
+
+fn build_event(instruction_count: usize) -> Vec<u8> {
+    let fixed_size = size_of::<TraceEventHeader>()
+        + size_of::<TraceEventMessage>()
+        + size_of::<InstructionHeader>()
+        + size_of::<EndInstructionData>()
+        + instruction_count
+            * (size_of::<InstructionHeader>() + size_of::<PrintComplexVariableData>());
+    let total_data_size = EVENT_SIZE
+        .checked_sub(fixed_size)
+        .expect("benchmark event metadata fits in 32 KiB");
+    let data_size = total_data_size / instruction_count;
+    let instructions_with_extra_byte = total_data_size % instruction_count;
+
+    let mut event = Vec::with_capacity(EVENT_SIZE);
+    event.extend_from_slice(
+        TraceEventHeader {
+            magic: ghostscope_protocol::consts::MAGIC,
+        }
+        .as_bytes(),
+    );
+    event.extend_from_slice(
+        TraceEventMessage {
+            trace_id: 1,
+            timestamp: 2,
+            pid: 3,
+            tid: 4,
+        }
+        .as_bytes(),
+    );
+
+    for index in 0..instruction_count {
+        let data_size = data_size + usize::from(index < instructions_with_extra_byte);
+        let instruction_data_size = size_of::<PrintComplexVariableData>() + data_size;
+        append_instruction_header(
+            &mut event,
+            InstructionType::PrintComplexVariable,
+            instruction_data_size,
+        );
+
+        event.extend_from_slice(&0u16.to_le_bytes()); // var_name_index
+        event.extend_from_slice(&0u16.to_le_bytes()); // type_index
+        event.push(0); // access_path_len
+        event.push(VariableStatus::Truncated as u8);
+        event.extend_from_slice(
+            &u16::try_from(data_size)
+                .expect("benchmark variable payload fits in u16")
+                .to_le_bytes(),
+        );
+        event.resize(event.len() + data_size, 0xa5);
+    }
+
+    append_instruction_header(
+        &mut event,
+        InstructionType::EndInstruction,
+        size_of::<EndInstructionData>(),
+    );
+    event.extend_from_slice(
+        &u16::try_from(instruction_count)
+            .expect("benchmark instruction count fits in u16")
+            .to_le_bytes(),
+    );
+    event.push(0); // execution_status
+    event.push(0); // reserved
+
+    assert_eq!(event.len(), EVENT_SIZE);
+    event
+}
+
+fn trace_context() -> TraceContext {
+    let mut trace_context = TraceContext::new();
+    trace_context
+        .add_variable_name("payload".to_string())
+        .expect("add benchmark variable name");
+    trace_context
+        .add_type(TypeInfo::UnknownType {
+            name: "payload".to_string(),
+        })
+        .expect("add benchmark type");
+    trace_context
+}
+
+fn benchmark_streaming_parser(c: &mut Criterion) {
+    let trace_context = trace_context();
+    let mut group = c.benchmark_group("streaming_parser/32_kib_event");
+    group.throughput(Throughput::Bytes(EVENT_SIZE as u64));
+
+    for instruction_count in INSTRUCTION_COUNTS {
+        let event = build_event(instruction_count);
+        group.bench_with_input(
+            BenchmarkId::new("instructions", instruction_count),
+            &event,
+            |b, event| {
+                let mut parser = StreamingTraceParser::new();
+                b.iter(|| {
+                    let parsed = parser
+                        .process_segment(black_box(event.as_slice()), black_box(&trace_context))
+                        .expect("benchmark event parses successfully")
+                        .expect("benchmark event is complete");
+                    black_box(parsed);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_streaming_parser);
+criterion_main!(benches);

--- a/ghostscope-protocol/src/streaming_parser.rs
+++ b/ghostscope-protocol/src/streaming_parser.rs
@@ -242,21 +242,27 @@ impl StreamingTraceParser {
             self.parse_state
         );
 
+        // Advance through the buffer by index so parsing several instructions from one
+        // segment does not repeatedly move the unread suffix to the front of the Vec.
+        let mut cursor = 0;
+
         // Process buffer in a loop until we can't make progress
         loop {
             let state = std::mem::replace(&mut self.parse_state, ParseState::Complete);
             let consumed = match state {
                 ParseState::WaitingForHeader => {
                     // Try to read header
-                    let (header, _rest) = match TraceEventHeader::read_from_prefix(&self.buffer) {
+                    let unread = &self.buffer[cursor..];
+                    let (header, _rest) = match TraceEventHeader::read_from_prefix(unread) {
                         Ok((h, r)) => (h, r),
                         Err(_) => {
                             self.parse_state = ParseState::WaitingForHeader;
                             debug!(
                                 "Waiting for more data for header (have {} bytes, need {})",
-                                self.buffer.len(),
+                                unread.len(),
                                 std::mem::size_of::<TraceEventHeader>()
                             );
+                            self.compact_buffer(cursor);
                             return Ok(None);
                         }
                     };
@@ -274,15 +280,17 @@ impl StreamingTraceParser {
 
                 ParseState::WaitingForMessage { header } => {
                     // Try to read message
-                    let (message, _rest) = match TraceEventMessage::read_from_prefix(&self.buffer) {
+                    let unread = &self.buffer[cursor..];
+                    let (message, _rest) = match TraceEventMessage::read_from_prefix(unread) {
                         Ok((m, r)) => (m, r),
                         Err(_) => {
                             self.parse_state = ParseState::WaitingForMessage { header };
                             debug!(
                                 "Waiting for more data for message (have {} bytes, need {})",
-                                self.buffer.len(),
+                                unread.len(),
                                 std::mem::size_of::<TraceEventMessage>()
                             );
+                            self.compact_buffer(cursor);
                             return Ok(None);
                         }
                     };
@@ -310,7 +318,7 @@ impl StreamingTraceParser {
                     mut instructions,
                 } => {
                     // Try to parse instruction from buffer
-                    match self.try_parse_instruction(&self.buffer, trace_context)? {
+                    match self.try_parse_instruction(&self.buffer[cursor..], trace_context)? {
                         Some((parsed_instruction, consumed_bytes)) => {
                             // Check if this is EndInstruction
                             if matches!(
@@ -335,15 +343,16 @@ impl StreamingTraceParser {
 
                                 // Reset state for next event
                                 self.parse_state = ParseState::WaitingForHeader;
+                                let event_consumed = cursor + consumed_bytes;
 
                                 // Handle buffer cleanup based on event source
                                 match self.event_source {
                                     EventSource::RingBuf => {
                                         // RingBuf: continuous stream, preserve residual bytes
-                                        self.buffer.drain(..consumed_bytes);
+                                        self.compact_buffer(event_consumed);
                                         debug!(
                                             "RingBuf mode: consumed {} bytes, {} bytes remain in buffer",
-                                            consumed_bytes,
+                                            event_consumed,
                                             self.buffer.len()
                                         );
                                     }
@@ -377,6 +386,7 @@ impl StreamingTraceParser {
                                 instructions,
                             };
                             debug!("Waiting for more data for instruction");
+                            self.compact_buffer(cursor);
                             return Ok(None);
                         }
                     }
@@ -389,15 +399,28 @@ impl StreamingTraceParser {
                 }
             };
 
-            // Consume processed bytes from buffer
+            // Keep parsed bytes in place until the event completes or more data is needed.
             if consumed > 0 {
-                self.buffer.drain(..consumed);
+                cursor += consumed;
                 debug!(
-                    "Consumed {} bytes, buffer now has {} bytes",
+                    "Advanced parser cursor by {} bytes, {} unread bytes remain",
                     consumed,
-                    self.buffer.len()
+                    self.buffer.len() - cursor
                 );
             }
+        }
+    }
+
+    fn compact_buffer(&mut self, consumed: usize) {
+        debug_assert!(consumed <= self.buffer.len());
+        if consumed == 0 {
+            return;
+        }
+
+        if consumed == self.buffer.len() {
+            self.buffer.clear();
+        } else {
+            self.buffer.drain(..consumed);
         }
     }
 
@@ -874,6 +897,53 @@ impl ParsedInstruction {
 mod tests {
     use super::*;
 
+    fn append_instruction_header(
+        buffer: &mut Vec<u8>,
+        instruction_type: InstructionType,
+        data_length: usize,
+    ) {
+        buffer.push(instruction_type as u8);
+        buffer.extend_from_slice(
+            &u16::try_from(data_length)
+                .expect("test instruction data length fits in u16")
+                .to_le_bytes(),
+        );
+        buffer.push(0);
+    }
+
+    fn print_string_event(trace_id: u64, string_index: u16) -> Vec<u8> {
+        let mut event = Vec::new();
+        let header = TraceEventHeader {
+            magic: crate::consts::MAGIC,
+        };
+        event.extend_from_slice(zerocopy::IntoBytes::as_bytes(&header));
+
+        let message = TraceEventMessage {
+            trace_id,
+            timestamp: trace_id + 1,
+            pid: 10,
+            tid: 11,
+        };
+        event.extend_from_slice(zerocopy::IntoBytes::as_bytes(&message));
+
+        append_instruction_header(
+            &mut event,
+            InstructionType::PrintStringIndex,
+            std::mem::size_of::<PrintStringIndexData>(),
+        );
+        event.extend_from_slice(&string_index.to_le_bytes());
+
+        append_instruction_header(
+            &mut event,
+            InstructionType::EndInstruction,
+            std::mem::size_of::<EndInstructionData>(),
+        );
+        event.extend_from_slice(&1u16.to_le_bytes());
+        event.push(0);
+        event.push(0);
+        event
+    }
+
     #[test]
     fn test_streaming_parser() {
         let mut trace_context = TraceContext::new();
@@ -1074,6 +1144,64 @@ mod tests {
             }
             other => panic!("unexpected instruction: {other:?}"),
         }
+    }
+
+    #[test]
+    fn compacts_parsed_prefix_when_instruction_needs_another_segment() {
+        let mut trace_context = TraceContext::new();
+        let string_index = trace_context
+            .add_string("hello".to_string())
+            .expect("add test string");
+        let event = print_string_event(7, string_index);
+        let end_instruction_size =
+            std::mem::size_of::<InstructionHeader>() + std::mem::size_of::<EndInstructionData>();
+        let split = event.len() - end_instruction_size + 2;
+        let mut parser = StreamingTraceParser::new();
+
+        assert!(parser
+            .process_segment(&event[..split], &trace_context)
+            .expect("parse first segment")
+            .is_none());
+        assert!(matches!(
+            &parser.parse_state,
+            ParseState::WaitingForInstructions { .. }
+        ));
+        assert_eq!(parser.buffer, event[split - 2..split]);
+
+        let parsed = parser
+            .process_segment(&event[split..], &trace_context)
+            .expect("parse second segment")
+            .expect("event completes");
+        assert_eq!(parsed.trace_id, 7);
+        assert_eq!(parsed.instructions.len(), 2);
+        assert!(parser.buffer.is_empty());
+    }
+
+    #[test]
+    fn ringbuf_preserves_the_next_event_after_completing_one() {
+        let mut trace_context = TraceContext::new();
+        let string_index = trace_context
+            .add_string("hello".to_string())
+            .expect("add test string");
+        let first = print_string_event(1, string_index);
+        let second = print_string_event(2, string_index);
+        let mut segment = first;
+        segment.extend_from_slice(&second);
+        let mut parser = StreamingTraceParser::new();
+
+        let first = parser
+            .process_segment(&segment, &trace_context)
+            .expect("parse concatenated events")
+            .expect("first event completes");
+        assert_eq!(first.trace_id, 1);
+        assert_eq!(parser.buffer, second);
+
+        let second = parser
+            .process_segment(&[], &trace_context)
+            .expect("parse buffered event")
+            .expect("second event completes");
+        assert_eq!(second.trace_id, 2);
+        assert!(parser.buffer.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- parse each buffered segment with a cursor instead of draining the Vec after every header, message, and instruction
- compact once when an event completes or when the parser needs the next segment, while preserving RingBuf residual data and PerfEventArray cleanup semantics
- add Criterion microbenchmarks for 1, 16, and 128 instructions in a 32 KiB event plus segmented and concatenated-event regressions

## Benchmark

| Instructions | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1 | 2.376 us | 1.598 us | -32.2% |
| 16 | 9.348 us | 6.786 us | -27.8% |
| 128 | 60.970 us | 42.414 us | -30.5% |

## Validation

- cargo fmt --all -- --check
- cargo test -p ghostscope-protocol (89 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- standard host-to-host e2e runner job b81d7f32b4d8 (succeeded, exit code 0)

Container-topology e2e was intentionally skipped because this change does not affect containers, PID namespaces, or topology handling.