### PR TITLE
perf: use GNU pubnames for DWARF indexing

### DIFF
--- a/.github/workflows/dwarf-perf-history.yml
+++ b/.github/workflows/dwarf-perf-history.yml
@@ -88,6 +88,7 @@ jobs:
           ./scripts/dwarf-perf/build_corpus.sh
           parse_targets=(
             parse-stress
+            gnu-pubnames-stress
             rust-parse-stress
             cpp-template-stress
             rust-generic-stress

--- a/.github/workflows/dwarf-perf-regression.yml
+++ b/.github/workflows/dwarf-perf-regression.yml
@@ -125,6 +125,7 @@ jobs:
           manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
           parse_targets=(
             parse-stress
+            gnu-pubnames-stress
             rust-parse-stress
             cpp-template-stress
             rust-generic-stress
@@ -150,6 +151,7 @@ jobs:
           manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
           parse_targets=(
             parse-stress
+            gnu-pubnames-stress
             rust-parse-stress
             cpp-template-stress
             rust-generic-stress
@@ -179,6 +181,7 @@ jobs:
           manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
           parse_targets=(
             parse-stress
+            gnu-pubnames-stress
             rust-parse-stress
             cpp-template-stress
             rust-generic-stress
@@ -218,6 +221,7 @@ jobs:
           base_manifest="$GITHUB_WORKSPACE/base/scripts/dwarf-perf/corpus/out/manifest.json"
           parse_targets=(
             parse-stress
+            gnu-pubnames-stress
             rust-parse-stress
             cpp-template-stress
             rust-generic-stress
@@ -309,6 +313,7 @@ jobs:
 
           parse_targets=(
             parse-stress
+            gnu-pubnames-stress
             rust-parse-stress
             cpp-template-stress
             rust-generic-stress
@@ -357,7 +362,7 @@ jobs:
             printf '%s\n' "- Head: \`${HEAD_SHA::12}\`"
             printf '%s\n' '- Note: The base revision does not contain the DWARF perf baseline tooling yet, so regression gating was skipped.'
             printf '\n'
-            printf '%s\n' 'Head-only baselines for `parse-stress`, `rust-parse-stress`, `cpp-template-stress`, `rust-generic-stress`, and `cpp-deep-namespace` were generated and uploaded as artifacts for inspection.'
+            printf '%s\n' 'Head-only baselines for `parse-stress`, `gnu-pubnames-stress`, `rust-parse-stress`, `cpp-template-stress`, `rust-generic-stress`, and `cpp-deep-namespace` were generated and uploaded as artifacts for inspection.'
           } > "$DWARF_PERF_RESULTS_DIR/summary.md"
 
       - name: Publish summary

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,10 +274,12 @@ Behavior:
 
 ### Native DWARF Indexes
 
-When the ELF file containing DWARF also contains `.debug_names` or
-`.gdb_index`, GhostScope uses that native index to select compilation units for
-on-demand parsing. Otherwise, it performs its normal full DWARF scan. An
-unusable index is reported in CLI/TUI startup status before falling back.
+When the ELF file containing DWARF also contains `.debug_names`, `.gdb_index`,
+or a complete `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` pair, GhostScope
+uses that native index to select compilation units for on-demand parsing. The
+preference order is `.debug_names`, `.gdb_index`, then the GNU pubnames pair.
+Otherwise, it performs its normal full DWARF scan. An unusable or incomplete
+index is reported in CLI/TUI startup status before falling back.
 
 ### Complete Command Reference
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -269,9 +269,11 @@ ghostscope bpffs prune --dry-run --json
 
 ### 原生 DWARF 索引
 
-当包含 DWARF 的 ELF 文件同时带有 `.debug_names` 或 `.gdb_index` 时，
-GhostScope 会使用该原生索引选择 CU，并按需调用 fast parser。否则执行原有
-的完整 DWARF 扫描。索引不可用时，CLI/TUI 启动状态会显示回退原因。
+当包含 DWARF 的 ELF 文件带有 `.debug_names`、`.gdb_index`，或完整的
+`.debug_gnu_pubnames` / `.debug_gnu_pubtypes` 组合时，GhostScope 会使用原生
+索引选择 CU，并按需调用 fast parser。优先级依次为 `.debug_names`、
+`.gdb_index`、GNU pubnames 组合；否则执行原有的完整 DWARF 扫描。索引
+不可用或覆盖不完整时，CLI/TUI 启动状态会显示回退原因。
 
 ### 完整命令参考
 

--- a/e2e-tests/tests/dwarf_index_regressions.rs
+++ b/e2e-tests/tests/dwarf_index_regressions.rs
@@ -303,6 +303,404 @@ fn test_read_uleb128_rejects_values_that_overflow_u64() {
 
 #[tokio::test]
 #[serial_test::serial]
+async fn test_gnu_pubnames_resolve_symbols_lazily_and_reject_corruption() -> anyhow::Result<()> {
+    init();
+
+    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sample_program");
+    let temp_dir = tempfile::tempdir()?;
+    let mut indexed_binaries = Vec::new();
+
+    for compiler in ["gcc", "clang"] {
+        if !command_available(compiler) {
+            continue;
+        }
+        for optimization in ["O0", "O2"] {
+            let indexed = temp_dir.path().join(format!(
+                "sample_program.{compiler}-{optimization}-gnu-pubnames"
+            ));
+            run_command(
+                StdCommand::new(compiler)
+                    .arg("-gdwarf-5")
+                    .arg("-ggnu-pubnames")
+                    .arg(format!("-{optimization}"))
+                    .arg(fixture_dir.join("sample_program.c"))
+                    .arg(fixture_dir.join("sample_lib.c"))
+                    .arg("-o")
+                    .arg(&indexed),
+                &format!("{compiler} {optimization} GNU pubnames fixture build"),
+            )?;
+
+            let indexed_bytes = fs::read(&indexed)?;
+            let indexed_object = object::File::parse(&*indexed_bytes)?;
+            anyhow::ensure!(
+                indexed_object
+                    .section_by_name(".debug_gnu_pubnames")
+                    .is_some(),
+                "{compiler} {optimization} -ggnu-pubnames did not emit .debug_gnu_pubnames"
+            );
+            anyhow::ensure!(
+                indexed_object
+                    .section_by_name(".debug_gnu_pubtypes")
+                    .is_some(),
+                "{compiler} {optimization} -ggnu-pubnames did not emit .debug_gnu_pubtypes"
+            );
+            anyhow::ensure!(
+                indexed_object.section_by_name(".debug_names").is_none()
+                    && indexed_object.section_by_name(".gdb_index").is_none(),
+                "{compiler} {optimization} GNU pubnames fixture unexpectedly contains a higher-priority index"
+            );
+
+            let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&indexed).await?;
+            assert_eq!(
+                analyzer.dwarf_index_status_for_module(&indexed),
+                Some(&ghostscope_dwarf::DwarfIndexStatus::GnuPubNames),
+                "GhostScope did not select {compiler} {optimization} GNU pubnames"
+            );
+            assert_native_index_queries(&analyzer, &indexed, "GNU pubnames")?;
+
+            let function_address = find_symbol_address(&indexed, "calculate_something")?;
+            let context = analyzer.resolve_pc(&ghostscope_dwarf::ModuleAddress::new(
+                indexed.clone(),
+                function_address,
+            ))?;
+            assert_eq!(
+                context.function_name.as_deref(),
+                Some("calculate_something"),
+                "{compiler} {optimization} GNU pubnames did not seed address-based lazy CU loading"
+            );
+            indexed_binaries.push(indexed);
+        }
+    }
+
+    if let Some(compiler) = ["g++", "clang++"]
+        .into_iter()
+        .find(|compiler| command_available(compiler))
+    {
+        let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/cpp_complex_program/main.cpp");
+        let indexed = temp_dir
+            .path()
+            .join(format!("cpp_complex.{compiler}-gnu-pubnames"));
+        run_command(
+            StdCommand::new(compiler)
+                .arg("-gdwarf-5")
+                .arg("-ggnu-pubnames")
+                .arg("-O0")
+                .arg(&source)
+                .arg("-o")
+                .arg(&indexed),
+            &format!("{compiler} C++ GNU pubnames fixture build"),
+        )?;
+
+        let analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&indexed).await?;
+        assert_eq!(
+            analyzer.dwarf_index_status_for_module(&indexed),
+            Some(&ghostscope_dwarf::DwarfIndexStatus::GnuPubNames),
+            "GhostScope did not select {compiler} C++ GNU pubnames"
+        );
+        assert!(
+            !analyzer
+                .lookup_function_addresses("ns1::nested_member_probe")
+                .is_empty(),
+            "C++ GNU pubnames did not resolve a qualified function name"
+        );
+        let outer = analyzer
+            .resolve_struct_type_shallow_by_name("Outer")
+            .context("C++ GNU pubtypes did not resolve the leaf type name Outer")?;
+        assert_eq!(outer.size(), 16, "unexpected ns1::Outer size");
+        assert!(
+            analyzer
+                .find_global_variables_by_name("g_counter")
+                .iter()
+                .any(|(_, global)| global.link_address.is_some()),
+            "C++ GNU pubnames did not resolve g_counter"
+        );
+    }
+
+    let lossy_source =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gnu_pubnames_lossy/main.cpp");
+    for compiler in ["g++", "clang++"] {
+        if !command_available(compiler) {
+            continue;
+        }
+        let lossy = temp_dir
+            .path()
+            .join(format!("gnu-pubnames-lossy.{compiler}"));
+        run_command(
+            StdCommand::new(compiler)
+                .arg("-gdwarf-5")
+                .arg("-ggnu-pubnames")
+                .arg("-O0")
+                .arg(&lossy_source)
+                .arg("-o")
+                .arg(&lossy),
+            &format!("{compiler} lossy GNU pubnames fixture build"),
+        )?;
+
+        let overload_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        assert_eq!(
+            overload_analyzer.dwarf_index_status_for_module(&lossy),
+            Some(&ghostscope_dwarf::DwarfIndexStatus::GnuPubNames),
+            "GhostScope did not select {compiler} lossy GNU pubnames"
+        );
+        let overloads = overload_analyzer.lookup_function_addresses("ns2::f");
+        assert_eq!(
+            overloads.len(),
+            2,
+            "{compiler} GNU pubnames did not materialize both ns2::f overloads: {overloads:?}"
+        );
+
+        let signature_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        let signature_first = signature_analyzer.lookup_function_addresses("ns2::f(int)");
+        assert_eq!(
+            signature_first.len(),
+            1,
+            "{compiler} GNU pubnames did not resolve the exact signature-first overload: {signature_first:?}"
+        );
+        let ordered_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        let _ = ordered_analyzer.lookup_function_addresses("ns2::f");
+        let signature_after_seed = ordered_analyzer.lookup_function_addresses("ns2::f(int)");
+        assert_eq!(
+            signature_first, signature_after_seed,
+            "{compiler} GNU pubnames made signature lookup query-order dependent"
+        );
+
+        let global_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        assert!(
+            global_analyzer
+                .find_global_variables_by_name("ns2::qualified_global")
+                .iter()
+                .any(|(_, global)| global.link_address.is_some()),
+            "{compiler} GNU pubnames returned an unmaterialized qualified global"
+        );
+
+        let local_static_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        assert!(
+            local_static_analyzer
+                .find_global_variables_by_name("counter")
+                .iter()
+                .any(|(_, global)| global.link_address.is_some()),
+            "{compiler} GNU pubnames miss did not materialize a function-local static"
+        );
+
+        let local_type_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        assert!(
+            local_type_analyzer
+                .resolve_struct_type_shallow_by_name("LocalType")
+                .is_some(),
+            "{compiler} GNU pubtypes miss did not materialize a local type"
+        );
+
+        let template_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        assert!(
+            template_analyzer
+                .resolve_struct_type_shallow_by_name("Box<ns1::Inner>")
+                .is_some(),
+            "{compiler} GNU pubtypes did not match a template-aware leaf name"
+        );
+
+        let kind_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        assert!(
+            kind_analyzer
+                .resolve_union_type_shallow_by_name("Inner")
+                .is_none(),
+            "{compiler} GNU pubtypes fabricated a union result for a struct"
+        );
+        assert!(
+            kind_analyzer
+                .resolve_struct_type_shallow_by_name("Inner")
+                .is_some(),
+            "{compiler} GNU pubtypes did not materialize the real struct kind"
+        );
+
+        let enumeration_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&lossy).await?;
+        let function_names = enumeration_analyzer
+            .get_all_function_names()
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert!(
+            function_names.contains("f"),
+            "{compiler} GNU pubnames enumeration omitted cooked function names: {function_names:?}"
+        );
+        let global_names = enumeration_analyzer
+            .list_all_global_variables()
+            .into_iter()
+            .map(|(_, global)| global.name)
+            .collect::<HashSet<_>>();
+        assert!(
+            global_names.contains("counter"),
+            "{compiler} GNU pubnames enumeration omitted a function-local static: {global_names:?}"
+        );
+    }
+
+    for compiler in ["g++", "clang++"] {
+        if !command_available(compiler) {
+            continue;
+        }
+        let type_units = temp_dir
+            .path()
+            .join(format!("gnu-pubnames-lossy.type-units.{compiler}"));
+        run_command(
+            StdCommand::new(compiler)
+                .arg("-gdwarf-5")
+                .arg("-ggnu-pubnames")
+                .arg("-fdebug-types-section")
+                .arg("-O0")
+                .arg(&lossy_source)
+                .arg("-o")
+                .arg(&type_units),
+            &format!("{compiler} GNU pubnames type-unit fixture build"),
+        )?;
+        anyhow::ensure!(
+            dwarf_has_type_unit(&type_units)?,
+            "{compiler} did not emit a DWARF5 type unit for GNU pubnames"
+        );
+
+        let type_unit_analyzer =
+            ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&type_units).await?;
+        assert_eq!(
+            type_unit_analyzer.dwarf_index_status_for_module(&type_units),
+            Some(&ghostscope_dwarf::DwarfIndexStatus::GnuPubNames),
+            "GhostScope rejected {compiler} GNU pubnames because .debug_info contains type units"
+        );
+        assert!(
+            type_unit_analyzer
+                .resolve_struct_type_shallow_by_name("Box<ns1::Inner>")
+                .is_some(),
+            "{compiler} GNU pubnames did not resolve a type from a DWARF type-unit binary"
+        );
+    }
+
+    if let Some(compiler) = ["gcc", "clang"]
+        .into_iter()
+        .find(|compiler| command_available(compiler))
+    {
+        let indexed_object = temp_dir.path().join("mixed-indexed.o");
+        let unindexed_object = temp_dir.path().join("mixed-unindexed.o");
+        let mixed = temp_dir.path().join("sample_program.partial-gnu-pubnames");
+        run_command(
+            StdCommand::new(compiler)
+                .arg("-gdwarf-5")
+                .arg("-ggnu-pubnames")
+                .arg("-O0")
+                .arg("-c")
+                .arg(fixture_dir.join("sample_program.c"))
+                .arg("-o")
+                .arg(&indexed_object),
+            &format!("{compiler} indexed object build"),
+        )?;
+        run_command(
+            StdCommand::new(compiler)
+                .arg("-gdwarf-5")
+                .arg("-O0")
+                .arg("-c")
+                .arg(fixture_dir.join("sample_lib.c"))
+                .arg("-o")
+                .arg(&unindexed_object),
+            &format!("{compiler} unindexed object build"),
+        )?;
+        run_command(
+            StdCommand::new(compiler)
+                .arg(&indexed_object)
+                .arg(&unindexed_object)
+                .arg("-o")
+                .arg(&mixed),
+            &format!("{compiler} partially indexed fixture link"),
+        )?;
+
+        let fallback_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&mixed).await?;
+        match fallback_analyzer.dwarf_index_status_for_module(&mixed) {
+            Some(ghostscope_dwarf::DwarfIndexStatus::Rejected { reason }) => {
+                assert!(
+                    reason.contains("does not cover all .debug_info units"),
+                    "unexpected partial GNU pubnames rejection: {reason}"
+                );
+            }
+            status => panic!("partial GNU pubnames index was not rejected: {status:?}"),
+        }
+        assert_native_index_queries(&fallback_analyzer, &mixed, "partial GNU pubnames fallback")?;
+    }
+
+    let Some(indexed) = indexed_binaries.first() else {
+        eprintln!("Skipping GNU pubnames integration test because GCC and Clang are unavailable");
+        return Ok(());
+    };
+
+    let compressed = temp_dir
+        .path()
+        .join("sample_program.compressed-gnu-pubnames");
+    fs::copy(indexed, &compressed)?;
+    run_command(
+        StdCommand::new("objcopy")
+            .arg("--compress-debug-sections=zlib")
+            .arg(&compressed),
+        "compress GNU pubnames fixture",
+    )?;
+    let compressed_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&compressed).await?;
+    assert_eq!(
+        compressed_analyzer.dwarf_index_status_for_module(&compressed),
+        Some(&ghostscope_dwarf::DwarfIndexStatus::GnuPubNames),
+        "GhostScope did not select compressed GNU pubnames"
+    );
+    assert_native_index_queries(&compressed_analyzer, &compressed, "compressed GNU pubnames")?;
+
+    let mut corrupted_bytes = fs::read(indexed)?;
+    let (version_offset, endianness) = {
+        let object = object::File::parse(&*corrupted_bytes)?;
+        let section = object
+            .section_by_name(".debug_gnu_pubnames")
+            .context("GNU pubnames fixture has no .debug_gnu_pubnames")?;
+        let (section_offset, _) = section
+            .file_range()
+            .context(".debug_gnu_pubnames has no file range")?;
+        let section_offset = usize::try_from(section_offset)?;
+        let initial_length = corrupted_bytes
+            .get(section_offset..section_offset + 4)
+            .context(".debug_gnu_pubnames initial length is truncated")?;
+        let initial_length = match object.endianness() {
+            object::Endianness::Little => u32::from_le_bytes(initial_length.try_into()?),
+            object::Endianness::Big => u32::from_be_bytes(initial_length.try_into()?),
+        };
+        let initial_length_size = if initial_length == u32::MAX { 12 } else { 4 };
+        (
+            section_offset
+                .checked_add(initial_length_size)
+                .context(".debug_gnu_pubnames version offset overflow")?,
+            object.endianness(),
+        )
+    };
+    let invalid_version = match endianness {
+        object::Endianness::Little => u16::MAX.to_le_bytes(),
+        object::Endianness::Big => u16::MAX.to_be_bytes(),
+    };
+    corrupted_bytes
+        .get_mut(version_offset..version_offset + invalid_version.len())
+        .context(".debug_gnu_pubnames version is truncated")?
+        .copy_from_slice(&invalid_version);
+    let corrupted = temp_dir.path().join("sample_program.corrupt-gnu-pubnames");
+    fs::write(&corrupted, corrupted_bytes)?;
+
+    let fallback_analyzer = ghostscope_dwarf::DwarfAnalyzer::from_exec_path(&corrupted).await?;
+    match fallback_analyzer.dwarf_index_status_for_module(&corrupted) {
+        Some(ghostscope_dwarf::DwarfIndexStatus::Rejected { reason }) => {
+            assert!(
+                reason.contains("GNU pubnames index could not be used"),
+                "unexpected GNU pubnames rejection: {reason}"
+            );
+        }
+        status => panic!("malformed GNU pubnames did not fall back: {status:?}"),
+    }
+    assert_native_index_queries(
+        &fallback_analyzer,
+        &corrupted,
+        "rejected GNU pubnames fallback",
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
 async fn test_gdb_index_resolves_function_type_and_global_lazily() -> anyhow::Result<()> {
     init();
 

--- a/e2e-tests/tests/fixtures/gnu_pubnames_lossy/main.cpp
+++ b/e2e-tests/tests/fixtures/gnu_pubnames_lossy/main.cpp
@@ -1,0 +1,36 @@
+namespace ns1 {
+struct Inner {
+    long value;
+};
+}  // namespace ns1
+
+namespace ns2 {
+template <typename T>
+struct Box {
+    T value;
+};
+
+Box<ns1::Inner> qualified_global = {{17}};
+
+__attribute__((noinline)) int f(int value) {
+    return value + 1;
+}
+
+__attribute__((noinline)) int f(double value) {
+    return static_cast<int>(value) + 2;
+}
+
+__attribute__((noinline)) int local_entities() {
+    static int counter = 41;
+    struct LocalType {
+        long value;
+    };
+    volatile LocalType local = {counter};
+    return static_cast<int>(local.value) + counter;
+}
+}  // namespace ns2
+
+int main() {
+    return ns2::f(1) + ns2::f(2.0) + ns2::local_entities()
+        + static_cast<int>(ns2::qualified_global.value.value);
+}

--- a/ghostscope-dwarf/src/analyzer/types.rs
+++ b/ghostscope-dwarf/src/analyzer/types.rs
@@ -6,6 +6,7 @@ pub enum DwarfIndexStatus {
     FullScan,
     DebugNames,
     GdbIndex { version: u32 },
+    GnuPubNames,
     Rejected { reason: String },
 }
 
@@ -15,6 +16,7 @@ impl DwarfIndexStatus {
             Self::FullScan => "full-scan".to_string(),
             Self::DebugNames => ".debug_names".to_string(),
             Self::GdbIndex { version } => format!(".gdb_index-v{version}"),
+            Self::GnuPubNames => ".debug_gnu_pubnames".to_string(),
             Self::Rejected { .. } => "full-scan (index rejected)".to_string(),
         }
     }

--- a/ghostscope-dwarf/src/core/symbol_names.rs
+++ b/ghostscope-dwarf/src/core/symbol_names.rs
@@ -46,7 +46,50 @@ pub(crate) fn normalize_demangled_signature(s: &str) -> Option<String> {
 }
 
 pub(crate) fn plain_leaf(name: &str) -> &str {
-    name.rsplit("::").next().unwrap_or(name)
+    let mut angle_depth = 0_u32;
+    let mut paren_depth = 0_u32;
+    let mut bracket_depth = 0_u32;
+    let mut leaf_start = 0;
+    let mut chars = name.char_indices().peekable();
+
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '<' => angle_depth = angle_depth.saturating_add(1),
+            '>' => angle_depth = angle_depth.saturating_sub(1),
+            '(' => paren_depth = paren_depth.saturating_add(1),
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth = bracket_depth.saturating_add(1),
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            ':' if angle_depth == 0
+                && paren_depth == 0
+                && bracket_depth == 0
+                && chars.peek().is_some_and(|(_, next)| *next == ':') =>
+            {
+                let _ = chars.next();
+                leaf_start = index + 2;
+            }
+            _ => {}
+        }
+    }
+
+    &name[leaf_start..]
+}
+
+fn raw_symbol_matches_query(raw_symbol: &str, query: &str) -> bool {
+    let raw_leaf = plain_leaf(raw_symbol);
+    let query_leaf = plain_leaf(query);
+    if raw_symbol == query
+        || raw_leaf == query
+        || raw_symbol == query_leaf
+        || raw_leaf == query_leaf
+    {
+        return true;
+    }
+
+    let Some((callable_leaf, _)) = query_leaf.split_once('(') else {
+        return false;
+    };
+    !callable_leaf.is_empty() && (raw_symbol == callable_leaf || raw_leaf == callable_leaf)
 }
 
 pub(crate) fn symbol_name_matches_query(
@@ -55,12 +98,12 @@ pub(crate) fn symbol_name_matches_query(
     raw_symbol: &str,
     demangled: Option<&DemangledName>,
 ) -> bool {
-    if raw_symbol == query || plain_leaf(raw_symbol) == query {
+    if raw_symbol_matches_query(raw_symbol, query) {
         return true;
     }
 
     if let Some(normalized_query) = normalized_query {
-        if raw_symbol == normalized_query || plain_leaf(raw_symbol) == normalized_query {
+        if raw_symbol_matches_query(raw_symbol, normalized_query) {
             return true;
         }
     }
@@ -467,9 +510,15 @@ fn should_index_fragment(fragment: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        demangled_name, extract_name_fragments, normalize_demangled_signature,
+        demangled_name, extract_name_fragments, normalize_demangled_signature, plain_leaf,
         symbol_name_matches_query,
     };
+
+    #[test]
+    fn extracts_template_aware_cpp_leaf() {
+        assert_eq!(plain_leaf("ns2::Box<ns1::Inner>"), "Box<ns1::Inner>");
+        assert_eq!(plain_leaf("ns2::f(ns1::Inner)"), "f(ns1::Inner)");
+    }
 
     #[test]
     fn extracts_plain_name_fragments() {
@@ -521,6 +570,17 @@ mod tests {
             normalize_demangled_signature("ns::Widget::run( )").as_deref(),
             "_ZN2ns6Widget3runEv",
             Some(&demangled)
+        ));
+    }
+
+    #[test]
+    fn matches_unqualified_dwarf_names_against_qualified_signatures() {
+        assert!(symbol_name_matches_query("ns::f(int)", None, "f", None));
+        assert!(symbol_name_matches_query(
+            "ns::nested_member_probe",
+            None,
+            "nested_member_probe",
+            None
         ));
     }
 }

--- a/ghostscope-dwarf/src/index/gnu_pub_index.rs
+++ b/ghostscope-dwarf/src/index/gnu_pub_index.rs
@@ -1,0 +1,117 @@
+use crate::{
+    core::{normalize_demangled_signature, symbol_name_matches_query},
+    index::GdbSymbolKind,
+};
+use std::collections::HashMap;
+
+type SymbolsByName = HashMap<String, Vec<gimli::DebugInfoOffset>>;
+
+/// Lossy GNU pubnames accelerator used only to select compilation units.
+///
+/// GNU pubnames/pubtypes entries do not carry enough information to serve as
+/// cooked query results: compilers may omit local names, collapse overloads,
+/// and expose only a coarse symbol kind. Keep them separate from the
+/// materialized DWARF index and use them solely to decide which units to parse.
+#[derive(Debug, Default)]
+pub(crate) struct GnuPubIndex {
+    functions: SymbolsByName,
+    variables: SymbolsByName,
+    types: SymbolsByName,
+    all_unit_offsets: Vec<gimli::DebugInfoOffset>,
+}
+
+impl GnuPubIndex {
+    pub(crate) fn new(mut all_unit_offsets: Vec<gimli::DebugInfoOffset>) -> Self {
+        all_unit_offsets.sort_unstable_by_key(|offset| offset.0);
+        all_unit_offsets.dedup();
+        Self {
+            all_unit_offsets,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        name: String,
+        unit_offset: gimli::DebugInfoOffset,
+        kind: GdbSymbolKind,
+    ) {
+        let symbols = match kind {
+            GdbSymbolKind::Function => &mut self.functions,
+            GdbSymbolKind::Variable => &mut self.variables,
+            GdbSymbolKind::Type => &mut self.types,
+            GdbSymbolKind::Other => return,
+        };
+        let offsets = symbols.entry(name).or_default();
+        if !offsets.contains(&unit_offset) {
+            offsets.push(unit_offset);
+        }
+    }
+
+    pub(crate) fn lookup_units(
+        &self,
+        query: &str,
+        kind: GdbSymbolKind,
+        match_variants: bool,
+    ) -> Vec<gimli::DebugInfoOffset> {
+        let Some(symbols) = self.symbols(kind) else {
+            return Vec::new();
+        };
+        let mut units = if match_variants {
+            let normalized_query = normalize_demangled_signature(query);
+            symbols
+                .iter()
+                .filter(|(candidate, _)| {
+                    symbol_name_matches_query(query, normalized_query.as_deref(), candidate, None)
+                })
+                .flat_map(|(_, offsets)| offsets.iter().copied())
+                .collect::<Vec<_>>()
+        } else {
+            symbols.get(query).cloned().unwrap_or_default()
+        };
+        units.sort_unstable_by_key(|offset| offset.0);
+        units.dedup();
+        units
+    }
+
+    pub(crate) fn all_unit_offsets(&self) -> &[gimli::DebugInfoOffset] {
+        &self.all_unit_offsets
+    }
+
+    pub(crate) fn get_stats(&self) -> (usize, usize, usize) {
+        let functions = self.functions.len();
+        let variables = self.variables.len();
+        let types = self.types.len();
+        (functions, variables, functions + variables + types)
+    }
+
+    fn symbols(&self, kind: GdbSymbolKind) -> Option<&SymbolsByName> {
+        match kind {
+            GdbSymbolKind::Function => Some(&self.functions),
+            GdbSymbolKind::Variable => Some(&self.variables),
+            GdbSymbolKind::Type => Some(&self.types),
+            GdbSymbolKind::Other => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qualified_template_leaf_selects_its_compilation_unit() {
+        let expected = gimli::DebugInfoOffset(0x20);
+        let mut index = GnuPubIndex::new(vec![expected]);
+        index.insert(
+            "ns2::Box<ns1::Inner>".to_string(),
+            expected,
+            GdbSymbolKind::Type,
+        );
+
+        assert_eq!(
+            index.lookup_units("Box<ns1::Inner>", GdbSymbolKind::Type, true),
+            vec![expected]
+        );
+    }
+}

--- a/ghostscope-dwarf/src/index/lightweight_index.rs
+++ b/ghostscope-dwarf/src/index/lightweight_index.rs
@@ -579,6 +579,14 @@ impl LightweightIndex {
     /// Build only CU root ranges without walking every function DIE as a fallback.
     pub(crate) fn build_cu_maps_from_roots(&mut self, dwarf: &gimli::Dwarf<DwarfReader>) -> bool {
         let compilation_units = self.func_indices_by_cu.keys().copied().collect::<Vec<_>>();
+        self.build_cu_maps_from_unit_roots(dwarf, compilation_units)
+    }
+
+    pub(crate) fn build_cu_maps_from_unit_roots(
+        &mut self,
+        dwarf: &gimli::Dwarf<DwarfReader>,
+        compilation_units: impl IntoIterator<Item = DebugInfoOffset>,
+    ) -> bool {
         let mut added_any = false;
         for cu in compilation_units {
             for (start, end) in Self::resolve_cu_root_ranges(dwarf, cu).unwrap_or_default() {

--- a/ghostscope-dwarf/src/index/mod.rs
+++ b/ghostscope-dwarf/src/index/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod block_index;
 pub(crate) mod cfi_index;
+pub(crate) mod gnu_pub_index;
 pub(crate) mod lightweight_file_index;
 pub(crate) mod lightweight_index;
 pub(crate) mod line_mapping;
@@ -11,6 +12,7 @@ pub(crate) use block_index::{BlockIndex, BlockIndexBuilder, FunctionBlocks, VarR
 #[cfg(test)]
 pub(crate) use block_index::{BlockNode, CallSiteParameter, CallSiteRecord};
 pub(crate) use cfi_index::CfiIndex;
+pub(crate) use gnu_pub_index::GnuPubIndex;
 pub(crate) use lightweight_file_index::{LightweightFileIndex, ScopedFileIndexManager};
 pub(crate) use lightweight_index::{LightweightIndex, LightweightIndexShard};
 pub(crate) use line_mapping::LineMappingTable;

--- a/ghostscope-dwarf/src/objfile/function_lookup.rs
+++ b/ghostscope-dwarf/src/objfile/function_lookup.rs
@@ -243,13 +243,31 @@ impl LoadedObjfile {
                 error
             );
         }
-        Self::function_candidate_indices(
+        let mut candidates = Self::function_candidate_indices(
             &self
                 .lightweight_index
                 .read()
                 .expect("lightweight index lock poisoned"),
             name,
-        )
+        );
+        if candidates.is_empty() && self.uses_gnu_pub_index() {
+            if let Err(error) = self.ensure_all_debug_info_for_gnu_index() {
+                tracing::warn!(
+                    "Failed to exhaust GNU-indexed DWARF for function '{}' in {}: {}",
+                    name,
+                    self.module_path().display(),
+                    error
+                );
+            }
+            candidates = Self::function_candidate_indices(
+                &self
+                    .lightweight_index
+                    .read()
+                    .expect("lightweight index lock poisoned"),
+                name,
+            );
+        }
+        candidates
     }
 
     pub(super) fn matching_variable_candidate_indices(&self, name: &str) -> Vec<usize> {
@@ -279,13 +297,31 @@ impl LoadedObjfile {
                 error
             );
         }
-        Self::variable_candidate_indices(
+        let mut candidates = Self::variable_candidate_indices(
             &self
                 .lightweight_index
                 .read()
                 .expect("lightweight index lock poisoned"),
             name,
-        )
+        );
+        if candidates.is_empty() && self.uses_gnu_pub_index() {
+            if let Err(error) = self.ensure_all_debug_info_for_gnu_index() {
+                tracing::warn!(
+                    "Failed to exhaust GNU-indexed DWARF for variable '{}' in {}: {}",
+                    name,
+                    self.module_path().display(),
+                    error
+                );
+            }
+            candidates = Self::variable_candidate_indices(
+                &self
+                    .lightweight_index
+                    .read()
+                    .expect("lightweight index lock poisoned"),
+                name,
+            );
+        }
+        candidates
     }
 
     fn resolve_function_ranges(&self, entry: &crate::core::IndexEntry) -> Result<Vec<(u64, u64)>> {

--- a/ghostscope-dwarf/src/objfile/loaded.rs
+++ b/ghostscope-dwarf/src/objfile/loaded.rs
@@ -4,7 +4,7 @@ use crate::{
     binary::{DwarfReader, MappedFile},
     core::{mapping::ModuleMapping, DebugInfoSource, Result},
     index::{
-        BlockIndex, GdbIndex, GdbSymbolKind, LightweightIndex, LineMappingTable,
+        BlockIndex, GdbIndex, GdbSymbolKind, GnuPubIndex, LightweightIndex, LineMappingTable,
         ScopedFileIndexManager, TypeNameIndex,
     },
     objfile::ModuleUnwindInfo,
@@ -118,6 +118,7 @@ pub(crate) struct LoadedObjfile {
     pub(super) block_index: RwLock<BlockIndex>,
     pub(super) type_name_index: RwLock<TypeNameIndex>,
     pub(super) gdb_index: Option<GdbIndex>,
+    pub(super) gnu_pub_index: Option<GnuPubIndex>,
     pub(super) dwarf_index_status: crate::DwarfIndexStatus,
     pub(super) lazy_debug_info: bool,
     pub(super) indexed_debug_info_cus: Mutex<HashSet<gimli::DebugInfoOffset>>,
@@ -163,6 +164,13 @@ impl LoadedObjfile {
                 ),
             }
         }
+        if let Err(error) = self.ensure_all_debug_info_for_gnu_index() {
+            tracing::warn!(
+                "Failed to materialize all GNU-indexed DWARF functions in {}: {}",
+                self.module_path().display(),
+                error
+            );
+        }
         self.lightweight_index
             .read()
             .expect("lightweight index lock poisoned")
@@ -182,6 +190,13 @@ impl LoadedObjfile {
                     error
                 ),
             }
+        }
+        if let Err(error) = self.ensure_all_debug_info_for_gnu_index() {
+            tracing::warn!(
+                "Failed to materialize all GNU-indexed DWARF variables in {}: {}",
+                self.module_path().display(),
+                error
+            );
         }
         self.lightweight_index
             .read()
@@ -204,6 +219,9 @@ impl LoadedObjfile {
                 .symbol_names(GdbSymbolKind::Type)
                 .map_or(0, <[String]>::len);
             return (functions, variables, functions + variables + types);
+        }
+        if let Some(index) = &self.gnu_pub_index {
+            return index.get_stats();
         }
         self.lightweight_index
             .read()
@@ -256,15 +274,27 @@ impl LoadedObjfile {
         kind: GdbSymbolKind,
         match_variants: bool,
     ) -> Result<()> {
-        let Some(index) = &self.gdb_index else {
-            return Ok(());
-        };
-        let symbols = if match_variants {
-            index.lookup_matching_symbols(name, kind)?
-        } else {
-            index.lookup_symbol(name, kind)?
-        };
-        self.ensure_debug_info_cus(symbols.into_iter().map(|symbol| symbol.cu_offset))
+        if let Some(index) = &self.gdb_index {
+            let symbols = if match_variants {
+                index.lookup_matching_symbols(name, kind)?
+            } else {
+                index.lookup_symbol(name, kind)?
+            };
+            return self.ensure_debug_info_cus(symbols.into_iter().map(|symbol| symbol.cu_offset));
+        }
+
+        if let Some(index) = &self.gnu_pub_index {
+            let mut unit_offsets = index.lookup_units(name, kind, match_variants);
+            if unit_offsets.is_empty() && !match_variants {
+                unit_offsets = index.lookup_units(name, kind, true);
+            }
+            if unit_offsets.is_empty() {
+                return self.ensure_all_debug_info_for_gnu_index();
+            }
+            return self.ensure_debug_info_cus(unit_offsets);
+        }
+
+        Ok(())
     }
 
     pub(super) fn ensure_debug_info_for_address(&self, address: u64) -> Result<()> {
@@ -334,6 +364,17 @@ impl LoadedObjfile {
             .flat_map(|(_, offsets)| offsets.iter().copied())
             .collect::<Vec<_>>();
         self.ensure_line_info_cus(unit_offsets)
+    }
+
+    pub(super) fn uses_gnu_pub_index(&self) -> bool {
+        self.gnu_pub_index.is_some()
+    }
+
+    pub(super) fn ensure_all_debug_info_for_gnu_index(&self) -> Result<()> {
+        let Some(index) = &self.gnu_pub_index else {
+            return Ok(());
+        };
+        self.ensure_debug_info_cus(index.all_unit_offsets().iter().copied())
     }
 
     fn ensure_debug_info_cus(

--- a/ghostscope-dwarf/src/objfile/loading.rs
+++ b/ghostscope-dwarf/src/objfile/loading.rs
@@ -7,9 +7,9 @@ use crate::{
         DwarfReader, MappedFile,
     },
     core::{mapping::ModuleMapping, DebugInfoSource, Result},
-    index::{BlockIndex, GdbIndex, TypeNameIndex},
+    index::{BlockIndex, GdbIndex, GnuPubIndex, TypeNameIndex},
     objfile::ModuleUnwindInfo,
-    parser::DetailedParser,
+    parser::{DebugParseResult, DetailedParser, DwarfParser, GnuPubSections},
 };
 use ghostscope_debuginfod::{build_id_to_hex, DebuginfodClient};
 use gimli::{Reader, Section};
@@ -27,6 +27,75 @@ enum InitialIndexSelection {
     FullScan { rejection: Option<String> },
     DebugNames,
     GdbIndex,
+    GnuPubNames(GnuPubIndex),
+}
+
+fn append_index_rejection(current: Option<String>, next: String) -> Option<String> {
+    Some(match current {
+        Some(current) => format!("{current}; {next}"),
+        None => next,
+    })
+}
+
+fn select_fallback_index(
+    parser: &DwarfParser<'_>,
+    module_path: &str,
+    has_gdb_index: bool,
+    mapped_file: &Arc<MappedFile>,
+    mut rejection: Option<String>,
+) -> Result<(DebugParseResult, InitialIndexSelection)> {
+    if has_gdb_index {
+        return Ok((
+            parser.initialize_lazy_debug_info(),
+            InitialIndexSelection::GdbIndex,
+        ));
+    }
+
+    let gnu_pub_sections = match LoadedObjfile::load_gnu_pub_sections(mapped_file) {
+        Ok(Some(sections)) => {
+            tracing::info!(
+                "Found .debug_gnu_pubnames and .debug_gnu_pubtypes in {}",
+                mapped_file.path.display()
+            );
+            Some(sections)
+        }
+        Ok(None) => None,
+        Err(error) => {
+            tracing::warn!(
+                "Ignoring unusable GNU pubnames sections in {}: {}",
+                mapped_file.path.display(),
+                error
+            );
+            rejection = append_index_rejection(
+                rejection,
+                format!("GNU pubnames sections could not be loaded: {error}"),
+            );
+            None
+        }
+    };
+
+    if let Some(sections) = gnu_pub_sections.as_ref() {
+        match parser.parse_gnu_pubnames(sections, module_path) {
+            Ok((index, gnu_pub_index)) => {
+                return Ok((index, InitialIndexSelection::GnuPubNames(gnu_pub_index)));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Ignoring unusable GNU pubnames index for {}: {}",
+                    module_path,
+                    error
+                );
+                rejection = append_index_rejection(
+                    rejection,
+                    format!("GNU pubnames index could not be used: {error}"),
+                );
+            }
+        }
+    }
+
+    parser
+        .parse_debug_info(module_path)
+        .map(|index| (index, InitialIndexSelection::FullScan { rejection }))
 }
 
 impl LoadedObjfile {
@@ -202,7 +271,8 @@ impl LoadedObjfile {
             }
         };
         let has_gdb_index = gdb_index.is_some();
-        let initial_rejection = gdb_index_rejection.clone();
+        let initial_rejection =
+            gdb_index_rejection.map(|reason| format!(".gdb_index could not be used: {reason}"));
 
         tracing::debug!(
             "Starting parallel DWARF parsing with true debug_line || debug_info parallelism..."
@@ -211,6 +281,7 @@ impl LoadedObjfile {
         let (pair_result, unwind_info) = tokio::try_join!(
             tokio::task::spawn_blocking({
                 let dwarf = Arc::clone(&dwarf);
+                let mapped_file_for_index = Arc::clone(&mapped_file);
                 let module_path = module_mapping.path.to_string_lossy().to_string();
                 move || -> Result<(
                     crate::parser::LineParseResult,
@@ -226,56 +297,30 @@ impl LoadedObjfile {
                             let parser = crate::parser::DwarfParser::new(&dwarf);
                             match parser.parse_debug_names(&module_path) {
                                 Ok(Some(index)) => Ok((index, InitialIndexSelection::DebugNames)),
-                                Ok(None) if has_gdb_index => {
-                                    Ok((
-                                        parser.initialize_lazy_debug_info(),
-                                        InitialIndexSelection::GdbIndex,
-                                    ))
-                                }
-                                Ok(None) => parser
-                                    .parse_debug_info(&module_path)
-                                    .map(|index| {
-                                        (
-                                            index,
-                                            InitialIndexSelection::FullScan {
-                                                rejection: initial_rejection,
-                                            },
-                                        )
-                                    }),
+                                Ok(None) => select_fallback_index(
+                                    &parser,
+                                    &module_path,
+                                    has_gdb_index,
+                                    &mapped_file_for_index,
+                                    initial_rejection,
+                                ),
                                 Err(error) => {
                                     tracing::warn!(
                                         "Ignoring unusable .debug_names for {}: {}",
                                         module_path,
                                         error
                                     );
-                                    if has_gdb_index {
-                                        Ok((
-                                            parser.initialize_lazy_debug_info(),
-                                            InitialIndexSelection::GdbIndex,
-                                        ))
-                                    } else {
-                                        let debug_names_rejection = format!(
-                                            ".debug_names could not be used: {error}"
-                                        );
-                                        let rejection = initial_rejection.map_or(
-                                            debug_names_rejection.clone(),
-                                            |gdb_rejection| {
-                                                format!(
-                                                    ".gdb_index could not be used: {gdb_rejection}; {debug_names_rejection}"
-                                                )
-                                            },
-                                        );
-                                        parser
-                                            .parse_debug_info(&module_path)
-                                            .map(|index| {
-                                                (
-                                                    index,
-                                                    InitialIndexSelection::FullScan {
-                                                        rejection: Some(rejection),
-                                                    },
-                                                )
-                                            })
-                                    }
+                                    let rejection = append_index_rejection(
+                                        initial_rejection,
+                                        format!(".debug_names could not be used: {error}"),
+                                    );
+                                    select_fallback_index(
+                                        &parser,
+                                        &module_path,
+                                        has_gdb_index,
+                                        &mapped_file_for_index,
+                                        rejection,
+                                    )
                                 }
                             }
                         },
@@ -298,20 +343,23 @@ impl LoadedObjfile {
 
         let (line_result, info_result, index_selection) = pair_result?;
         let lazy_debug_info = !matches!(index_selection, InitialIndexSelection::FullScan { .. });
-        let (gdb_index, dwarf_index_status) = match index_selection {
+        let (gdb_index, gnu_pub_index, dwarf_index_status) = match index_selection {
             InitialIndexSelection::FullScan { rejection } => {
                 let status = rejection.map_or(DwarfIndexStatus::FullScan, |reason| {
                     DwarfIndexStatus::Rejected { reason }
                 });
-                (None, status)
+                (None, None, status)
             }
-            InitialIndexSelection::DebugNames => (None, DwarfIndexStatus::DebugNames),
+            InitialIndexSelection::DebugNames => (None, None, DwarfIndexStatus::DebugNames),
             InitialIndexSelection::GdbIndex => {
                 let index = gdb_index.expect("selected GDB index must be loaded");
                 let status = DwarfIndexStatus::GdbIndex {
                     version: index.version(),
                 };
-                (Some(index), status)
+                (Some(index), None, status)
+            }
+            InitialIndexSelection::GnuPubNames(index) => {
+                (None, Some(index), DwarfIndexStatus::GnuPubNames)
             }
         };
 
@@ -392,6 +440,7 @@ impl LoadedObjfile {
             block_index: std::sync::RwLock::new(BlockIndex::new()),
             type_name_index: RwLock::new(type_name_index),
             gdb_index,
+            gnu_pub_index,
             dwarf_index_status,
             lazy_debug_info,
             indexed_debug_info_cus: Mutex::new(HashSet::new()),
@@ -729,6 +778,54 @@ impl LoadedObjfile {
         index.validate_unit_headers(dwarf)?;
         index.validate_symbol_data()?;
         Ok(Some(index))
+    }
+
+    fn load_gnu_pub_sections(file_data: &Arc<MappedFile>) -> Result<Option<GnuPubSections>> {
+        let object = file_data.parse_object()?;
+        let endian = dwarf_endian_from_object(&object);
+        let load_section = |id: gimli::SectionId| -> Result<Option<DwarfReader>> {
+            let Some(section) = object.section_by_name(id.name()) else {
+                return Ok(None);
+            };
+            let compressed_range = section.compressed_file_range()?;
+            if compressed_range.format != object::read::CompressionFormat::None {
+                let data = section.uncompressed_data().map_err(|error| {
+                    anyhow::anyhow!(
+                        "Failed to decompress DWARF section {} in {}: {}",
+                        id.name(),
+                        file_data.path.display(),
+                        error
+                    )
+                })?;
+                let bytes: Arc<[u8]> = match data {
+                    Cow::Borrowed(bytes) => Arc::from(bytes),
+                    Cow::Owned(bytes) => Arc::from(bytes),
+                };
+                return Ok(Some(dwarf_reader_from_arc_with_endian(bytes, endian)));
+            }
+
+            let (start, size) = section
+                .file_range()
+                .ok_or_else(|| anyhow::anyhow!("Invalid DWARF section range for {}", id.name()))?;
+            let reader = MappedFile::dwarf_reader_range(Arc::clone(file_data), start, size, endian)
+                .ok_or_else(|| anyhow::anyhow!("Invalid DWARF section range for {}", id.name()))?;
+            Ok(Some(reader))
+        };
+
+        let pub_names = load_section(gimli::SectionId::DebugGnuPubNames)?;
+        let pub_types = load_section(gimli::SectionId::DebugGnuPubTypes)?;
+        match (pub_names, pub_types) {
+            (None, None) => Ok(None),
+            (Some(pub_names), Some(pub_types)) => {
+                Ok(Some(GnuPubSections::new(pub_names, pub_types)))
+            }
+            (Some(_), None) => {
+                anyhow::bail!(".debug_gnu_pubnames is present without .debug_gnu_pubtypes")
+            }
+            (None, Some(_)) => {
+                anyhow::bail!(".debug_gnu_pubtypes is present without .debug_gnu_pubnames")
+            }
+        }
     }
 
     fn load_dwarf_sections(file_data: &Arc<MappedFile>) -> Result<DwarfData> {

--- a/ghostscope-dwarf/src/objfile/variables.rs
+++ b/ghostscope-dwarf/src/objfile/variables.rs
@@ -382,56 +382,75 @@ impl LoadedObjfile {
                 error
             );
         }
-        for &tag in tags {
-            let loc = self
-                .type_name_index
-                .read()
-                .expect("type name index lock poisoned")
-                .find_aggregate_definition(name, tag);
-            if let Some(loc) = loc {
-                let ty = self.detailed_shallow_type(loc.cu_offset, loc.die_offset)?;
-                return Some((
-                    ty,
-                    TypeLoc {
-                        cu_off: loc.cu_offset,
-                        die_off: loc.die_offset,
-                    },
-                ));
-            }
-        }
-
-        let typedef = self
-            .type_name_index
-            .read()
-            .expect("type name index lock poisoned")
-            .find_typedef(name);
-        if let Some(td) = typedef {
-            let dwarf = self.dwarf();
-            if let Ok(unit) = self.unit(td.cu_offset) {
-                if let Ok(entry) = unit.entry(td.die_offset) {
-                    if let Ok(Some(type_loc)) = resolve_type_ref_with_origins(dwarf, &entry, &unit)
-                    {
-                        let ty = self.detailed_shallow_type(type_loc.cu_off, type_loc.die_off)?;
-                        return Some((ty, type_loc));
-                    }
-                    let ty = crate::parser::DetailedParser::resolve_type_shallow_at_offset(
-                        dwarf,
-                        &unit,
-                        td.die_offset,
-                        self.compilation_unit_language(td.cu_offset, &unit),
-                    )?;
+        let resolve_materialized = || -> Option<(crate::TypeInfo, TypeLoc)> {
+            for &tag in tags {
+                let loc = self
+                    .type_name_index
+                    .read()
+                    .expect("type name index lock poisoned")
+                    .find_aggregate_definition(name, tag);
+                if let Some(loc) = loc {
+                    let ty = self.detailed_shallow_type(loc.cu_offset, loc.die_offset)?;
                     return Some((
                         ty,
                         TypeLoc {
-                            cu_off: td.cu_offset,
-                            die_off: td.die_offset,
+                            cu_off: loc.cu_offset,
+                            die_off: loc.die_offset,
                         },
                     ));
                 }
             }
+
+            let typedef = self
+                .type_name_index
+                .read()
+                .expect("type name index lock poisoned")
+                .find_typedef(name);
+            if let Some(td) = typedef {
+                let dwarf = self.dwarf();
+                if let Ok(unit) = self.unit(td.cu_offset) {
+                    if let Ok(entry) = unit.entry(td.die_offset) {
+                        if let Ok(Some(type_loc)) =
+                            resolve_type_ref_with_origins(dwarf, &entry, &unit)
+                        {
+                            let ty =
+                                self.detailed_shallow_type(type_loc.cu_off, type_loc.die_off)?;
+                            return Some((ty, type_loc));
+                        }
+                        let ty = crate::parser::DetailedParser::resolve_type_shallow_at_offset(
+                            dwarf,
+                            &unit,
+                            td.die_offset,
+                            self.compilation_unit_language(td.cu_offset, &unit),
+                        )?;
+                        return Some((
+                            ty,
+                            TypeLoc {
+                                cu_off: td.cu_offset,
+                                die_off: td.die_offset,
+                            },
+                        ));
+                    }
+                }
+            }
+
+            None
+        };
+
+        let resolved = resolve_materialized();
+        if resolved.is_some() || !self.uses_gnu_pub_index() {
+            return resolved;
         }
 
-        None
+        if let Err(error) = self.ensure_all_debug_info_for_gnu_index() {
+            tracing::warn!(
+                "Failed to exhaust GNU-indexed DWARF for type '{}' in {}: {}",
+                name,
+                self.module_path().display(),
+                error
+            );
+        }
+        resolve_materialized()
     }
 
     pub(crate) fn get_visible_variables_at_address_best_effort_with_diagnostics(

--- a/ghostscope-dwarf/src/parser/fast_parser/mod.rs
+++ b/ghostscope-dwarf/src/parser/fast_parser/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     binary::{dwarf_reader_from_arc_with_endian, DwarfReader},
     core::{FunctionDieKind, IndexEntry, LineEntry, Result},
     index::{
-        directory_from_index, resolve_file_path, LightweightFileIndex, LightweightIndex,
-        LightweightIndexShard, LineMappingTable, ScopedFileIndexManager,
+        directory_from_index, resolve_file_path, GdbSymbolKind, GnuPubIndex, LightweightFileIndex,
+        LightweightIndex, LightweightIndexShard, LineMappingTable, ScopedFileIndexManager,
     },
 };
 use gimli::{Reader, Section};
@@ -15,6 +15,33 @@ use std::{
     sync::Arc,
 };
 use tracing::debug;
+
+#[derive(Debug, Clone)]
+pub(crate) struct GnuPubSections {
+    pub_names: gimli::DebugGnuPubNames<DwarfReader>,
+    pub_types: gimli::DebugGnuPubTypes<DwarfReader>,
+}
+
+impl GnuPubSections {
+    pub(crate) fn new(pub_names: DwarfReader, pub_types: DwarfReader) -> Self {
+        Self {
+            pub_names: gimli::DebugGnuPubNames::from(pub_names),
+            pub_types: gimli::DebugGnuPubTypes::from(pub_types),
+        }
+    }
+}
+
+fn gnu_pub_symbol_kind(
+    kind: gimli::constants::GdbIndexSymbolKind,
+) -> Result<Option<GdbSymbolKind>> {
+    match kind {
+        gimli::constants::GDB_INDEX_SYMBOL_KIND_TYPE => Ok(Some(GdbSymbolKind::Type)),
+        gimli::constants::GDB_INDEX_SYMBOL_KIND_VARIABLE => Ok(Some(GdbSymbolKind::Variable)),
+        gimli::constants::GDB_INDEX_SYMBOL_KIND_FUNCTION => Ok(Some(GdbSymbolKind::Function)),
+        gimli::constants::GDB_INDEX_SYMBOL_KIND_OTHER => Ok(None),
+        _ => anyhow::bail!("invalid GNU pubnames symbol kind {kind}"),
+    }
+}
 
 fn is_gdb2_name_index(header: &gimli::NameIndexHeader<DwarfReader>) -> Result<bool> {
     let Some(augmentation) = header.augmentation_string() else {
@@ -142,6 +169,7 @@ fn patch_gdb2_abbreviations(
 #[derive(Clone, Default)]
 struct FunctionMetadata {
     name: Option<Arc<str>>,
+    linkage_name: Option<Arc<str>>,
     has_inline_attribute: bool,
     is_linkage_name: bool,
     is_external: Option<bool>,
@@ -337,7 +365,7 @@ impl<'a> DwarfParser<'a> {
                             is_linkage: metadata.is_linkage_name,
                             ..Default::default()
                         };
-                        let linkage_name = raw_attrs.linkage_name.as_ref().map(Arc::clone);
+                        let linkage_name = metadata.linkage_name.as_ref().map(Arc::clone);
                         let seed = FunctionEntrySeed {
                             die_offset: entry_offset,
                             tag,
@@ -381,7 +409,7 @@ impl<'a> DwarfParser<'a> {
                             is_linkage: metadata.is_linkage_name,
                             ..Default::default()
                         };
-                        let linkage_name = raw_attrs.linkage_name.as_ref().map(Arc::clone);
+                        let linkage_name = metadata.linkage_name.as_ref().map(Arc::clone);
                         let seed = FunctionEntrySeed {
                             die_offset: entry_offset,
                             tag,
@@ -861,6 +889,7 @@ impl<'a> DwarfParser<'a> {
             metadata.name = Some(Arc::clone(name));
             metadata.is_linkage_name = true;
         }
+        metadata.linkage_name = attrs.linkage_name.as_ref().map(Arc::clone);
 
         metadata.has_inline_attribute = attrs.has_inline_attribute;
         metadata.is_external = attrs.is_external;
@@ -888,6 +917,9 @@ impl<'a> DwarfParser<'a> {
 
             if metadata.name.is_none() {
                 metadata.name = origin_metadata.name.as_ref().map(Arc::clone);
+            }
+            if metadata.linkage_name.is_none() {
+                metadata.linkage_name = origin_metadata.linkage_name.as_ref().map(Arc::clone);
             }
             if metadata.is_external.is_none() {
                 metadata.is_external = origin_metadata.is_external;
@@ -1376,6 +1408,53 @@ impl<'a> DwarfParser<'a> {
         })
     }
 
+    fn validate_gnu_pub_set(
+        &self,
+        section_name: &str,
+        unit_offset: gimli::DebugInfoOffset,
+        unit_length: usize,
+        format: gimli::Format,
+    ) -> Result<()> {
+        let header = self.dwarf.unit_header(unit_offset).map_err(|error| {
+            anyhow::anyhow!(
+                "{section_name} references invalid CU 0x{:x}: {error}",
+                unit_offset.0
+            )
+        })?;
+        if header.format() != format {
+            anyhow::bail!(
+                "{section_name} CU 0x{:x} uses {:?}, but its index contribution uses {:?}",
+                unit_offset.0,
+                header.format(),
+                format
+            );
+        }
+        let actual_length = header.length_including_self();
+        if actual_length != unit_length {
+            anyhow::bail!(
+                "{section_name} CU 0x{:x} length 0x{unit_length:x} does not match .debug_info length 0x{actual_length:x}",
+                unit_offset.0
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_gnu_pub_die_offset(
+        section_name: &str,
+        unit_offset: gimli::DebugInfoOffset,
+        unit_length: usize,
+        die_offset: gimli::UnitOffset,
+    ) -> Result<()> {
+        if die_offset.0 >= unit_length {
+            anyhow::bail!(
+                "{section_name} DIE offset 0x{:x} is outside CU 0x{:x} with length 0x{unit_length:x}",
+                die_offset.0,
+                unit_offset.0
+            );
+        }
+        Ok(())
+    }
+
     fn compatible_debug_names(&self) -> Result<gimli::DebugNames<DwarfReader>> {
         let mut patches = Vec::new();
         let mut headers = self.dwarf.debug_names.headers();
@@ -1536,6 +1615,174 @@ impl<'a> DwarfParser<'a> {
             functions_count,
             variables_count,
         }))
+    }
+
+    pub(crate) fn parse_gnu_pubnames(
+        &self,
+        sections: &GnuPubSections,
+        module_path: &str,
+    ) -> Result<(DebugParseResult, GnuPubIndex)> {
+        debug!("Starting GNU pubnames parsing for: {}", module_path);
+        let mut pub_names_sets = Vec::new();
+        let mut pub_names_set_iter = sections.pub_names.sets();
+        while let Some(set) = pub_names_set_iter.next()? {
+            pub_names_sets.push(set);
+        }
+        let mut pub_types_sets = Vec::new();
+        let mut pub_types_set_iter = sections.pub_types.sets();
+        while let Some(set) = pub_types_set_iter.next()? {
+            pub_types_sets.push(set);
+        }
+
+        let pub_names_set_count = pub_names_sets.len();
+        let pub_types_set_count = pub_types_sets.len();
+        if pub_names_set_count == 0 || pub_types_set_count == 0 {
+            anyhow::bail!(
+                "GNU pubnames index is incomplete: {pub_names_set_count} pubnames sets and {pub_types_set_count} pubtypes sets"
+            );
+        }
+
+        let pub_names_units = pub_names_sets
+            .iter()
+            .map(|set| set.unit_header_offset())
+            .collect::<HashSet<_>>();
+        let pub_types_units = pub_types_sets
+            .iter()
+            .map(|set| set.unit_header_offset())
+            .collect::<HashSet<_>>();
+        if pub_names_units.len() != pub_names_set_count
+            || pub_types_units.len() != pub_types_set_count
+        {
+            anyhow::bail!("GNU pubnames index contains duplicate CU contributions");
+        }
+
+        let mut all_debug_info_units = Vec::new();
+        let mut pub_contribution_units = HashSet::new();
+        let mut units = self.dwarf.units();
+        while let Some(header) = units.next()? {
+            if let Some(unit_offset) = header.debug_info_offset() {
+                all_debug_info_units.push(unit_offset);
+                if !matches!(
+                    header.type_(),
+                    gimli::UnitType::Type { .. } | gimli::UnitType::SplitType { .. }
+                ) {
+                    pub_contribution_units.insert(unit_offset);
+                }
+            }
+        }
+        let missing_pub_names = pub_contribution_units.difference(&pub_names_units).count();
+        let missing_pub_types = pub_contribution_units.difference(&pub_types_units).count();
+        let extra_pub_names = pub_names_units.difference(&pub_contribution_units).count();
+        let extra_pub_types = pub_types_units.difference(&pub_contribution_units).count();
+        if missing_pub_names != 0
+            || missing_pub_types != 0
+            || extra_pub_names != 0
+            || extra_pub_types != 0
+        {
+            anyhow::bail!(
+                "GNU pubnames index does not cover all .debug_info units: {missing_pub_names} missing pubnames, {missing_pub_types} missing pubtypes, {extra_pub_names} unknown pubnames, {extra_pub_types} unknown pubtypes contributions"
+            );
+        }
+
+        let pub_name_seed_shards = pub_names_sets
+            .into_par_iter()
+            .map(
+                |set| -> Result<Vec<(String, gimli::DebugInfoOffset, GdbSymbolKind)>> {
+                    let unit_offset = set.unit_header_offset();
+                    let unit_length = set.unit_length();
+                    self.validate_gnu_pub_set(
+                        ".debug_gnu_pubnames",
+                        unit_offset,
+                        unit_length,
+                        set.format(),
+                    )?;
+                    let mut seeds = Vec::new();
+                    let mut entries = set.items();
+                    while let Some(entry) = entries.next()? {
+                        let die_offset = entry.die_offset();
+                        Self::validate_gnu_pub_die_offset(
+                            ".debug_gnu_pubnames",
+                            unit_offset,
+                            unit_length,
+                            die_offset,
+                        )?;
+                        if let Some(kind) = gnu_pub_symbol_kind(entry.kind())? {
+                            let name = entry.name().to_string_lossy()?.into_owned();
+                            seeds.push((name, unit_offset, kind));
+                        }
+                    }
+                    Ok(seeds)
+                },
+            )
+            .collect::<Result<Vec<_>>>()?;
+        let pub_type_seed_shards = pub_types_sets
+            .into_par_iter()
+            .map(
+                |set| -> Result<Vec<(String, gimli::DebugInfoOffset, GdbSymbolKind)>> {
+                    let unit_offset = set.unit_header_offset();
+                    let unit_length = set.unit_length();
+                    self.validate_gnu_pub_set(
+                        ".debug_gnu_pubtypes",
+                        unit_offset,
+                        unit_length,
+                        set.format(),
+                    )?;
+                    let mut seeds = Vec::new();
+                    let mut entries = set.items();
+                    while let Some(entry) = entries.next()? {
+                        let die_offset = entry.die_offset();
+                        Self::validate_gnu_pub_die_offset(
+                            ".debug_gnu_pubtypes",
+                            unit_offset,
+                            unit_length,
+                            die_offset,
+                        )?;
+                        if let Some(kind) = gnu_pub_symbol_kind(entry.kind())? {
+                            let name = entry.name().to_string_lossy()?.into_owned();
+                            seeds.push((name, unit_offset, kind));
+                        }
+                    }
+                    Ok(seeds)
+                },
+            )
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut gnu_pub_index = GnuPubIndex::new(all_debug_info_units);
+        for (name, unit_offset, kind) in pub_name_seed_shards
+            .into_iter()
+            .chain(pub_type_seed_shards)
+            .flatten()
+        {
+            gnu_pub_index.insert(name, unit_offset, kind);
+        }
+
+        let (functions_count, variables_count, _) = gnu_pub_index.get_stats();
+        let mut lightweight_index = LightweightIndex::new();
+        let has_aranges = lightweight_index.build_cu_maps_from_aranges(self.dwarf);
+        let has_root_ranges = lightweight_index
+            .build_cu_maps_from_unit_roots(self.dwarf, pub_contribution_units.iter().copied());
+        if !has_aranges && !has_root_ranges && functions_count > 0 {
+            anyhow::bail!(
+                "GNU pubnames index for {module_path} has functions but no usable address-to-CU ranges",
+            );
+        }
+
+        debug!(
+            "Completed GNU pubnames parsing for {}: {} functions, {} variables, {} pubnames sets, {} pubtypes sets",
+            module_path,
+            functions_count,
+            variables_count,
+            pub_names_set_count,
+            pub_types_set_count
+        );
+        Ok((
+            DebugParseResult {
+                lightweight_index,
+                functions_count,
+                variables_count,
+            },
+            gnu_pub_index,
+        ))
     }
 
     pub(crate) fn parse_debug_info_cus(

--- a/ghostscope-dwarf/src/parser/mod.rs
+++ b/ghostscope-dwarf/src/parser/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use detailed_parser::ParsedVariable;
 pub(crate) use crate::dwarf_expr::ExpressionEvaluator;
 pub(crate) use detailed_parser::DetailedParser;
 pub(crate) use fast_parser::{
-    CompilationUnit, DebugParseResult, DwarfParseResult, DwarfParser, LineParseResult, SourceFile,
+    CompilationUnit, DebugParseResult, DwarfParseResult, DwarfParser, GnuPubSections,
+    LineParseResult, SourceFile,
 };
 pub(crate) use range_extractor::RangeExtractor;

--- a/scripts/dwarf-perf/build_corpus.sh
+++ b/scripts/dwarf-perf/build_corpus.sh
@@ -93,6 +93,7 @@ docker run --rm \
 echo "Host artifacts:"
 echo "  $OUT_DIR/query-hotspot/query_hotspot"
 echo "  $OUT_DIR/parse-stress/parse_stress"
+echo "  $OUT_DIR/gnu-pubnames-stress/gnu_pubnames_stress"
 echo "  $OUT_DIR/rust-parse-stress/rust_parse_stress"
 echo "  $OUT_DIR/cpp-template-stress/cpp_template_stress"
 echo "  $OUT_DIR/rust-generic-stress/rust_generic_stress"

--- a/scripts/dwarf-perf/build_corpus_in_container.sh
+++ b/scripts/dwarf-perf/build_corpus_in_container.sh
@@ -12,6 +12,7 @@ fi
 OUT_DIR=$1
 QUERY_OUT_DIR="$OUT_DIR/query-hotspot"
 PARSE_OUT_DIR="$OUT_DIR/parse-stress"
+GNU_PUBNAMES_PARSE_OUT_DIR="$OUT_DIR/gnu-pubnames-stress"
 RUST_PARSE_OUT_DIR="$OUT_DIR/rust-parse-stress"
 CPP_TEMPLATE_OUT_DIR="$OUT_DIR/cpp-template-stress"
 RUST_GENERIC_OUT_DIR="$OUT_DIR/rust-generic-stress"
@@ -19,6 +20,7 @@ CPP_NAMESPACE_OUT_DIR="$OUT_DIR/cpp-deep-namespace"
 WORK_DIR="$OUT_DIR/_build"
 PARSE_SRC_DIR="$WORK_DIR/parse-stress-src"
 PARSE_OBJ_DIR="$WORK_DIR/parse-stress-obj"
+GNU_PUBNAMES_PARSE_OBJ_DIR="$WORK_DIR/gnu-pubnames-stress-obj"
 RUST_PARSE_SRC_DIR="$WORK_DIR/rust-parse-stress-src"
 CPP_TEMPLATE_SRC_DIR="$WORK_DIR/cpp-template-stress-src"
 CPP_TEMPLATE_OBJ_DIR="$WORK_DIR/cpp-template-stress-obj"
@@ -118,6 +120,7 @@ fi
 mkdir -p \
     "$QUERY_OUT_DIR" \
     "$PARSE_OUT_DIR" \
+    "$GNU_PUBNAMES_PARSE_OUT_DIR" \
     "$RUST_PARSE_OUT_DIR" \
     "$CPP_TEMPLATE_OUT_DIR" \
     "$RUST_GENERIC_OUT_DIR" \
@@ -125,6 +128,7 @@ mkdir -p \
 rm -rf \
     "$PARSE_SRC_DIR" \
     "$PARSE_OBJ_DIR" \
+    "$GNU_PUBNAMES_PARSE_OBJ_DIR" \
     "$RUST_PARSE_SRC_DIR" \
     "$CPP_TEMPLATE_SRC_DIR" \
     "$CPP_TEMPLATE_OBJ_DIR" \
@@ -134,6 +138,7 @@ rm -rf \
 mkdir -p \
     "$PARSE_SRC_DIR" \
     "$PARSE_OBJ_DIR" \
+    "$GNU_PUBNAMES_PARSE_OBJ_DIR" \
     "$RUST_PARSE_SRC_DIR" \
     "$CPP_TEMPLATE_SRC_DIR" \
     "$CPP_TEMPLATE_OBJ_DIR" \
@@ -166,6 +171,38 @@ compile_cpp_corpus() {
         -fno-pie \
         -no-pie \
         "${cpp_objects[@]}" \
+        -o "$out_bin" \
+        "${COMMON_LDFLAGS[@]}" \
+        "${EXTRA_LDFLAGS[@]}"
+}
+
+compile_c_corpus() {
+    local src_dir=$1
+    local obj_dir=$2
+    local out_bin=$3
+    shift 3
+    local -a corpus_cflags=("$@")
+    local -a c_objects=()
+
+    mapfile -t c_sources < <(find "$src_dir" -name '*.c' -print | sort)
+    for source_path in "${c_sources[@]}"; do
+        local source_name
+        local object_path
+        source_name=$(basename "$source_path" .c)
+        object_path="$obj_dir/${source_name}.o"
+        "$CC" \
+            "${COMMON_CFLAGS[@]}" \
+            "${EXTRA_CFLAGS[@]}" \
+            "${corpus_cflags[@]}" \
+            -I"$src_dir" \
+            -c \
+            -o "$object_path" \
+            "$source_path"
+        c_objects+=("$object_path")
+    done
+
+    "$CC" \
+        "${c_objects[@]}" \
         -o "$out_bin" \
         "${COMMON_LDFLAGS[@]}" \
         "${EXTRA_LDFLAGS[@]}"
@@ -216,28 +253,14 @@ PARSE_STRESS_HISTORY_LEN=$(jq -r '.history_len' "$PARSE_CONFIG_PATH")
 PARSE_STRESS_GENERATED_C_FILES=$(jq -r '.generated_c_files' "$PARSE_CONFIG_PATH")
 PARSE_STRESS_GENERATED_HEADER_FILES=$(jq -r '.generated_header_files' "$PARSE_CONFIG_PATH")
 
-mapfile -t parse_sources < <(find "$PARSE_SRC_DIR" -name '*.c' -print | sort)
-parse_objects=()
-
-for source_path in "${parse_sources[@]}"; do
-    source_name=$(basename "$source_path" .c)
-    object_path="$PARSE_OBJ_DIR/${source_name}.o"
-    "$CC" \
-        "${COMMON_CFLAGS[@]}" \
-        "${EXTRA_CFLAGS[@]}" \
-        -I"$PARSE_SRC_DIR" \
-        -c \
-        -o "$object_path" \
-        "$source_path"
-    parse_objects+=("$object_path")
-done
-
 PARSE_BIN="$PARSE_OUT_DIR/parse_stress"
-"$CC" \
-    "${parse_objects[@]}" \
-    -o "$PARSE_BIN" \
-    "${COMMON_LDFLAGS[@]}" \
-    "${EXTRA_LDFLAGS[@]}"
+GNU_PUBNAMES_PARSE_BIN="$GNU_PUBNAMES_PARSE_OUT_DIR/gnu_pubnames_stress"
+compile_c_corpus "$PARSE_SRC_DIR" "$PARSE_OBJ_DIR" "$PARSE_BIN"
+compile_c_corpus \
+    "$PARSE_SRC_DIR" \
+    "$GNU_PUBNAMES_PARSE_OBJ_DIR" \
+    "$GNU_PUBNAMES_PARSE_BIN" \
+    -ggnu-pubnames
 
 rust_generator_args=(
     --output-dir "$RUST_PARSE_SRC_DIR"
@@ -386,12 +409,14 @@ compile_cpp_corpus "$CPP_NAMESPACE_SRC_DIR" "$CPP_NAMESPACE_OBJ_DIR" "$CPP_NAMES
 
 query_sha=$(sha256sum "$QUERY_BIN" | awk '{print $1}')
 parse_sha=$(sha256sum "$PARSE_BIN" | awk '{print $1}')
+gnu_pubnames_parse_sha=$(sha256sum "$GNU_PUBNAMES_PARSE_BIN" | awk '{print $1}')
 rust_parse_sha=$(sha256sum "$RUST_PARSE_BIN" | awk '{print $1}')
 cpp_template_sha=$(sha256sum "$CPP_TEMPLATE_BIN" | awk '{print $1}')
 rust_generic_sha=$(sha256sum "$RUST_GENERIC_BIN" | awk '{print $1}')
 cpp_namespace_sha=$(sha256sum "$CPP_NAMESPACE_BIN" | awk '{print $1}')
 query_size=$(stat -c '%s' "$QUERY_BIN")
 parse_size=$(stat -c '%s' "$PARSE_BIN")
+gnu_pubnames_parse_size=$(stat -c '%s' "$GNU_PUBNAMES_PARSE_BIN")
 rust_parse_size=$(stat -c '%s' "$RUST_PARSE_BIN")
 cpp_template_size=$(stat -c '%s' "$CPP_TEMPLATE_BIN")
 rust_generic_size=$(stat -c '%s' "$RUST_GENERIC_BIN")
@@ -409,6 +434,8 @@ jq -n \
     --arg query_marker "DWARF_PERF_QUERY_HOTSPOT" \
     --arg parse_path "parse-stress/parse_stress" \
     --arg parse_sha "$parse_sha" \
+    --arg gnu_pubnames_parse_path "gnu-pubnames-stress/gnu_pubnames_stress" \
+    --arg gnu_pubnames_parse_sha "$gnu_pubnames_parse_sha" \
     --arg parse_generator "scripts/dwarf-perf/generate_parse_stress.py" \
     --arg parse_preset "$PARSE_STRESS_PRESET" \
     --arg rust_parse_path "rust-parse-stress/rust_parse_stress" \
@@ -431,6 +458,7 @@ jq -n \
     --argjson query_line "$QUERY_MARKER_LINE" \
     --argjson query_size "$query_size" \
     --argjson parse_size "$parse_size" \
+    --argjson gnu_pubnames_parse_size "$gnu_pubnames_parse_size" \
     --argjson rust_parse_size "$rust_parse_size" \
     --argjson cpp_template_size "$cpp_template_size" \
     --argjson rust_generic_size "$rust_generic_size" \
@@ -493,6 +521,25 @@ jq -n \
                 relative_path: $parse_path,
                 sha256: $parse_sha,
                 size_bytes: $parse_size,
+                generator: {
+                    script: $parse_generator,
+                    preset: $parse_preset,
+                    units: $parse_units,
+                    types_per_unit: $parse_types_per_unit,
+                    functions_per_unit: $parse_functions_per_unit,
+                    history_len: $parse_history_len,
+                    generated_c_files: $parse_generated_c_files,
+                    generated_header_files: $parse_generated_header_files
+                }
+            },
+            {
+                name: "gnu-pubnames-stress",
+                kind: "fast-parse",
+                language: "c",
+                index: "gnu-pubnames",
+                relative_path: $gnu_pubnames_parse_path,
+                sha256: $gnu_pubnames_parse_sha,
+                size_bytes: $gnu_pubnames_parse_size,
                 generator: {
                     script: $parse_generator,
                     preset: $parse_preset,
@@ -581,6 +628,7 @@ jq -n \
 echo "Built DWARF perf corpus into $OUT_DIR"
 echo "  query-hotspot: $QUERY_BIN"
 echo "  parse-stress:  $PARSE_BIN"
+echo "  gnu-pubnames-stress: $GNU_PUBNAMES_PARSE_BIN"
 echo "  rust-parse-stress: $RUST_PARSE_BIN"
 echo "  cpp-template-stress: $CPP_TEMPLATE_BIN"
 echo "  rust-generic-stress: $RUST_GENERIC_BIN"

--- a/scripts/dwarf-perf/corpus/README.md
+++ b/scripts/dwarf-perf/corpus/README.md
@@ -54,6 +54,7 @@ The build writes artifacts under `scripts/dwarf-perf/corpus/out/`:
 
 - `query-hotspot/query_hotspot`
 - `parse-stress/parse_stress`
+- `gnu-pubnames-stress/gnu_pubnames_stress`
 - `rust-parse-stress/rust_parse_stress`
 - `cpp-template-stress/cpp_template_stress`
 - `rust-generic-stress/rust_generic_stress`
@@ -85,6 +86,7 @@ To run only one parse corpus:
 Other built-in parse targets include:
 
 - `parse-stress`
+- `gnu-pubnames-stress`
 - `rust-parse-stress`
 - `cpp-template-stress`
 - `rust-generic-stress`
@@ -213,6 +215,10 @@ The Rust parse corpus is intentionally tuned for DWARF density rather than runti
 performance. It keeps debug info in the binary, references a broad slice of `std`,
 and compiles with `-C link-dead-code=yes` so it is useful for fast-index pressure
 tests.
+
+`gnu-pubnames-stress` recompiles the same generated sources as `parse-stress` with
+`-ggnu-pubnames`. Keeping the program and DWARF density aligned makes it a focused
+regression target for the `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` fast path.
 
 The new comparison groups focus on mangled-symbol coverage from three angles:
 

--- a/scripts/dwarf-perf/publish_history.py
+++ b/scripts/dwarf-perf/publish_history.py
@@ -12,6 +12,7 @@ from typing import Any
 MAX_HISTORY_ENTRIES = 500
 PREFERRED_PARSE_TARGETS = [
     "parse-stress",
+    "gnu-pubnames-stress",
     "rust-parse-stress",
     "cpp-template-stress",
     "rust-generic-stress",


### PR DESCRIPTION
## Summary

- parse complete `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` pairs with
  gimli 0.34 into GhostScope's lazy DWARF index
- validate CU coverage and index structure, preserve safe full-scan fallback,
  and support compressed sections and qualified C++ type aliases
- add GCC/Clang correctness coverage plus a persistent GNU-pubnames
  performance target in CI and history reports

## Performance

Same large `parse-stress` binary, 30 runs; the comparison copy only removed
the GNU index sections:

| Path | Average load | Internal parse |
| --- | ---: | ---: |
| Full scan | 49.468 ms | 37.900 ms |
| GNU pubnames | 26.684 ms | 14.567 ms |

Average load time improves by about 46.1%, and internal parse time improves
by about 61.6%.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p ghostscope-dwarf`
- `dwarf_index_regressions`: 16 passed
- DWARF perf corpus build and `gnu-pubnames-stress` baseline
- `actionlint` for both DWARF perf workflows
- standard host-to-host e2e runner job `79045c625e86`: succeeded

An additional strict all-target clippy run for `ghostscope-e2e-tests` still
hits the pre-existing `single_match` lint in
`e2e-tests/tests/common/termination.rs:118`; targeted regression-test clippy
passed with the existing common-test lints allowed.

Container-topology e2e was not run because this change does not affect
container or PID-namespace behavior.
