### PR TITLE
perf: reuse accumulation buffer lookup per program

### DIFF
--- a/ghostscope-compiler/src/ebpf/codegen/backtrace/tail_call.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/backtrace/tail_call.rs
@@ -709,6 +709,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         plan: &crate::ebpf::context::PendingBacktraceTailCall,
     ) -> Result<()> {
         self.create_tail_call_function(&plan.step_program_name)?;
+        let accum_buffer = self.initialize_event_accumulation_buffer_or_return_zero()?;
         let current_fn = self.current_function("generate bt tail-call step")?;
         let return_block = self
             .context
@@ -716,9 +717,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let state_ok_block = self
             .context
             .append_basic_block(current_fn, "bt_step_state_ok");
-        let accum_ok_block = self
-            .context
-            .append_basic_block(current_fn, "bt_step_accum_ok");
         let bounds_ok_block = self
             .context
             .append_basic_block(current_fn, "bt_step_bounds_ok");
@@ -757,16 +755,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
 
         self.builder.position_at_end(active_state_ok_block);
-        let accum_buffer = self.lookup_percpu_value_ptr("event_accum_buffer", 0)?;
-        let accum_is_null = self
-            .builder
-            .build_is_null(accum_buffer, "bt_step_accum_null")
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-        self.builder
-            .build_conditional_branch(accum_is_null, return_block, accum_ok_block)
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
-
-        self.builder.position_at_end(accum_ok_block);
         let inst_offset = self.load_state_i32(
             state_ptr,
             crate::BACKTRACE_TAIL_STATE_INST_OFFSET_OFFSET,

--- a/ghostscope-compiler/src/ebpf/codegen/tests.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::CompileOptions;
 use ghostscope_protocol::trace_event::{TraceEventHeader, TraceEventMessage};
+use inkwell::values::AnyValue;
 
 #[test]
 fn print_complex_format_budget_tracks_event_size() {
@@ -106,6 +107,115 @@ fn computed_int_in_format_compiles() {
     let program = crate::script::Program::new();
     let res = ctx.compile_program(&program, "test_fmt", &[stmt], None, None, None);
     assert!(res.is_ok(), "Compilation failed: {:?}", res.err());
+}
+
+#[test]
+fn event_accumulation_buffer_is_looked_up_once_per_program() {
+    let context = inkwell::context::Context::create();
+    let opts = CompileOptions::default();
+    let mut ctx =
+        EbpfContext::new(&context, "test_mod", Some(0), &opts).expect("create EbpfContext");
+    let statements = [
+        crate::script::Statement::Print(crate::script::PrintStatement::String("first".to_string())),
+        crate::script::Statement::Print(crate::script::PrintStatement::String(
+            "second".to_string(),
+        )),
+    ];
+    let program = crate::script::Program::new();
+
+    let (function, _) = ctx
+        .compile_program(
+            &program,
+            "single_accum_lookup",
+            &statements,
+            None,
+            None,
+            None,
+        )
+        .expect("compile program");
+    let ir = function.print_to_string().to_string();
+
+    assert_eq!(
+        ir.matches("@event_accum_buffer").count(),
+        1,
+        "generated program must reference event_accum_buffer once:\n{ir}"
+    );
+}
+
+#[test]
+fn namespace_pid_filter_reuses_entry_stack_before_accumulation_buffer_lookup() {
+    let context = inkwell::context::Context::create();
+    let opts = CompileOptions {
+        pid_filter_spec: Some(crate::PidFilterSpec::NamespaceTgid {
+            filter_pid: 42,
+            pid_ns: crate::PidNamespaceId {
+                dev: Some(1),
+                inode: 2,
+            },
+        }),
+        ..CompileOptions::default()
+    };
+    let mut ctx =
+        EbpfContext::new(&context, "test_mod", Some(0), &opts).expect("create EbpfContext");
+    let program = crate::script::Program::new();
+
+    let (function, _) = ctx
+        .compile_program(&program, "namespace_pid_filter", &[], None, None, None)
+        .expect("compile namespace-filtered program");
+    ctx.module.verify().expect("verify generated LLVM IR");
+
+    let ir = function.print_to_string().to_string();
+    assert!(ir.contains("%pm_key = alloca [4 x i32]"));
+    assert!(
+        !ir.contains("%pidns_info = alloca"),
+        "namespace filtering must reuse entry-block key storage:\n{ir}"
+    );
+    let continue_offset = ir
+        .find("continue_execution:")
+        .expect("namespace filter has a continuation block");
+    let lookup_offset = ir
+        .find("@event_accum_buffer")
+        .expect("program looks up event_accum_buffer");
+    assert!(
+        lookup_offset > continue_offset,
+        "accumulation buffer lookup must follow namespace filtering:\n{ir}"
+    );
+    assert_eq!(
+        ir.matches("@event_accum_buffer").count(),
+        1,
+        "namespace-filtered program must still look up event_accum_buffer once"
+    );
+}
+
+#[test]
+fn event_accumulation_buffer_lookup_is_not_shared_across_programs() {
+    let context = inkwell::context::Context::create();
+    let opts = CompileOptions::default();
+    let mut ctx =
+        EbpfContext::new(&context, "test_mod", Some(0), &opts).expect("create EbpfContext");
+    let program = crate::script::Program::new();
+    let (main_function, _) = ctx
+        .compile_program(&program, "main_program", &[], None, None, None)
+        .expect("compile main program");
+
+    let step_function = ctx
+        .create_tail_call_function("tail_step_program")
+        .expect("create tail-call step program");
+    ctx.initialize_event_accumulation_buffer_or_return_zero()
+        .expect("initialize tail-call accumulation buffer");
+    ctx.builder
+        .build_return(Some(&context.i32_type().const_zero()))
+        .expect("return from tail-call step program");
+    ctx.module.verify().expect("verify generated LLVM IR");
+
+    let main_ir = main_function.print_to_string().to_string();
+    let step_ir = step_function.print_to_string().to_string();
+    assert_eq!(main_ir.matches("@event_accum_buffer").count(), 1);
+    assert_eq!(
+        step_ir.matches("@event_accum_buffer").count(),
+        1,
+        "tail-call step program must perform its own lookup:\n{step_ir}"
+    );
 }
 
 #[test]

--- a/ghostscope-compiler/src/ebpf/context.rs
+++ b/ghostscope-compiler/src/ebpf/context.rs
@@ -159,6 +159,10 @@ pub struct EbpfContext<'ctx, 'dw> {
     pub(super) tls_scratch_alloca: Option<inkwell::values::PointerValue<'ctx>>,
     // Per-invocation event accumulation offset (u32) stored on stack (entry block)
     pub event_offset_alloca: Option<inkwell::values::PointerValue<'ctx>>,
+    // Per-program SSA pointer returned by the entry-block event_accum_buffer lookup.
+    // Function-local storage prevents main and tail-call programs from sharing a pointer.
+    pub(crate) event_accumulation_buffers:
+        HashMap<FunctionValue<'ctx>, inkwell::values::PointerValue<'ctx>>,
     // Sequence numbers keep verifier-oriented llvm.bpf.passthrough calls
     // distinct while LLVM optimizes the generated module.
     pub(super) next_bpf_passthrough_sequence: u32,
@@ -298,6 +302,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             pm_key_alloca: None,
             tls_scratch_alloca: None,
             event_offset_alloca: None,
+            event_accumulation_buffers: HashMap::new(),
             next_bpf_passthrough_sequence: 0,
             compile_time_event_bytes_upper_bound: 0,
             compile_options: compile_options.clone(),
@@ -779,6 +784,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         if let Some(spec) = pid_filter_spec {
             self.add_pid_filter(spec)?;
         }
+        self.initialize_event_accumulation_buffer_or_return_zero()?;
 
         // Use new staged transmission system for all statements
         let program = crate::script::ast::Program {
@@ -982,20 +988,21 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let i32_type = self.context.i32_type();
         let i64_type = self.context.i64_type();
         let ptr_type = self.context.ptr_type(AddressSpace::default());
+        let key_arr_ty = i32_type.array_type(4);
+        let key_alloca = self.pm_key_alloca.ok_or_else(|| {
+            CodeGenError::LLVMError("pm_key not allocated in entry block".to_string())
+        })?;
 
-        // Stack-allocate bpf_pidns_info-compatible storage: [pid:u32, tgid:u32].
-        let pidns_info_ty = i32_type.array_type(2);
-        let pidns_info_alloca = self
-            .builder
-            .build_alloca(pidns_info_ty, "pidns_info")
-            .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
+        // Reuse the entry-block map-key storage. The namespace helper needs only
+        // the first 8 bytes for [pid:u32, tgid:u32], and later map lookups may
+        // overwrite it after this filter has consumed the result.
         self.builder
-            .build_store(pidns_info_alloca, pidns_info_ty.const_zero())
+            .build_store(key_alloca, key_arr_ty.const_zero())
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
 
         let pidns_info_ptr = self
             .builder
-            .build_bit_cast(pidns_info_alloca, ptr_type, "pidns_info_ptr")
+            .build_bit_cast(key_alloca, ptr_type, "pidns_info_ptr")
             .map_err(|e| CodeGenError::LLVMError(e.to_string()))?;
 
         let helper_args = [
@@ -1033,12 +1040,12 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .map_err(|e| CodeGenError::Builder(e.to_string()))?;
 
         self.builder.position_at_end(helper_ok_block);
-        // SAFETY: pidns_info_alloca has the pid namespace helper result layout
-        // [pid, tgid], so [0, 1] addresses the tgid field.
+        // SAFETY: key_alloca temporarily holds the pid namespace helper result,
+        // so [0, 1] addresses the tgid field.
         let tgid_ptr = unsafe {
             self.builder.build_gep(
-                pidns_info_ty,
-                pidns_info_alloca,
+                key_arr_ty,
+                key_alloca,
                 &[i32_type.const_zero(), i32_type.const_int(1, false)],
                 "pidns_tgid_ptr",
             )

--- a/ghostscope-compiler/src/ebpf/instruction.rs
+++ b/ghostscope-compiler/src/ebpf/instruction.rs
@@ -35,7 +35,6 @@ fn checked_event_reservation(current: usize, size: u64, maximum: usize) -> Resul
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RuntimeEarlyReturnReason {
-    AccumulationBufferNull,
     EventBufferOverflow,
 }
 
@@ -88,10 +87,8 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let i32_ty = self.context.i32_type();
         let i64_ty = self.context.i64_type();
 
-        // Lookup accumulation buffer value pointer; early-return if NULL
-        let accum_buffer_lookup = self.get_or_create_perf_accumulation_buffer_or_return_zero()?;
-        let accum_buffer = accum_buffer_lookup.value;
-        let mut early_returns = accum_buffer_lookup.early_returns;
+        let accum_buffer = self.current_event_accumulation_buffer()?;
+        let mut early_returns = Vec::new();
         let offset_ptr = self.get_or_create_perf_buffer_offset()?;
 
         // Load current offset
@@ -228,10 +225,20 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         self.reserve_event_space_or_return_zero(size)
     }
 
-    /// Get per-CPU accumulation buffer pointer (event_accum_buffer[0]) and return early if null.
-    fn get_or_create_perf_accumulation_buffer_or_return_zero(
+    /// Look up event_accum_buffer[0] once for the current eBPF program.
+    ///
+    /// The resulting map-value pointer is an SSA value owned by the current function. It must not
+    /// be reused by another eBPF program, including a tail-call step program.
+    pub(crate) fn initialize_event_accumulation_buffer_or_return_zero(
         &mut self,
-    ) -> Result<RuntimeReturnAwareValue<'ctx, PointerValue<'ctx>>> {
+    ) -> Result<PointerValue<'ctx>> {
+        let current_fn = self
+            .current_codegen_continuation("initialize accumulation buffer")?
+            .function;
+        if let Some(accum_buffer) = self.event_accumulation_buffers.get(&current_fn) {
+            return Ok(*accum_buffer);
+        }
+
         let ptr_ty = self.context.ptr_type(AddressSpace::default());
         let val_ptr = self.lookup_percpu_value_ptr("event_accum_buffer", 0)?;
 
@@ -240,9 +247,6 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             .builder
             .build_is_null(val_ptr, "accum_buf_is_null")
             .map_err(|e| CodeGenError::LLVMError(format!("Failed to check buffer null: {e}")))?;
-        let current_fn = self
-            .current_codegen_continuation("check accumulation buffer")?
-            .function;
         let cont_bb = self
             .context
             .append_basic_block(current_fn, "accum_buf_cont");
@@ -278,17 +282,24 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
             }
         };
 
-        Ok(RuntimeReturnAwareValue {
-            value: accum_buffer,
-            continuation: CodegenContinuation {
-                function: current_fn,
-                block: cont_bb,
-            },
-            early_returns: vec![RuntimeEarlyReturn {
-                reason: RuntimeEarlyReturnReason::AccumulationBufferNull,
-                block: ret_bb,
-            }],
-        })
+        self.event_accumulation_buffers
+            .insert(current_fn, accum_buffer);
+        Ok(accum_buffer)
+    }
+
+    fn current_event_accumulation_buffer(&self) -> Result<PointerValue<'ctx>> {
+        let current_fn = self
+            .current_codegen_continuation("get accumulation buffer")?
+            .function;
+        self.event_accumulation_buffers
+            .get(&current_fn)
+            .copied()
+            .ok_or_else(|| {
+                CodeGenError::LLVMError(
+                    "event_accum_buffer was not initialized for the current eBPF program"
+                        .to_string(),
+                )
+            })
     }
 
     /// Get pointer to per-invocation stack event offset (u32)
@@ -664,9 +675,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
     }
 
     pub(crate) fn emit_accumulated_event_output_from_stack_offset(&mut self) -> Result<()> {
-        let accum_buffer = self
-            .get_or_create_perf_accumulation_buffer_or_return_zero()?
-            .into_value_after_runtime_returns();
+        let accum_buffer = self.current_event_accumulation_buffer()?;
         let offset_ptr = self.get_or_create_perf_buffer_offset()?;
 
         let total_accumulated_size = self


### PR DESCRIPTION
## Summary

- look up and null-check `event_accum_buffer` once per eBPF program after PID filtering
- reuse the resulting SSA pointer for event reservations and final output
- keep tail-call step programs isolated by performing their own lookup
- reuse entry-block `pm_key` scratch for namespace PID filtering to stay within the BPF stack limit
- add IR regression tests for one lookup per program, independent tail-call lookup, and namespace-filter ordering/scratch reuse

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks`
- `cargo test -p ghostscope-compiler` (181 passed)
- standard host-to-host e2e
- full host-to-private container e2e
- full private same-sandbox container e2e
- full private-to-child-container e2e
- host-PID same-sandbox smoke e2e
- hot-function benchmark: baseline 13.10 ms, GhostScope 17.28 ms / 1.32x slowdown, GDB 516.72 ms / 39.44x slowdown