### PR TITLE
refactor: decouple trace event readers

### DIFF
--- a/ghostscope-loader/src/lib.rs
+++ b/ghostscope-loader/src/lib.rs
@@ -100,7 +100,7 @@ use ghostscope_process::pinned_bpf_maps::{
 
 /// Event output map type wrapper
 enum EventMap {
-    RingBuf(RingBuf<MapData>),
+    RingBuf(RingBufEventMap),
     PerfEventArray {
         _map: PerfEventArray<MapData>,
         cpu_buffers: Vec<PerfEventCpuBuffer>,
@@ -108,12 +108,19 @@ enum EventMap {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct PerfBufferFd(RawFd);
+struct EventBufferFd(RawFd);
 
-impl AsRawFd for PerfBufferFd {
+impl AsRawFd for EventBufferFd {
     fn as_raw_fd(&self) -> RawFd {
         self.0
     }
+}
+
+struct RingBufEventMap {
+    // Fields are dropped in declaration order. Keep readiness first so Tokio
+    // deregisters the borrowed fd before RingBuf closes the underlying fd.
+    readiness: AsyncFd<EventBufferFd>,
+    ringbuf: RingBuf<MapData>,
 }
 
 fn log_backtrace_unwind_row_samples<T: Borrow<MapData>>(
@@ -152,8 +159,10 @@ fn log_backtrace_unwind_row_samples<T: Borrow<MapData>>(
 
 struct PerfEventCpuBuffer {
     cpu_id: u32,
+    // See RingBufEventMap: reactor registration must be removed before the
+    // perf buffer destroys the fd borrowed by EventBufferFd.
+    readiness: AsyncFd<EventBufferFd>,
     buffer: aya::maps::perf::PerfEventArrayBuffer<MapData>,
-    readiness: AsyncFd<PerfBufferFd>,
 }
 
 fn drain_perf_cpu_buffer(
@@ -785,7 +794,12 @@ impl GhostScopeLoader {
             let ringbuf: RingBuf<_> = map
                 .try_into()
                 .map_err(|e| LoaderError::Generic(format!("Failed to convert ringbuf map: {e}")))?;
-            EventMap::RingBuf(ringbuf)
+            let fd = ringbuf.as_raw_fd();
+            let readiness =
+                AsyncFd::with_interest(EventBufferFd(fd), Interest::READABLE).map_err(|err| {
+                    LoaderError::Generic(format!("Failed to register ring buffer fd: {err}"))
+                })?;
+            EventMap::RingBuf(RingBufEventMap { readiness, ringbuf })
         } else if let Some(map) = self.bpf.take_map("events") {
             info!("Initializing PerfEventArray event map");
             let mut perf_array: PerfEventArray<_> = map.try_into().map_err(|e| {
@@ -822,7 +836,7 @@ impl GhostScopeLoader {
                         }
                         let fd = buffer.as_raw_fd();
                         let readiness =
-                            AsyncFd::with_interest(PerfBufferFd(fd), Interest::READABLE).map_err(
+                            AsyncFd::with_interest(EventBufferFd(fd), Interest::READABLE).map_err(
                                 |err| {
                                     LoaderError::Generic(format!(
                                         "Failed to register perf buffer fd for CPU {cpu_id}: {err}"
@@ -831,8 +845,8 @@ impl GhostScopeLoader {
                             )?;
                         cpu_buffers.push(PerfEventCpuBuffer {
                             cpu_id,
-                            buffer,
                             readiness,
+                            buffer,
                         });
                     }
                     Err(e) => {
@@ -1071,23 +1085,26 @@ impl GhostScopeLoader {
         let mut events = Vec::with_capacity(MAX_EVENTS_PER_WAIT.min(128));
 
         match event_map {
-            EventMap::RingBuf(ringbuf) => {
-                // Create AsyncFd and wait for readable; clear readiness to avoid spin
-                let async_fd = AsyncFd::new(ringbuf.as_raw_fd())
-                    .map_err(|e| LoaderError::Generic(format!("Failed to create AsyncFd: {e}")))?;
-                let mut guard = async_fd
+            EventMap::RingBuf(event_map) => {
+                // The registration lives for the event map's lifetime. Keep its
+                // readiness set when a bounded batch stops before the ring is
+                // empty, so the next call resumes immediately even if the fd
+                // never transitions through another readiness edge.
+                let mut guard = event_map
+                    .readiness
                     .readable()
                     .await
                     .map_err(|e| LoaderError::Generic(format!("AsyncFd error: {e}")))?;
-                guard.clear_ready();
 
                 // Drain a bounded batch. Under very hot probes the ringbuf may never
                 // become empty, so an unbounded drain would starve output and signals.
                 let mut records_read = 0;
+                let mut drained_to_empty = false;
                 while events.len() < MAX_EVENTS_PER_WAIT
                     && records_read < MAX_RINGBUF_RECORDS_PER_WAIT
                 {
-                    let Some(item) = ringbuf.next() else {
+                    let Some(item) = event_map.ringbuf.next() else {
+                        drained_to_empty = true;
                         break;
                     };
                     records_read += 1;
@@ -1100,6 +1117,14 @@ impl GhostScopeLoader {
                             )));
                         }
                     }
+                }
+                if drained_to_empty {
+                    // `clear_ready` is tied to this guard's readiness event, so
+                    // a later edge is not lost if data arrives after the empty
+                    // observation.
+                    guard.clear_ready();
+                } else {
+                    guard.retain_ready();
                 }
                 if events.len() == MAX_EVENTS_PER_WAIT
                     || records_read == MAX_RINGBUF_RECORDS_PER_WAIT

--- a/ghostscope-ui/src/components/app/runtime_status.rs
+++ b/ghostscope-ui/src/components/app/runtime_status.rs
@@ -1241,6 +1241,21 @@ impl App {
                     queue_capacity,
                 );
             }
+            RuntimeStatus::TraceReaderBackpressure {
+                trace_id,
+                target_display,
+                dropped_since_last,
+                dropped_total,
+                queue_capacity_batches,
+            } => {
+                self.show_trace_reader_backpressure_alert(
+                    trace_id,
+                    target_display,
+                    dropped_since_last,
+                    dropped_total,
+                    queue_capacity_batches,
+                );
+            }
             RuntimeStatus::EbpfOutputLoss {
                 trace_id,
                 target_display,
@@ -1347,6 +1362,34 @@ impl App {
 
         self.add_ebpf_runtime_warning(format!(
             "Warning: TUI trace queue saturated; dropped {dropped_since_last} events before display in last 1s (total {dropped_total}, capacity {queue_capacity})"
+        ));
+    }
+
+    fn show_trace_reader_backpressure_alert(
+        &mut self,
+        trace_id: u32,
+        target_display: String,
+        dropped_since_last: u64,
+        dropped_total: u64,
+        queue_capacity_batches: usize,
+    ) {
+        let content = format!(
+            "⚠ Trace reader queue saturated: trace #{trace_id} ({target_display}) dropped {dropped_since_last} parsed events in last 1s (total {dropped_total}, capacity {queue_capacity_batches} batches); kernel draining continued"
+        );
+        let styled_lines =
+            crate::components::command_panel::ResponseFormatter::style_generic_message_lines(
+                &content,
+            );
+        crate::components::command_panel::ResponseFormatter::upsert_runtime_alert_with_style(
+            &mut self.state.command_panel,
+            content,
+            Some(styled_lines),
+            crate::action::ResponseType::Warning,
+        );
+        self.state.command_renderer.mark_pending_updates();
+
+        self.add_ebpf_runtime_warning(format!(
+            "Warning: trace reader queue saturated for trace #{trace_id} ({target_display}); dropped {dropped_since_last} parsed events in last 1s while kernel draining continued (total {dropped_total}, capacity {queue_capacity_batches} batches)"
         ));
     }
 

--- a/ghostscope-ui/src/events/runtime.rs
+++ b/ghostscope-ui/src/events/runtime.rs
@@ -350,6 +350,14 @@ pub enum RuntimeStatus {
         dropped_total: u64,
         queue_capacity: usize,
     },
+    /// Per-trace readers kept draining kernel buffers but could not enqueue all parsed events.
+    TraceReaderBackpressure {
+        trace_id: u32,
+        target_display: String,
+        dropped_since_last: u64,
+        dropped_total: u64,
+        queue_capacity_batches: usize,
+    },
     /// eBPF program failed to write events into the kernel output buffer.
     EbpfOutputLoss {
         trace_id: u32,

--- a/ghostscope/src/cli/script_runtime.rs
+++ b/ghostscope/src/cli/script_runtime.rs
@@ -509,7 +509,7 @@ async fn run_cli_with_session(
             }
 
             _ = ebpf_loss_report_ticker.tick() => {
-                report_ebpf_output_loss_reports(&mut session.trace_manager);
+                report_ebpf_output_loss_reports(&mut session.trace_manager).await;
             }
 
             signal = &mut shutdown_signal => {
@@ -525,14 +525,26 @@ async fn run_cli_with_session(
     Ok(())
 }
 
-fn report_ebpf_output_loss_reports(trace_manager: &mut crate::trace::TraceManager) {
-    for report in trace_manager.collect_event_loss_reports() {
+async fn report_ebpf_output_loss_reports(trace_manager: &mut crate::trace::TraceManager) {
+    let reports = trace_manager.collect_event_loss_reports().await;
+    for report in reports.kernel {
         let message = format!(
             "eBPF output helper failed: trace #{} ({}) lost {} events in kernel before userspace delivery (total {})",
             report.trace_id,
             report.target_display,
             report.lost_since_last,
             report.lost_total
+        );
+        warn!("{message}");
+        eprintln!("ghostscope: {message}");
+    }
+    for report in reports.delivery {
+        let message = format!(
+            "trace reader queue dropped {} parsed events for trace #{} ({}) while continuing to drain the kernel buffer (total {})",
+            report.dropped_since_last,
+            report.trace_id,
+            report.target_display,
+            report.dropped_total
         );
         warn!("{message}");
         eprintln!("ghostscope: {message}");

--- a/ghostscope/src/core/session.rs
+++ b/ghostscope/src/core/session.rs
@@ -77,7 +77,7 @@ pub struct GhostSession {
     pub target_binary: Option<String>,
     pub target_args: Vec<String>,
     pid_context: Option<RuntimePidContext>,
-    pub trace_manager: TraceManager, // Manages all trace instances with their loaders
+    pub trace_manager: TraceManager, // Manages trace metadata and loader-owning actors
     pub source_path_resolver: SourcePathResolver, // Resolves DWARF paths to actual filesystem paths
     #[allow(dead_code)]
     pub debug_file: Option<String>, // Optional debug file path
@@ -490,7 +490,8 @@ impl GhostSession {
         .await?;
 
         if loaded > 0 {
-            BacktraceRuntimeRunner::append_loaded_module_cfi(analyzer, &mut self.trace_manager);
+            BacktraceRuntimeRunner::append_loaded_module_cfi(analyzer, &mut self.trace_manager)
+                .await;
             info!(
                 "Refreshed PID {} runtime module analysis with {} new module(s)",
                 proc_pid, loaded
@@ -546,7 +547,8 @@ impl GhostSession {
         .await?;
 
         if loaded > 0 {
-            BacktraceRuntimeRunner::append_loaded_module_cfi(analyzer, &mut self.trace_manager);
+            BacktraceRuntimeRunner::append_loaded_module_cfi(analyzer, &mut self.trace_manager)
+                .await;
             info!(
                 "Refreshed target-mode runtime module analysis with {} new module(s)",
                 loaded

--- a/ghostscope/src/script/attach.rs
+++ b/ghostscope/src/script/attach.rs
@@ -268,7 +268,7 @@ pub(super) async fn create_and_attach_loader(
     Ok(loader)
 }
 
-pub(super) fn register_attached_trace(
+pub(super) async fn register_attached_trace(
     session: &mut GhostSession,
     script: &str,
     config: &ghostscope_compiler::UProbeConfig,
@@ -300,7 +300,11 @@ pub(super) fn register_attached_trace(
                 address_global_index: config.resolved_address_index,
             });
 
-    if let Err(e) = session.trace_manager.enable_trace(config.assigned_trace_id) {
+    if let Err(e) = session
+        .trace_manager
+        .enable_trace(config.assigned_trace_id)
+        .await
+    {
         warn!(
             "Failed to enable trace_id {}: {}",
             config.assigned_trace_id, e

--- a/ghostscope/src/script/cli.rs
+++ b/ghostscope/src/script/cli.rs
@@ -84,7 +84,7 @@ pub async fn compile_and_load_script_for_cli(
                     "✓ Successfully attached uprobe for trace_id {}",
                     config.assigned_trace_id
                 );
-                if register_attached_trace(session, script, config, loader) {
+                if register_attached_trace(session, script, config, loader).await {
                     attached_count += 1;
                 }
             }

--- a/ghostscope/src/script/tui.rs
+++ b/ghostscope/src/script/tui.rs
@@ -20,7 +20,12 @@ pub async fn compile_and_load_script_for_tui(
     refresh_runtime_modules_before_compile(script, session, &mut compile_options).await?;
 
     let binary_path = main_executable_path(session)?;
-    let compilation_result = match compile_script_with_session(script, session, &compile_options) {
+    // Compilation is synchronous and can be long-running. Mark the section as
+    // blocking so Tokio replaces this runtime worker while trace actors keep
+    // draining their RingBuf/PerfEventArray sources on other workers.
+    let compilation_result = match tokio::task::block_in_place(|| {
+        compile_script_with_session(script, session, &compile_options)
+    }) {
         Ok(result) => result,
         Err(SessionCompileError::Compile(e)) => {
             let friendly = e.user_message().into_owned();
@@ -63,7 +68,7 @@ pub async fn compile_and_load_script_for_tui(
                         "✓ Successfully attached uprobe for trace_id {}",
                         config.assigned_trace_id
                     );
-                    if register_attached_trace(session, script, config, loader) {
+                    if register_attached_trace(session, script, config, loader).await {
                         attached_count += 1;
                     }
                 }

--- a/ghostscope/src/trace/actor.rs
+++ b/ghostscope/src/trace/actor.rs
@@ -1,0 +1,373 @@
+use super::instance::TracePidContext;
+use anyhow::Result;
+use ghostscope_loader::{BacktraceUnwindRowsAppendStats, EventLossStats, GhostScopeLoader};
+use ghostscope_protocol::{BacktraceUnwindRow, ParsedTraceEvent};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{error, info, warn};
+
+// Each slot contains one bounded loader batch (currently at most 128 events).
+pub(super) const TRACE_EVENT_CHANNEL_CAPACITY: usize = 64;
+const TRACE_COMMAND_CHANNEL_CAPACITY: usize = 8;
+
+#[derive(Debug)]
+pub(super) enum TraceActorEvent {
+    Events {
+        trace_id: u32,
+        generation: u64,
+        events: Vec<ParsedTraceEvent>,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct TraceActorFatal {
+    pub trace_id: u32,
+    pub error: String,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct TraceActorLossStats {
+    pub kernel: Option<EventLossStats>,
+    pub delivery_dropped: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct TraceActorBacktraceUpdate {
+    pub stats: BacktraceUnwindRowsAppendStats,
+    pub event_generation: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct TraceActorConfig {
+    pub trace_id: u32,
+    pub target_display: String,
+    pub pc: u64,
+    pub binary_path: String,
+    pub pid_context: TracePidContext,
+    pub ebpf_function_name: String,
+}
+
+enum TraceCommand {
+    Enable(oneshot::Sender<Result<()>>),
+    Disable(oneshot::Sender<Result<()>>),
+    ReadLossStats(oneshot::Sender<Result<TraceActorLossStats>>),
+    AppendBacktraceRows {
+        modules: Arc<Vec<(u64, Vec<BacktraceUnwindRow>)>>,
+        response: oneshot::Sender<Result<TraceActorBacktraceUpdate>>,
+    },
+    Delete(oneshot::Sender<Result<()>>),
+}
+
+enum CommandOutcome {
+    Continue,
+    Delete {
+        response: oneshot::Sender<Result<()>>,
+        result: Result<()>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct TraceActorHandle {
+    command_sender: mpsc::Sender<TraceCommand>,
+}
+
+impl TraceActorHandle {
+    pub async fn enable(&self) -> Result<()> {
+        self.request(TraceCommand::Enable).await
+    }
+
+    pub async fn disable(&self) -> Result<()> {
+        self.request(TraceCommand::Disable).await
+    }
+
+    pub async fn read_loss_stats(&self) -> Result<TraceActorLossStats> {
+        self.request(TraceCommand::ReadLossStats).await
+    }
+
+    pub async fn append_backtrace_rows(
+        &self,
+        modules: Arc<Vec<(u64, Vec<BacktraceUnwindRow>)>>,
+    ) -> Result<TraceActorBacktraceUpdate> {
+        let (response, receiver) = oneshot::channel();
+        self.command_sender
+            .send(TraceCommand::AppendBacktraceRows { modules, response })
+            .await
+            .map_err(|_| anyhow::anyhow!("trace actor command channel closed"))?;
+        receiver
+            .await
+            .map_err(|_| anyhow::anyhow!("trace actor stopped before replying"))?
+    }
+
+    pub async fn delete(&self) -> Result<()> {
+        let (response, receiver) = oneshot::channel();
+        // A closed command channel means the actor already exited and dropped
+        // its loader (for example after a fatal parser error), so deletion is
+        // already complete from the manager's perspective.
+        if self
+            .command_sender
+            .send(TraceCommand::Delete(response))
+            .await
+            .is_err()
+        {
+            return Ok(());
+        }
+        match receiver.await {
+            Ok(result) => result,
+            Err(_) => Ok(()),
+        }
+    }
+
+    async fn request<T>(
+        &self,
+        build: impl FnOnce(oneshot::Sender<Result<T>>) -> TraceCommand,
+    ) -> Result<T> {
+        let (response, receiver) = oneshot::channel();
+        self.command_sender
+            .send(build(response))
+            .await
+            .map_err(|_| anyhow::anyhow!("trace actor command channel closed"))?;
+        receiver
+            .await
+            .map_err(|_| anyhow::anyhow!("trace actor stopped before replying"))?
+    }
+}
+
+pub(super) fn spawn_trace_actor(
+    mut loader: GhostScopeLoader,
+    config: TraceActorConfig,
+    event_sender: mpsc::Sender<TraceActorEvent>,
+    fatal_sender: mpsc::UnboundedSender<TraceActorFatal>,
+) -> TraceActorHandle {
+    let (command_sender, mut command_receiver) = mpsc::channel(TRACE_COMMAND_CHANNEL_CAPACITY);
+    let handle = TraceActorHandle { command_sender };
+
+    tokio::spawn(async move {
+        let mut is_enabled = false;
+        let mut delivery_dropped = 0u64;
+        let mut event_generation = 0u64;
+
+        loop {
+            if !is_enabled {
+                let Some(command) = command_receiver.recv().await else {
+                    destroy_loader(&mut loader, config.trace_id);
+                    break;
+                };
+                if let CommandOutcome::Delete { response, result } = handle_command(
+                    command,
+                    &mut loader,
+                    &config,
+                    &mut is_enabled,
+                    delivery_dropped,
+                    &mut event_generation,
+                ) {
+                    // Drop the complete loader before acknowledging deletion.
+                    // EventMap drops its readiness registrations before their
+                    // borrowed fds, then Ebpf drops the remaining program/map fds.
+                    drop(loader);
+                    let _ = response.send(result);
+                    break;
+                }
+                continue;
+            }
+
+            // When a command wins, select! cancels and drops the pending read
+            // future before entering the command branch. Any readiness guard is
+            // therefore gone before Delete can destroy the registered source.
+            tokio::select! {
+                biased;
+
+                command = command_receiver.recv() => {
+                    let Some(command) = command else {
+                        destroy_loader(&mut loader, config.trace_id);
+                        break;
+                    };
+                    if let CommandOutcome::Delete { response, result } = handle_command(
+                        command,
+                        &mut loader,
+                        &config,
+                        &mut is_enabled,
+                        delivery_dropped,
+                        &mut event_generation,
+                    ) {
+                        drop(loader);
+                        let _ = response.send(result);
+                        break;
+                    }
+                }
+
+                result = loader.wait_for_events_async() => {
+                    match result {
+                        Ok(events) if events.is_empty() => {}
+                        Ok(events) => {
+                            let event_count = events.len() as u64;
+                            match event_sender.try_send(TraceActorEvent::Events {
+                                trace_id: config.trace_id,
+                                generation: event_generation,
+                                events,
+                            }) {
+                                Ok(()) => {}
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    delivery_dropped = delivery_dropped.saturating_add(event_count);
+                                }
+                                Err(mpsc::error::TrySendError::Closed(_)) => {
+                                    destroy_loader(&mut loader, config.trace_id);
+                                    break;
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            let error = err.to_string();
+                            error!(
+                                trace_id = config.trace_id,
+                                "Fatal error reading trace events: {error}"
+                            );
+                            // Fatal notifications use a separate unbounded control
+                            // path (at most one per actor), so a saturated bounded
+                            // event queue cannot hide failure or delay teardown.
+                            let _ = fatal_sender.send(TraceActorFatal {
+                                trace_id: config.trace_id,
+                                error,
+                            });
+                            destroy_loader(&mut loader, config.trace_id);
+                            break;
+                        }
+                    }
+                    // A hot trace should not monopolize a runtime worker even when
+                    // its fd remains continuously readable.
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    });
+
+    handle
+}
+
+fn handle_command(
+    command: TraceCommand,
+    loader: &mut GhostScopeLoader,
+    config: &TraceActorConfig,
+    is_enabled: &mut bool,
+    delivery_dropped: u64,
+    event_generation: &mut u64,
+) -> CommandOutcome {
+    match command {
+        TraceCommand::Enable(response) => {
+            let result = enable_loader(loader, config, *is_enabled);
+            if result.is_ok() {
+                *is_enabled = true;
+            }
+            let _ = response.send(result);
+            CommandOutcome::Continue
+        }
+        TraceCommand::Disable(response) => {
+            let result = disable_loader(loader, config, *is_enabled);
+            if result.is_ok() {
+                *is_enabled = false;
+            }
+            let _ = response.send(result);
+            CommandOutcome::Continue
+        }
+        TraceCommand::ReadLossStats(response) => {
+            let result = loader
+                .read_event_loss_stats()
+                .map(|kernel| TraceActorLossStats {
+                    kernel,
+                    delivery_dropped,
+                })
+                .map_err(Into::into);
+            let _ = response.send(result);
+            CommandOutcome::Continue
+        }
+        TraceCommand::AppendBacktraceRows { modules, response } => {
+            let result = loader
+                .append_backtrace_unwind_rows_for_modules(modules.as_slice())
+                .map(|stats| {
+                    if stats.modules > 0 {
+                        // Batches already queued were captured with the previous
+                        // unwind tables. Advancing the generation lets the
+                        // manager discard those stale batches without blocking
+                        // newly captured events behind a hot trace's backlog.
+                        *event_generation = event_generation.saturating_add(1);
+                    }
+                    TraceActorBacktraceUpdate {
+                        stats,
+                        event_generation: *event_generation,
+                    }
+                })
+                .map_err(Into::into);
+            let _ = response.send(result);
+            CommandOutcome::Continue
+        }
+        TraceCommand::Delete(response) => {
+            // destroy() explicitly clears EventMap. The caller then drops the
+            // rest of the loader before acknowledging the command.
+            let result = loader.destroy().map_err(Into::into);
+            CommandOutcome::Delete { response, result }
+        }
+    }
+}
+
+fn enable_loader(
+    loader: &mut GhostScopeLoader,
+    config: &TraceActorConfig,
+    is_enabled: bool,
+) -> Result<()> {
+    if is_enabled {
+        info!("Trace {} is already enabled", config.trace_id);
+        return Ok(());
+    }
+
+    if loader.is_uprobe_attached() {
+        return Ok(());
+    }
+
+    info!(
+        "Enabling trace {} for target '{}' at PC 0x{:x} in binary '{}'",
+        config.trace_id, config.target_display, config.pc, config.binary_path
+    );
+    if loader.get_attachment_info().is_some() {
+        loader
+            .reattach_uprobe()
+            .map_err(|err| anyhow::anyhow!("Failed to re-attach uprobe: {err}"))?;
+    } else {
+        loader
+            .attach_uprobe(
+                &config.binary_path,
+                &config.ebpf_function_name,
+                Some(config.pc),
+                config.pid_context.attach_pid.map(|pid| pid as i32),
+            )
+            .map_err(|err| anyhow::anyhow!("Failed to attach uprobe: {err}"))?;
+    }
+
+    info!("Successfully enabled trace {}", config.trace_id);
+    Ok(())
+}
+
+fn disable_loader(
+    loader: &mut GhostScopeLoader,
+    config: &TraceActorConfig,
+    is_enabled: bool,
+) -> Result<()> {
+    if !is_enabled {
+        info!("Trace {} is already disabled", config.trace_id);
+        return Ok(());
+    }
+
+    info!(
+        "Disabling trace {} for target '{}' at PC 0x{:x}",
+        config.trace_id, config.target_display, config.pc
+    );
+    loader
+        .detach_uprobe()
+        .map_err(|err| anyhow::anyhow!("Failed to detach uprobe: {err}"))?;
+    info!("Successfully disabled trace {}", config.trace_id);
+    Ok(())
+}
+
+fn destroy_loader(loader: &mut GhostScopeLoader, trace_id: u32) {
+    if let Err(err) = loader.destroy() {
+        warn!(trace_id, "Failed to destroy trace loader: {err}");
+    }
+}

--- a/ghostscope/src/trace/actor.rs
+++ b/ghostscope/src/trace/actor.rs
@@ -49,7 +49,7 @@ pub(super) struct TraceActorConfig {
 
 enum TraceCommand {
     Enable(oneshot::Sender<Result<()>>),
-    Disable(oneshot::Sender<Result<()>>),
+    Disable(oneshot::Sender<Result<u64>>),
     ReadLossStats(oneshot::Sender<Result<TraceActorLossStats>>),
     AppendBacktraceRows {
         modules: Arc<Vec<(u64, Vec<BacktraceUnwindRow>)>>,
@@ -76,7 +76,7 @@ impl TraceActorHandle {
         self.request(TraceCommand::Enable).await
     }
 
-    pub async fn disable(&self) -> Result<()> {
+    pub async fn disable(&self) -> Result<u64> {
         self.request(TraceCommand::Disable).await
     }
 
@@ -261,10 +261,10 @@ fn handle_command(
             CommandOutcome::Continue
         }
         TraceCommand::Disable(response) => {
-            let result = disable_loader(loader, config, *is_enabled);
-            if result.is_ok() {
+            let result = disable_loader(loader, config, *is_enabled).map(|()| {
                 *is_enabled = false;
-            }
+                advance_event_generation(event_generation)
+            });
             let _ = response.send(result);
             CommandOutcome::Continue
         }
@@ -283,16 +283,13 @@ fn handle_command(
             let result = loader
                 .append_backtrace_unwind_rows_for_modules(modules.as_slice())
                 .map(|stats| {
-                    if stats.modules > 0 {
-                        // Batches already queued were captured with the previous
-                        // unwind tables. Advancing the generation lets the
-                        // manager discard those stale batches without blocking
-                        // newly captured events behind a hot trace's backlog.
-                        *event_generation = event_generation.saturating_add(1);
-                    }
+                    // Shared pinned unwind maps may have been populated by a
+                    // different actor, in which case this loader reports zero
+                    // inserted modules but its queued batches are still stale.
+                    let event_generation = advance_event_generation(event_generation);
                     TraceActorBacktraceUpdate {
                         stats,
-                        event_generation: *event_generation,
+                        event_generation,
                     }
                 })
                 .map_err(Into::into);
@@ -306,6 +303,11 @@ fn handle_command(
             CommandOutcome::Delete { response, result }
         }
     }
+}
+
+fn advance_event_generation(event_generation: &mut u64) -> u64 {
+    *event_generation = event_generation.saturating_add(1);
+    *event_generation
 }
 
 fn enable_loader(

--- a/ghostscope/src/trace/backtrace_runtime.rs
+++ b/ghostscope/src/trace/backtrace_runtime.rs
@@ -102,12 +102,14 @@ impl BacktraceRuntimeRunner {
             .await
     }
 
-    pub fn append_loaded_module_cfi(
+    pub async fn append_loaded_module_cfi(
         analyzer: &DwarfAnalyzer,
         trace_manager: &mut TraceManager,
     ) -> BacktraceUnwindRowsAppendStats {
         let modules = Self::collect_backtrace_unwind_rows(analyzer);
-        let stats = trace_manager.append_backtrace_unwind_rows_for_modules(&modules);
+        let stats = trace_manager
+            .append_backtrace_unwind_rows_for_modules(&modules)
+            .await;
         if stats.modules > 0 {
             info!(
                 modules = stats.modules,

--- a/ghostscope/src/trace/instance.rs
+++ b/ghostscope/src/trace/instance.rs
@@ -1,6 +1,8 @@
+use super::actor::{TraceActorBacktraceUpdate, TraceActorHandle, TraceActorLossStats};
 use anyhow::Result;
-use ghostscope_loader::{EventLossStats, GhostScopeLoader};
-use tracing::{error, info, warn};
+use ghostscope_protocol::BacktraceUnwindRow;
+use std::sync::Arc;
+use tracing::{info, warn};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TracePidContext {
@@ -20,7 +22,7 @@ impl TracePidContext {
 
 /// Individual trace instance with single PC value
 #[derive(Debug)]
-pub struct TraceInstance {
+pub(super) struct TraceInstance {
     pub trace_id: u32,
     pub target: String, // Target identifier for grouping (e.g., "test_program:L15")
     pub script_content: String, // Original script content
@@ -29,12 +31,12 @@ pub struct TraceInstance {
     pub pc: u64,        // Program counter value for this trace (file offset for uprobe)
     pub pid_context: TracePidContext,
     pub is_enabled: bool, // Whether the uprobe is currently enabled
-    pub loader: Option<GhostScopeLoader>, // eBPF loader for this trace
+    pub(super) actor: Option<TraceActorHandle>, // Owns the eBPF loader for this trace
     pub ebpf_function_name: String, // eBPF function name for uprobe attachment
     pub address_global_index: Option<usize>, // Global 1-based index of the resolved address
 }
 
-pub struct TraceInstanceArgs {
+pub(super) struct TraceInstanceArgs {
     pub trace_id: u32,
     pub target: String,
     pub script_content: String,
@@ -42,13 +44,13 @@ pub struct TraceInstanceArgs {
     pub binary_path: String,
     pub target_display: String,
     pub pid_context: TracePidContext,
-    pub loader: Option<ghostscope_loader::GhostScopeLoader>,
+    pub(super) actor: Option<TraceActorHandle>,
     pub ebpf_function_name: String,
     pub address_global_index: Option<usize>,
 }
 
 impl TraceInstance {
-    pub fn new(args: TraceInstanceArgs) -> Self {
+    pub(super) fn new(args: TraceInstanceArgs) -> Self {
         Self {
             trace_id: args.trace_id,
             target: args.target,
@@ -58,86 +60,28 @@ impl TraceInstance {
             target_display: args.target_display,
             pid_context: args.pid_context,
             is_enabled: false,
-            loader: args.loader,
+            actor: args.actor,
             ebpf_function_name: args.ebpf_function_name,
             address_global_index: args.address_global_index,
         }
     }
 
     /// Enable this trace instance
-    pub fn enable(&mut self) -> Result<()> {
+    pub(super) async fn enable(&mut self) -> Result<()> {
         if self.is_enabled {
             info!("Trace {} is already enabled", self.trace_id);
             Ok(())
-        } else if let Some(ref mut loader) = self.loader {
-            let already_attached = loader.is_uprobe_attached();
-            if !already_attached {
-                info!(
-                    "Enabling trace {} for target '{}' at PC 0x{:x} in binary '{}'",
-                    self.trace_id, self.target_display, self.pc, self.binary_path
-                );
-            }
-            if already_attached {
-                self.is_enabled = true;
-                Ok(())
-            } else if loader.get_attachment_info().is_some() {
-                info!(
-                    "Re-attaching uprobe for trace {} (program already loaded)",
-                    self.trace_id
-                );
-                match loader.reattach_uprobe() {
-                    Ok(_) => {
-                        info!(
-                            "✓ Successfully re-attached uprobe for trace {}",
-                            self.trace_id
-                        );
-                        self.is_enabled = true;
-                        Ok(())
-                    }
-                    Err(e) => {
-                        error!(
-                            "❌ Failed to re-attach uprobe for trace {}: {}",
-                            self.trace_id, e
-                        );
-                        Err(anyhow::anyhow!("Failed to re-attach uprobe: {e}"))
-                    }
-                }
-            } else {
-                info!(
-                    "Attaching uprobe for trace {} at offset 0x{:x} using program '{}'",
-                    self.trace_id, self.pc, self.ebpf_function_name
-                );
-                match loader.attach_uprobe(
-                    &self.binary_path,
-                    &self.ebpf_function_name,
-                    Some(self.pc),
-                    self.pid_context.attach_pid.map(|pid| pid as i32),
-                ) {
-                    Ok(_) => {
-                        info!(
-                            "✓ Successfully attached uprobe for trace {} at offset 0x{:x}",
-                            self.trace_id, self.pc
-                        );
-                        self.is_enabled = true;
-                        Ok(())
-                    }
-                    Err(e) => {
-                        error!(
-                            "❌ Failed to attach uprobe for trace {}: {}",
-                            self.trace_id, e
-                        );
-                        Err(anyhow::anyhow!("Failed to attach uprobe: {e}"))
-                    }
-                }
-            }
+        } else if let Some(actor) = &self.actor {
+            actor.enable().await?;
+            self.is_enabled = true;
+            Ok(())
         } else {
-            error!("No eBPF loader available for trace {}", self.trace_id);
-            Err(anyhow::anyhow!("No eBPF loader available"))
+            Err(anyhow::anyhow!("No trace actor available"))
         }
     }
 
     /// Disable this trace instance
-    pub fn disable(&mut self) -> Result<()> {
+    pub(super) async fn disable(&mut self) -> Result<()> {
         if !self.is_enabled {
             info!("Trace {} is already disabled", self.trace_id);
             return Ok(());
@@ -148,25 +92,13 @@ impl TraceInstance {
             self.trace_id, self.target_display, self.pc
         );
 
-        // Detach uprobe using the loader
-        if let Some(ref mut loader) = self.loader {
-            match loader.detach_uprobe() {
-                Ok(_) => {
-                    info!("✓ Successfully detached uprobe for trace {}", self.trace_id);
-                    self.is_enabled = false;
-                    Ok(())
-                }
-                Err(e) => {
-                    error!(
-                        "❌ Failed to detach uprobe for trace {}: {}",
-                        self.trace_id, e
-                    );
-                    Err(anyhow::anyhow!("Failed to detach uprobe: {e}"))
-                }
-            }
+        if let Some(actor) = &self.actor {
+            actor.disable().await?;
+            self.is_enabled = false;
+            Ok(())
         } else {
             warn!(
-                "No eBPF loader available for trace {}, marking as disabled",
+                "No trace actor available for trace {}, marking as disabled",
                 self.trace_id
             );
             self.is_enabled = false;
@@ -174,37 +106,30 @@ impl TraceInstance {
         }
     }
 
-    /// Wait for events asynchronously from this trace instance
-    pub async fn wait_for_events_async(
-        &mut self,
-    ) -> Result<Vec<ghostscope_protocol::ParsedTraceEvent>> {
-        if !self.is_enabled {
-            return Ok(Vec::new());
-        }
-
-        // Wait for events using the loader
-        if let Some(ref mut loader) = self.loader {
-            match loader.wait_for_events_async().await {
-                Ok(events) => Ok(events),
-                Err(e) => {
-                    warn!(
-                        "Error waiting for events from trace {}: {}",
-                        self.trace_id, e
-                    );
-                    Err(e.into())
-                }
-            }
+    pub(super) async fn read_loss_stats(&self) -> Result<TraceActorLossStats> {
+        if let Some(actor) = &self.actor {
+            actor.read_loss_stats().await
         } else {
-            error!("No eBPF loader available for trace {}", self.trace_id);
-            Err(anyhow::anyhow!("No eBPF loader available"))
+            Ok(TraceActorLossStats::default())
         }
     }
 
-    pub fn read_event_loss_stats(&self) -> Result<Option<EventLossStats>> {
-        if let Some(loader) = &self.loader {
-            loader.read_event_loss_stats().map_err(Into::into)
+    pub(super) async fn append_backtrace_rows(
+        &self,
+        modules: Arc<Vec<(u64, Vec<BacktraceUnwindRow>)>>,
+    ) -> Result<TraceActorBacktraceUpdate> {
+        if let Some(actor) = &self.actor {
+            actor.append_backtrace_rows(modules).await
         } else {
-            Ok(None)
+            Ok(Default::default())
+        }
+    }
+
+    pub(super) async fn delete(&self) -> Result<()> {
+        if let Some(actor) = &self.actor {
+            actor.delete().await
+        } else {
+            Ok(())
         }
     }
 }

--- a/ghostscope/src/trace/instance.rs
+++ b/ghostscope/src/trace/instance.rs
@@ -81,10 +81,10 @@ impl TraceInstance {
     }
 
     /// Disable this trace instance
-    pub(super) async fn disable(&mut self) -> Result<()> {
+    pub(super) async fn disable(&mut self) -> Result<Option<u64>> {
         if !self.is_enabled {
             info!("Trace {} is already disabled", self.trace_id);
-            return Ok(());
+            return Ok(None);
         }
 
         info!(
@@ -93,16 +93,16 @@ impl TraceInstance {
         );
 
         if let Some(actor) = &self.actor {
-            actor.disable().await?;
+            let event_generation = actor.disable().await?;
             self.is_enabled = false;
-            Ok(())
+            Ok(Some(event_generation))
         } else {
             warn!(
                 "No trace actor available for trace {}, marking as disabled",
                 self.trace_id
             );
             self.is_enabled = false;
-            Ok(())
+            Ok(None)
         }
     }
 

--- a/ghostscope/src/trace/manager.rs
+++ b/ghostscope/src/trace/manager.rs
@@ -1,14 +1,17 @@
+use crate::trace::actor::{
+    spawn_trace_actor, TraceActorConfig, TraceActorEvent, TraceActorFatal,
+    TRACE_EVENT_CHANNEL_CAPACITY,
+};
 use crate::trace::instance::{TraceInstance, TraceInstanceArgs, TracePidContext};
 use crate::trace::snapshot::{TraceSnapshot, TraceSummary};
 use anyhow::Result;
-use futures::future::{select_all, BoxFuture};
-use futures::FutureExt;
 use ghostscope_loader::{BacktraceUnwindRowsAppendStats, EventLossStats, GhostScopeLoader};
 use ghostscope_protocol::BacktraceUnwindRow;
 use ghostscope_protocol::ParsedTraceEvent;
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::Notify;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 const MAX_AGGREGATED_EVENTS_PER_WAIT: usize = 1024;
@@ -19,11 +22,17 @@ pub struct TraceManager {
     traces: HashMap<u32, TraceInstance>,
     next_trace_id: u32,
     target_to_trace_id: HashMap<String, u32>, // Map target name to trace_id
-    no_trace_wait_notify: Notify,             // Notify when first trace is successfully enabled
     // Track creation timestamps for duration calculation
     trace_created_times: HashMap<u32, u64>,
+    event_sender: mpsc::Sender<TraceActorEvent>,
+    event_receiver: mpsc::Receiver<TraceActorEvent>,
+    fatal_sender: mpsc::UnboundedSender<TraceActorFatal>,
+    fatal_receiver: mpsc::UnboundedReceiver<TraceActorFatal>,
     pending_events: VecDeque<ParsedTraceEvent>,
+    pending_error: Option<anyhow::Error>,
+    minimum_event_generations: HashMap<u32, u64>,
     last_reported_event_loss: HashMap<u32, EventLossStats>,
+    last_reported_delivery_loss: HashMap<u32, u64>,
 }
 
 /// Parameters for adding a new trace with a pre-allocated ID
@@ -49,16 +58,38 @@ pub struct EventLossReport {
     pub lost_total: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventDeliveryLossReport {
+    pub trace_id: u32,
+    pub target_display: String,
+    pub dropped_since_last: u64,
+    pub dropped_total: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct TraceLossReports {
+    pub kernel: Vec<EventLossReport>,
+    pub delivery: Vec<EventDeliveryLossReport>,
+}
+
 impl TraceManager {
     pub fn new() -> Self {
+        let (event_sender, event_receiver) = mpsc::channel(TRACE_EVENT_CHANNEL_CAPACITY);
+        let (fatal_sender, fatal_receiver) = mpsc::unbounded_channel();
         Self {
             traces: HashMap::new(),
             next_trace_id: ghostscope_protocol::consts::DEFAULT_TRACE_ID as u32,
             target_to_trace_id: HashMap::new(),
-            no_trace_wait_notify: Notify::new(),
             trace_created_times: HashMap::new(),
+            event_sender,
+            event_receiver,
+            fatal_sender,
+            fatal_receiver,
             pending_events: VecDeque::new(),
+            pending_error: None,
+            minimum_event_generations: HashMap::new(),
             last_reported_event_loss: HashMap::new(),
+            last_reported_delivery_loss: HashMap::new(),
         }
     }
 
@@ -66,6 +97,10 @@ impl TraceManager {
     /// This is used for script compilation to know the starting trace ID
     pub fn get_next_trace_id(&self) -> u32 {
         self.next_trace_id
+    }
+
+    pub fn event_channel_capacity(&self) -> usize {
+        TRACE_EVENT_CHANNEL_CAPACITY
     }
 
     /// Add a new trace instance with a pre-allocated trace ID
@@ -82,10 +117,27 @@ impl TraceManager {
             .unwrap_or_default()
             .as_secs();
         self.trace_created_times.insert(params.trace_id, now);
+        self.minimum_event_generations.insert(params.trace_id, 0);
 
         // Create unique target key by combining target with trace_id
         // This allows multiple traces for the same target (e.g., same function/line)
         let unique_target = format!("{}#{}", params.target, params.trace_id);
+
+        let actor = params.loader.map(|loader| {
+            spawn_trace_actor(
+                loader,
+                TraceActorConfig {
+                    trace_id: params.trace_id,
+                    target_display: params.target_display.clone(),
+                    pc: params.pc,
+                    binary_path: params.binary_path.clone(),
+                    pid_context: params.pid_context,
+                    ebpf_function_name: params.ebpf_function_name.clone(),
+                },
+                self.event_sender.clone(),
+                self.fatal_sender.clone(),
+            )
+        });
 
         let trace_instance = TraceInstance::new(TraceInstanceArgs {
             trace_id: params.trace_id,
@@ -95,7 +147,7 @@ impl TraceManager {
             binary_path: params.binary_path,
             target_display: params.target_display,
             pid_context: params.pid_context,
-            loader: params.loader,
+            actor,
             ebpf_function_name: params.ebpf_function_name,
             address_global_index: params.address_global_index,
         });
@@ -112,7 +164,11 @@ impl TraceManager {
     }
 
     /// Completely delete a trace by ID, destroying all associated resources
-    pub fn delete_trace(&mut self, trace_id: u32) -> Result<()> {
+    pub async fn delete_trace(&mut self, trace_id: u32) -> Result<()> {
+        if let Some(trace) = self.traces.get(&trace_id) {
+            trace.delete().await?;
+        }
+
         if let Some(trace) = self.traces.remove(&trace_id) {
             // Remove from target mapping using the correct unique target key
             let unique_target = format!("{}#{}", trace.target, trace_id);
@@ -121,7 +177,9 @@ impl TraceManager {
             self.trace_created_times.remove(&trace_id);
             self.pending_events
                 .retain(|event| event.trace_id != trace_id as u64);
+            self.minimum_event_generations.remove(&trace_id);
             self.last_reported_event_loss.remove(&trace_id);
+            self.last_reported_delivery_loss.remove(&trace_id);
 
             info!("Deleted trace {} with target '{}'", trace_id, trace.target);
             Ok(())
@@ -131,13 +189,17 @@ impl TraceManager {
     }
 
     /// Delete all traces
-    pub fn delete_all_traces(&mut self) -> Result<usize> {
+    pub async fn delete_all_traces(&mut self) -> Result<usize> {
         let count = self.traces.len();
-        self.traces.clear();
-        self.target_to_trace_id.clear();
-        self.trace_created_times.clear();
+        let trace_ids = self.get_all_trace_ids();
+        for trace_id in trace_ids {
+            self.delete_trace(trace_id).await?;
+        }
         self.pending_events.clear();
+        self.pending_error = None;
+        self.minimum_event_generations.clear();
         self.last_reported_event_loss.clear();
+        self.last_reported_delivery_loss.clear();
         info!("Deleted all {} traces", count);
         Ok(count)
     }
@@ -153,16 +215,15 @@ impl TraceManager {
     }
 
     /// Enable a specific trace by ID
-    pub fn enable_trace(&mut self, trace_id: u32) -> Result<()> {
+    pub async fn enable_trace(&mut self, trace_id: u32) -> Result<()> {
         // Check if this is the first trace being enabled (from 0 to 1)
         let was_no_active_traces = self.active_trace_count() == 0;
 
         if let Some(trace) = self.traces.get_mut(&trace_id) {
-            trace.enable()?;
+            trace.enable().await?;
 
-            // If this was the first trace being enabled, notify waiters
-            if was_no_active_traces && self.active_trace_count() == 1 {
-                self.no_trace_wait_notify.notify_waiters();
+            if was_no_active_traces {
+                debug!(trace_id, "First trace actor enabled");
             }
 
             Ok(())
@@ -172,19 +233,19 @@ impl TraceManager {
     }
 
     /// Disable a specific trace by ID
-    pub fn disable_trace(&mut self, trace_id: u32) -> Result<()> {
+    pub async fn disable_trace(&mut self, trace_id: u32) -> Result<()> {
         if let Some(trace) = self.traces.get_mut(&trace_id) {
-            trace.disable()
+            trace.disable().await
         } else {
             Err(anyhow::anyhow!("Trace {trace_id} not found"))
         }
     }
 
     /// Enable all traces
-    pub fn enable_all_traces(&mut self) -> Result<()> {
+    pub async fn enable_all_traces(&mut self) -> Result<()> {
         let trace_ids: Vec<u32> = self.traces.keys().cloned().collect();
         for trace_id in trace_ids {
-            if let Err(e) = self.enable_trace(trace_id) {
+            if let Err(e) = self.enable_trace(trace_id).await {
                 warn!("Failed to enable trace {}: {}", trace_id, e);
             }
         }
@@ -192,10 +253,10 @@ impl TraceManager {
     }
 
     /// Disable all traces
-    pub fn disable_all_traces(&mut self) -> Result<()> {
+    pub async fn disable_all_traces(&mut self) -> Result<()> {
         let trace_ids: Vec<u32> = self.traces.keys().cloned().collect();
         for trace_id in trace_ids {
-            if let Err(e) = self.disable_trace(trace_id) {
+            if let Err(e) = self.disable_trace(trace_id).await {
                 warn!("Failed to disable trace {}: {}", trace_id, e);
             }
         }
@@ -231,45 +292,61 @@ impl TraceManager {
         }
     }
 
-    pub fn collect_event_loss_reports(&mut self) -> Vec<EventLossReport> {
-        let mut reports = Vec::new();
+    pub async fn collect_event_loss_reports(&mut self) -> TraceLossReports {
+        let mut reports = TraceLossReports::default();
 
         for (&trace_id, trace) in self.traces.iter() {
-            let stats = match trace.read_event_loss_stats() {
-                Ok(Some(stats)) => stats,
-                Ok(None) => continue,
+            let stats = match trace.read_loss_stats().await {
+                Ok(stats) => stats,
                 Err(err) => {
                     warn!(
-                        "Failed to read eBPF event loss counters for trace {}: {}",
+                        "Failed to read event loss counters for trace {}: {}",
                         trace_id, err
                     );
                     continue;
                 }
             };
 
-            let previous = self
-                .last_reported_event_loss
+            if let Some(kernel_stats) = stats.kernel {
+                let previous = self
+                    .last_reported_event_loss
+                    .get(&trace_id)
+                    .copied()
+                    .unwrap_or_default();
+                let delta = kernel_stats.saturating_sub(previous);
+                if !delta.is_empty() {
+                    self.last_reported_event_loss.insert(trace_id, kernel_stats);
+                    reports.kernel.push(EventLossReport {
+                        trace_id,
+                        target_display: trace.target_display.clone(),
+                        lost_since_last: delta.output_failures,
+                        lost_total: kernel_stats.output_failures,
+                    });
+                }
+            }
+
+            let previous_delivery = self
+                .last_reported_delivery_loss
                 .get(&trace_id)
                 .copied()
                 .unwrap_or_default();
-            let delta = stats.saturating_sub(previous);
-            if delta.is_empty() {
-                continue;
+            let delivery_delta = stats.delivery_dropped.saturating_sub(previous_delivery);
+            if delivery_delta > 0 {
+                self.last_reported_delivery_loss
+                    .insert(trace_id, stats.delivery_dropped);
+                reports.delivery.push(EventDeliveryLossReport {
+                    trace_id,
+                    target_display: trace.target_display.clone(),
+                    dropped_since_last: delivery_delta,
+                    dropped_total: stats.delivery_dropped,
+                });
             }
-
-            self.last_reported_event_loss.insert(trace_id, stats);
-            reports.push(EventLossReport {
-                trace_id,
-                target_display: trace.target_display.clone(),
-                lost_since_last: delta.output_failures,
-                lost_total: stats.output_failures,
-            });
         }
 
         reports
     }
 
-    pub fn append_backtrace_unwind_rows_for_modules(
+    pub async fn append_backtrace_unwind_rows_for_modules(
         &mut self,
         modules: &[(u64, Vec<BacktraceUnwindRow>)],
     ) -> BacktraceUnwindRowsAppendStats {
@@ -278,14 +355,20 @@ impl TraceManager {
             return total;
         }
 
-        for (&trace_id, trace) in self.traces.iter_mut() {
-            let Some(loader) = trace.loader.as_mut() else {
-                continue;
+        let modules = Arc::new(modules.to_vec());
+        let trace_ids = self.get_all_trace_ids();
+        for trace_id in trace_ids {
+            let update = {
+                let Some(trace) = self.traces.get(&trace_id) else {
+                    continue;
+                };
+                trace.append_backtrace_rows(Arc::clone(&modules)).await
             };
-
-            match loader.append_backtrace_unwind_rows_for_modules(modules) {
-                Ok(stats) => {
+            match update {
+                Ok(update) => {
+                    let stats = update.stats;
                     if stats.modules > 0 {
+                        self.require_event_generation(trace_id, update.event_generation);
                         debug!(
                             trace_id,
                             modules = stats.modules,
@@ -308,97 +391,132 @@ impl TraceManager {
         total
     }
 
-    /// Wait for the first trace to be enabled (for TUI mode to avoid busy waiting)
-    pub async fn wait_for_first_trace(&self) {
-        self.no_trace_wait_notify.notified().await;
+    fn require_event_generation(&mut self, trace_id: u32, generation: u64) {
+        let minimum = self.minimum_event_generations.entry(trace_id).or_default();
+        if generation <= *minimum {
+            return;
+        }
+
+        *minimum = generation;
+        // Events deferred by the aggregation limit were necessarily captured
+        // before the actor acknowledged the update. Remove them here so they do
+        // not hide events captured with the newly installed unwind tables.
+        self.pending_events
+            .retain(|event| event.trace_id != trace_id as u64);
     }
 
-    /// Wait for events from all active traces using futures::select_all
+    /// Wait for events emitted by the independent trace actors.
     pub async fn wait_for_all_events_async(&mut self) -> anyhow::Result<Vec<ParsedTraceEvent>> {
-        loop {
-            if let Some(events) = self.take_pending_events() {
-                return Ok(events);
-            }
+        if let Some(events) = self.take_pending_events() {
+            return Ok(events);
+        }
+        if let Some(error) = self.pending_error.take() {
+            return Err(error);
+        }
 
-            let futures: Vec<BoxFuture<'_, (u32, anyhow::Result<Vec<ParsedTraceEvent>>)>> = self
-                .traces
-                .iter_mut()
-                .filter_map(|(&trace_id, trace)| {
-                    if trace.is_enabled {
-                        Some(async move { (trace_id, trace.wait_for_events_async().await) }.boxed())
-                    } else {
-                        None
+        let mut aggregated_events = Vec::new();
+        let mut deferred_by_batch_limit = 0usize;
+        let first = loop {
+            let event = tokio::select! {
+                biased;
+                event = self.event_receiver.recv() => Some(event
+                    .ok_or_else(|| anyhow::anyhow!("trace actor event channel closed"))?),
+                fatal = self.fatal_receiver.recv() => {
+                    let fatal = fatal
+                        .ok_or_else(|| anyhow::anyhow!("trace actor fatal channel closed"))?;
+                    if self.traces.contains_key(&fatal.trace_id) {
+                        return Err(actor_fatal_error(fatal));
                     }
-                })
-                .collect();
-
-            if futures.is_empty() {
-                drop(futures);
-                self.wait_for_first_trace().await;
-                continue;
+                    debug!(
+                        trace_id = fatal.trace_id,
+                        "Ignoring fatal notification from deleted trace actor"
+                    );
+                    None
+                }
+            };
+            if let Some(event) = event {
+                break event;
             }
+        };
+        self.append_actor_event(first, &mut aggregated_events, &mut deferred_by_batch_limit);
 
-            let ((trace_id, result), _index, remaining) = select_all(futures).await;
-
-            let mut aggregated_events = Vec::new();
-            let mut deferred_by_batch_limit = 0usize;
-
-            match result {
-                Ok(events) => {
-                    deferred_by_batch_limit += append_with_limit(
+        while aggregated_events.len() < MAX_AGGREGATED_EVENTS_PER_WAIT {
+            match self.event_receiver.try_recv() {
+                Ok(event) => {
+                    self.append_actor_event(
+                        event,
                         &mut aggregated_events,
-                        events,
-                        &mut self.pending_events,
-                        MAX_AGGREGATED_EVENTS_PER_WAIT,
+                        &mut deferred_by_batch_limit,
                     );
                 }
-                Err(e) => {
-                    // Fatal errors should be propagated to the caller
-                    error!(
-                        "Fatal error waiting for events from trace {}: {}",
-                        trace_id, e
-                    );
-                    return Err(e);
-                }
-            }
-
-            for future in remaining {
-                if aggregated_events.len() >= MAX_AGGREGATED_EVENTS_PER_WAIT {
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    if aggregated_events.is_empty() {
+                        return Err(anyhow::anyhow!("trace actor event channel closed"));
+                    }
                     break;
                 }
-                if let Some((trace_id, result)) = future.now_or_never() {
-                    match result {
-                        Ok(events) => {
-                            deferred_by_batch_limit += append_with_limit(
-                                &mut aggregated_events,
-                                events,
-                                &mut self.pending_events,
-                                MAX_AGGREGATED_EVENTS_PER_WAIT,
-                            );
-                        }
-                        Err(e) => {
-                            // Fatal errors should be propagated to the caller
-                            error!(
-                                "Fatal error waiting for events from trace {}: {}",
-                                trace_id, e
-                            );
-                            return Err(e);
-                        }
-                    }
-                }
             }
+        }
 
-            if !aggregated_events.is_empty() {
-                if deferred_by_batch_limit > 0 {
-                    debug!(
-                        "Trace manager batch limit reached ({} events returned, {} parsed events deferred)",
-                        aggregated_events.len(),
-                        deferred_by_batch_limit
-                    );
+        if let Ok(fatal) = self.fatal_receiver.try_recv() {
+            if self.traces.contains_key(&fatal.trace_id) {
+                let error = actor_fatal_error(fatal);
+                if aggregated_events.is_empty() {
+                    return Err(error);
                 }
-                return Ok(aggregated_events);
+                self.pending_error = Some(error);
+            } else {
+                debug!(
+                    trace_id = fatal.trace_id,
+                    "Ignoring fatal notification from deleted trace actor"
+                );
             }
-            // No events received after draining ready traces, continue looping.
+        }
+
+        if deferred_by_batch_limit > 0 {
+            debug!(
+                "Trace manager batch limit reached ({} events returned, {} parsed events deferred)",
+                aggregated_events.len(),
+                deferred_by_batch_limit
+            );
+        }
+        Ok(aggregated_events)
+    }
+
+    fn append_actor_event(
+        &mut self,
+        event: TraceActorEvent,
+        aggregated_events: &mut Vec<ParsedTraceEvent>,
+        deferred_by_batch_limit: &mut usize,
+    ) {
+        match event {
+            TraceActorEvent::Events {
+                trace_id,
+                generation,
+                events,
+            } => {
+                // Delete waits for the actor to tear down its loader, but batches
+                // sent before that acknowledgement may still be queued.
+                if !self.traces.contains_key(&trace_id) {
+                    return;
+                }
+                if generation
+                    < self
+                        .minimum_event_generations
+                        .get(&trace_id)
+                        .copied()
+                        .unwrap_or_default()
+                {
+                    return;
+                }
+                *deferred_by_batch_limit += append_with_limit(
+                    aggregated_events,
+                    events,
+                    &mut self.pending_events,
+                    MAX_AGGREGATED_EVENTS_PER_WAIT,
+                );
+            }
         }
     }
 
@@ -419,6 +537,18 @@ impl TraceManager {
         }
         Some(events)
     }
+}
+
+fn actor_fatal_error(fatal: TraceActorFatal) -> anyhow::Error {
+    error!(
+        trace_id = fatal.trace_id,
+        "Fatal error waiting for trace events: {}", fatal.error
+    );
+    anyhow::anyhow!(
+        "Fatal error waiting for events from trace {}: {}",
+        fatal.trace_id,
+        fatal.error
+    )
 }
 
 fn append_with_limit<T>(
@@ -454,7 +584,9 @@ impl Default for TraceManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{append_with_limit, TraceManager, MAX_AGGREGATED_EVENTS_PER_WAIT};
+    use super::{append_with_limit, AddTraceParams, TraceManager, MAX_AGGREGATED_EVENTS_PER_WAIT};
+    use crate::trace::actor::{TraceActorEvent, TraceActorFatal};
+    use crate::trace::instance::TracePidContext;
     use ghostscope_protocol::ParsedTraceEvent;
     use std::collections::VecDeque;
 
@@ -466,6 +598,21 @@ mod tests {
             tid: 0,
             instructions: Vec::new(),
         }
+    }
+
+    fn add_test_trace(manager: &mut TraceManager, trace_id: u32) {
+        manager.add_trace_with_id(AddTraceParams {
+            trace_id,
+            target: format!("target-{trace_id}"),
+            script_content: String::new(),
+            pc: 0,
+            binary_path: String::new(),
+            target_display: format!("trace-{trace_id}"),
+            pid_context: TracePidContext::default(),
+            loader: None,
+            ebpf_function_name: String::new(),
+            address_global_index: None,
+        });
     }
 
     #[test]
@@ -523,5 +670,128 @@ mod tests {
             Some(MAX_AGGREGATED_EVENTS_PER_WAIT as u64)
         );
         assert!(manager.take_pending_events().is_none());
+    }
+
+    #[tokio::test]
+    async fn actor_batches_are_aggregated_from_the_shared_queue() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7), event(7)],
+            })
+            .await
+            .unwrap();
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 3);
+        assert!(events.iter().all(|event| event.trace_id == 7));
+    }
+
+    #[tokio::test]
+    async fn queued_events_for_a_deleted_trace_are_ignored() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        add_test_trace(&mut manager, 8);
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+        manager.delete_trace(7).await.unwrap();
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 8,
+                generation: 0,
+                events: vec![event(8)],
+            })
+            .await
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].trace_id, 8);
+    }
+
+    #[tokio::test]
+    async fn stale_event_generations_and_pending_events_are_ignored_after_update() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        add_test_trace(&mut manager, 8);
+        manager.pending_events.push_back(event(7));
+        manager.pending_events.push_back(event(8));
+        manager.require_event_generation(7, 1);
+
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 1,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+
+        let pending = manager.take_pending_events().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].trace_id, 8);
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].trace_id, 7);
+    }
+
+    #[tokio::test]
+    async fn fatal_actor_error_is_deferred_until_queued_events_are_returned() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+        manager
+            .fatal_sender
+            .send(TraceActorFatal {
+                trace_id: 7,
+                error: "reader failed".to_string(),
+            })
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+
+        let error = manager.wait_for_all_events_async().await.unwrap_err();
+        assert!(error.to_string().contains("reader failed"));
     }
 }

--- a/ghostscope/src/trace/manager.rs
+++ b/ghostscope/src/trace/manager.rs
@@ -16,6 +16,12 @@ use tracing::{debug, error, info, warn};
 
 const MAX_AGGREGATED_EVENTS_PER_WAIT: usize = 1024;
 
+#[derive(Debug)]
+struct DeferredActorError {
+    trace_id: u32,
+    error: anyhow::Error,
+}
+
 /// Manager for all active trace instances
 #[derive(Debug)]
 pub struct TraceManager {
@@ -29,7 +35,7 @@ pub struct TraceManager {
     fatal_sender: mpsc::UnboundedSender<TraceActorFatal>,
     fatal_receiver: mpsc::UnboundedReceiver<TraceActorFatal>,
     pending_events: VecDeque<ParsedTraceEvent>,
-    pending_error: Option<anyhow::Error>,
+    pending_error: Option<DeferredActorError>,
     minimum_event_generations: HashMap<u32, u64>,
     last_reported_event_loss: HashMap<u32, EventLossStats>,
     last_reported_delivery_loss: HashMap<u32, u64>,
@@ -177,6 +183,13 @@ impl TraceManager {
             self.trace_created_times.remove(&trace_id);
             self.pending_events
                 .retain(|event| event.trace_id != trace_id as u64);
+            if self
+                .pending_error
+                .as_ref()
+                .is_some_and(|pending| pending.trace_id == trace_id)
+            {
+                self.pending_error = None;
+            }
             self.minimum_event_generations.remove(&trace_id);
             self.last_reported_event_loss.remove(&trace_id);
             self.last_reported_delivery_loss.remove(&trace_id);
@@ -234,11 +247,15 @@ impl TraceManager {
 
     /// Disable a specific trace by ID
     pub async fn disable_trace(&mut self, trace_id: u32) -> Result<()> {
-        if let Some(trace) = self.traces.get_mut(&trace_id) {
-            trace.disable().await
-        } else {
-            Err(anyhow::anyhow!("Trace {trace_id} not found"))
-        }
+        let generation = {
+            let trace = self
+                .traces
+                .get_mut(&trace_id)
+                .ok_or_else(|| anyhow::anyhow!("Trace {trace_id} not found"))?;
+            trace.disable().await?
+        };
+        self.invalidate_queued_events(trace_id, generation);
+        Ok(())
     }
 
     /// Enable all traces
@@ -366,18 +383,7 @@ impl TraceManager {
             };
             match update {
                 Ok(update) => {
-                    let stats = update.stats;
-                    if stats.modules > 0 {
-                        self.require_event_generation(trace_id, update.event_generation);
-                        debug!(
-                            trace_id,
-                            modules = stats.modules,
-                            rows = stats.rows,
-                            "Appended runtime DWARF bt unwind rows to trace"
-                        );
-                        total.modules += stats.modules;
-                        total.rows += stats.rows;
-                    }
+                    self.record_backtrace_actor_update(trace_id, update, &mut total);
                 }
                 Err(err) => {
                     warn!(
@@ -389,6 +395,39 @@ impl TraceManager {
         }
 
         total
+    }
+
+    fn record_backtrace_actor_update(
+        &mut self,
+        trace_id: u32,
+        update: crate::trace::actor::TraceActorBacktraceUpdate,
+        total: &mut BacktraceUnwindRowsAppendStats,
+    ) {
+        // Apply the generation even when this actor inserted no rows: another
+        // actor may have updated the shared pinned CFI maps first.
+        self.require_event_generation(trace_id, update.event_generation);
+
+        let stats = update.stats;
+        if stats.modules == 0 {
+            return;
+        }
+        debug!(
+            trace_id,
+            modules = stats.modules,
+            rows = stats.rows,
+            "Appended runtime DWARF bt unwind rows to trace"
+        );
+        total.modules += stats.modules;
+        total.rows += stats.rows;
+    }
+
+    fn invalidate_queued_events(&mut self, trace_id: u32, generation: Option<u64>) {
+        if let Some(generation) = generation {
+            self.require_event_generation(trace_id, generation);
+        } else {
+            self.pending_events
+                .retain(|event| event.trace_id != trace_id as u64);
+        }
     }
 
     fn require_event_generation(&mut self, trace_id: u32, generation: u64) {
@@ -410,8 +449,14 @@ impl TraceManager {
         if let Some(events) = self.take_pending_events() {
             return Ok(events);
         }
-        if let Some(error) = self.pending_error.take() {
-            return Err(error);
+        if let Some(pending) = self.pending_error.take() {
+            if self.traces.contains_key(&pending.trace_id) {
+                return Err(pending.error);
+            }
+            debug!(
+                trace_id = pending.trace_id,
+                "Ignoring deferred fatal error from deleted trace actor"
+            );
         }
 
         let mut aggregated_events = Vec::new();
@@ -461,11 +506,12 @@ impl TraceManager {
 
         if let Ok(fatal) = self.fatal_receiver.try_recv() {
             if self.traces.contains_key(&fatal.trace_id) {
+                let trace_id = fatal.trace_id;
                 let error = actor_fatal_error(fatal);
                 if aggregated_events.is_empty() {
                     return Err(error);
                 }
-                self.pending_error = Some(error);
+                self.pending_error = Some(DeferredActorError { trace_id, error });
             } else {
                 debug!(
                     trace_id = fatal.trace_id,
@@ -498,7 +544,10 @@ impl TraceManager {
             } => {
                 // Delete waits for the actor to tear down its loader, but batches
                 // sent before that acknowledgement may still be queued.
-                if !self.traces.contains_key(&trace_id) {
+                let Some(trace) = self.traces.get(&trace_id) else {
+                    return;
+                };
+                if !trace.is_enabled {
                     return;
                 }
                 if generation
@@ -585,8 +634,9 @@ impl Default for TraceManager {
 #[cfg(test)]
 mod tests {
     use super::{append_with_limit, AddTraceParams, TraceManager, MAX_AGGREGATED_EVENTS_PER_WAIT};
-    use crate::trace::actor::{TraceActorEvent, TraceActorFatal};
+    use crate::trace::actor::{TraceActorBacktraceUpdate, TraceActorEvent, TraceActorFatal};
     use crate::trace::instance::TracePidContext;
+    use ghostscope_loader::BacktraceUnwindRowsAppendStats;
     use ghostscope_protocol::ParsedTraceEvent;
     use std::collections::VecDeque;
 
@@ -613,6 +663,11 @@ mod tests {
             ebpf_function_name: String::new(),
             address_global_index: None,
         });
+        manager
+            .traces
+            .get_mut(&trace_id)
+            .expect("test trace should exist")
+            .is_enabled = true;
     }
 
     #[test]
@@ -731,6 +786,104 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queued_events_for_a_disabled_trace_stay_invalid_after_reenable() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+
+        manager.traces.get_mut(&7).unwrap().is_enabled = false;
+        manager.invalidate_queued_events(7, Some(1));
+        manager.traces.get_mut(&7).unwrap().is_enabled = true;
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 1,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].trace_id, 7);
+    }
+
+    #[tokio::test]
+    async fn queued_events_are_not_forwarded_while_trace_is_disabled() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        add_test_trace(&mut manager, 8);
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+        manager.traces.get_mut(&7).unwrap().is_enabled = false;
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 8,
+                generation: 0,
+                events: vec![event(8)],
+            })
+            .await
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].trace_id, 8);
+    }
+
+    #[test]
+    fn shared_cfi_updates_invalidate_batches_for_every_actor() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        add_test_trace(&mut manager, 8);
+        manager.pending_events.push_back(event(7));
+        manager.pending_events.push_back(event(8));
+        let mut total = BacktraceUnwindRowsAppendStats::default();
+
+        manager.record_backtrace_actor_update(
+            7,
+            TraceActorBacktraceUpdate {
+                stats: BacktraceUnwindRowsAppendStats {
+                    modules: 1,
+                    rows: 2,
+                },
+                event_generation: 1,
+            },
+            &mut total,
+        );
+        manager.record_backtrace_actor_update(
+            8,
+            TraceActorBacktraceUpdate {
+                stats: BacktraceUnwindRowsAppendStats::default(),
+                event_generation: 1,
+            },
+            &mut total,
+        );
+
+        assert_eq!(manager.minimum_event_generations.get(&7), Some(&1));
+        assert_eq!(manager.minimum_event_generations.get(&8), Some(&1));
+        assert!(manager.pending_events.is_empty());
+        assert_eq!(total.modules, 1);
+        assert_eq!(total.rows, 2);
+    }
+
+    #[tokio::test]
     async fn stale_event_generations_and_pending_events_are_ignored_after_update() {
         let mut manager = TraceManager::new();
         add_test_trace(&mut manager, 7);
@@ -793,5 +946,45 @@ mod tests {
 
         let error = manager.wait_for_all_events_async().await.unwrap_err();
         assert!(error.to_string().contains("reader failed"));
+    }
+
+    #[tokio::test]
+    async fn deleting_trace_clears_its_deferred_fatal_error() {
+        let mut manager = TraceManager::new();
+        add_test_trace(&mut manager, 7);
+        add_test_trace(&mut manager, 8);
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 7,
+                generation: 0,
+                events: vec![event(7)],
+            })
+            .await
+            .unwrap();
+        manager
+            .fatal_sender
+            .send(TraceActorFatal {
+                trace_id: 7,
+                error: "reader failed".to_string(),
+            })
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+        manager.delete_trace(7).await.unwrap();
+        manager
+            .event_sender
+            .send(TraceActorEvent::Events {
+                trace_id: 8,
+                generation: 0,
+                events: vec![event(8)],
+            })
+            .await
+            .unwrap();
+
+        let events = manager.wait_for_all_events_async().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].trace_id, 8);
     }
 }

--- a/ghostscope/src/trace/mod.rs
+++ b/ghostscope/src/trace/mod.rs
@@ -1,5 +1,6 @@
 //! Trace module - manages trace instances and their lifecycle
 
+mod actor;
 pub mod backtrace;
 pub mod backtrace_runtime;
 pub mod instance;

--- a/ghostscope/src/tui/coordinator.rs
+++ b/ghostscope/src/tui/coordinator.rs
@@ -167,7 +167,7 @@ async fn run_runtime_coordinator(
 ) -> Result<()> {
     info!("Runtime coordinator started");
 
-    // Create trace sender for event polling task
+    // Create trace sender for forwarding actor-delivered events to the UI.
     let trace_sender = runtime_channels.create_trace_sender();
     let trace_channel_capacity = runtime_channels.trace_channel_capacity;
     let mut backtrace_renderer = crate::trace::backtrace::BacktraceRenderer::default();
@@ -177,7 +177,7 @@ async fn run_runtime_coordinator(
 
     loop {
         tokio::select! {
-            // Wait for events asynchronously from active traces' loaders
+            // Wait on the shared queue populated by independent trace actors.
             result = async {
                 if let Some(ref mut session) = session {
                     // Use trace_manager's built-in event polling method
@@ -466,7 +466,8 @@ async fn run_runtime_coordinator(
                 }
 
                 if let Some(ref mut session) = session {
-                    for report in session.trace_manager.collect_event_loss_reports() {
+                    let loss_reports = session.trace_manager.collect_event_loss_reports().await;
+                    for report in loss_reports.kernel {
                         warn!(
                             "eBPF output helper loss detected: trace {} ({}) lost {} events in last interval (total {})",
                             report.trace_id,
@@ -480,6 +481,26 @@ async fn run_runtime_coordinator(
                             lost_since_last: report.lost_since_last,
                             lost_total: report.lost_total,
                         });
+                    }
+                    for report in loss_reports.delivery {
+                        warn!(
+                            "Trace reader queue backpressure: trace {} ({}) dropped {} parsed events in last interval (total {}) while continuing to drain the kernel buffer",
+                            report.trace_id,
+                            report.target_display,
+                            report.dropped_since_last,
+                            report.dropped_total
+                        );
+                        let _ = runtime_channels.status_sender.send(
+                            RuntimeStatus::TraceReaderBackpressure {
+                                trace_id: report.trace_id,
+                                target_display: report.target_display,
+                                dropped_since_last: report.dropped_since_last,
+                                dropped_total: report.dropped_total,
+                                queue_capacity_batches: session
+                                    .trace_manager
+                                    .event_channel_capacity(),
+                            },
+                        );
                     }
                 }
             }
@@ -592,7 +613,7 @@ fn recalculate_script_compilation_counts(
     details.total_count = success_count + failed_count;
 }
 
-fn restore_loaded_traces_as_disabled(
+async fn restore_loaded_traces_as_disabled(
     session: &mut GhostSession,
     details: &mut ghostscope_ui::events::ScriptCompilationDetails,
 ) {
@@ -627,7 +648,7 @@ fn restore_loaded_traces_as_disabled(
             continue;
         };
 
-        match session.trace_manager.disable_trace(trace_id) {
+        match session.trace_manager.disable_trace(trace_id).await {
             Ok(()) => {
                 info!("Loaded trace {} as disabled", trace_id);
                 retained_trace_ids.push(trace_id);
@@ -756,7 +777,7 @@ async fn handle_load_traces(
 
         if !trace.enabled {
             if let Some(ref mut session) = session {
-                restore_loaded_traces_as_disabled(session, &mut details);
+                restore_loaded_traces_as_disabled(session, &mut details).await;
             }
         }
 

--- a/ghostscope/src/tui/trace_handlers.rs
+++ b/ghostscope/src/tui/trace_handlers.rs
@@ -9,7 +9,7 @@ pub async fn handle_disable_trace(
     trace_id: u32,
 ) {
     if let Some(ref mut session) = session {
-        match session.trace_manager.disable_trace(trace_id) {
+        match session.trace_manager.disable_trace(trace_id).await {
             Ok(_) => {
                 info!("✓ Disabled trace {}", trace_id);
                 let _ = runtime_channels
@@ -43,7 +43,7 @@ pub async fn handle_enable_trace(
     trace_id: u32,
 ) {
     if let Some(ref mut session) = session {
-        match session.trace_manager.enable_trace(trace_id) {
+        match session.trace_manager.enable_trace(trace_id).await {
             Ok(_) => {
                 info!("✓ Enabled trace {}", trace_id);
                 let _ = runtime_channels
@@ -77,7 +77,7 @@ pub async fn handle_disable_all_traces(
 ) {
     if let Some(ref mut session) = session {
         let trace_count = session.trace_manager.get_all_trace_ids().len();
-        match session.trace_manager.disable_all_traces() {
+        match session.trace_manager.disable_all_traces().await {
             Ok(_) => {
                 info!("✓ Disabled all traces (count: {})", trace_count);
                 let _ = runtime_channels
@@ -114,7 +114,7 @@ pub async fn handle_enable_all_traces(
 ) {
     if let Some(ref mut session) = session {
         let trace_count = session.trace_manager.get_all_trace_ids().len();
-        match session.trace_manager.enable_all_traces() {
+        match session.trace_manager.enable_all_traces().await {
             Ok(_) => {
                 info!("✓ Enabled all traces (count: {})", trace_count);
                 let _ = runtime_channels
@@ -151,7 +151,7 @@ pub async fn handle_delete_trace(
     trace_id: u32,
 ) {
     if let Some(ref mut session) = session {
-        match session.trace_manager.delete_trace(trace_id) {
+        match session.trace_manager.delete_trace(trace_id).await {
             Ok(_) => {
                 info!("✓ Deleted trace {}", trace_id);
                 let _ = runtime_channels
@@ -184,7 +184,7 @@ pub async fn handle_delete_all_traces(
     runtime_channels: &mut RuntimeChannels,
 ) {
     if let Some(ref mut session) = session {
-        match session.trace_manager.delete_all_traces() {
+        match session.trace_manager.delete_all_traces().await {
             Ok(count) => {
                 info!("✓ Deleted all traces (count: {})", count);
                 let _ = runtime_channels


### PR DESCRIPTION
## Summary

- persist RingBuf AsyncFd registrations and retain readiness across bounded partial drains
- move each GhostScopeLoader into an independent per-trace actor with bounded event and command channels
- keep existing traces draining while the TUI compiles and attaches new traces, with explicit userspace backpressure reporting
- discard stale queued backtrace events after runtime CFI updates
- guarantee readiness guards and registrations are dropped before their underlying file descriptors

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks
- cargo test --all-features --quiet
- targeted target-mode dlopen backtrace e2e
- complete standard host e2e through the runner service

Container-topology e2e was intentionally skipped because this change does not affect container, PID namespace, or sandbox behavior.