### PR TITLE
chore: upgrade gimli to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
  "ghostscope-platform",
  "ghostscope-process",
  "ghostscope-protocol",
- "gimli 0.33.0",
+ "gimli 0.34.0",
  "libc",
  "memmap2",
  "num_cpus",
@@ -1110,7 +1110,7 @@ dependencies = [
  "ghostscope-compiler",
  "ghostscope-dwarf",
  "ghostscope-process",
- "gimli 0.33.0",
+ "gimli 0.34.0",
  "lazy_static",
  "libc",
  "object 0.36.7",
@@ -1174,7 +1174,7 @@ dependencies = [
  "chrono",
  "criterion",
  "ghostscope-platform",
- "gimli 0.33.0",
+ "gimli 0.34.0",
  "serde",
  "serde_json",
  "tracing",
@@ -1205,12 +1205,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gimli"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
  "fnv",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "stable_deref_trait",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ toml = "0.8"
 dirs = "5.0"
 object = "0.36"
 
-gimli = "0.33.0"
+gimli = "0.34.0"
 aya = "0.14"
 aya-obj = "0.3"
 aya-ebpf-bindings = "0.2"


### PR DESCRIPTION
## Summary

- upgrade the workspace gimli dependency from 0.33.0 to 0.34.0
- refresh Cargo.lock, including gimli’s hashbrown dependency
- keep the transitive gimli 0.31.1 required by addr2line unchanged
- no source compatibility changes were required

## Testing

- cargo fmt --all
- cargo check --all-targets --all-features (using a temporary target directory)
- cargo clippy --all-targets --all-features -- -D warnings (using a temporary target directory)
- standard host-to-host e2e via the GhostScope runner service: job 6b6f1bf6db3c, succeeded
- container-topology e2e intentionally not run because this dependency-only change does not affect container behavior