### PR TITLE
chore: upgrade Rust to 1.98.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
         with:
           components: rustfmt
 
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get install -y llvm-22-dev libpolly-22-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
         with:
           components: clippy
 
@@ -98,7 +98,7 @@ jobs:
           sudo apt-get install -y llvm-22-dev libpolly-22-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Install Rust compatibility toolchains
         run: |
@@ -164,7 +164,7 @@ jobs:
           sudo apt-get install -y llvm-22-dev libpolly-22-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Install Rust e2e compatibility toolchains
         run: |
@@ -258,7 +258,7 @@ jobs:
           sudo apt-get install -y llvm-22-dev libpolly-22-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/container-e2e.yml
+++ b/.github/workflows/container-e2e.yml
@@ -55,7 +55,7 @@ jobs:
           clang-18 --version
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -167,7 +167,7 @@ jobs:
           sudo apt-get install -y llvm-22-dev libpolly-22-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/dwarf-perf-history.yml
+++ b/.github/workflows/dwarf-perf-history.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install -y llvm-18-dev libpolly-18-dev jq
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/dwarf-perf-regression.yml
+++ b/.github/workflows/dwarf-perf-regression.yml
@@ -86,7 +86,7 @@ jobs:
           sudo apt-get install -y llvm-18-dev libpolly-18-dev jq
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --version "$CARGO_AUDIT_VERSION" --locked
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@1.98.0
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --version "$CARGO_DENY_VERSION" --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ default-members = [
 [workspace.package]
 version = "0.1.6"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.98"
 authors = ["swananan <jt26wzz@gmail.com>"]
 license = "GPL-3.0-only"
 description = "GhostScope brings DWARF-aware eBPF tracing to user-space binaries with a printf-like experience."

--- a/README-zh.md
+++ b/README-zh.md
@@ -10,7 +10,7 @@
     <img src="https://img.shields.io/badge/版本-0.1.6-blue.svg" alt="版本"/>
     <img src="https://img.shields.io/badge/协议-GPL-green.svg" alt="协议"/>
     <img src="https://img.shields.io/badge/Linux-4.4+-orange.svg" alt="Linux 4.4+"/>
-    <img src="https://img.shields.io/badge/Rust-1.88.0-red.svg" alt="Rust 1.88.0"/>
+    <img src="https://img.shields.io/badge/Rust-1.98.0-red.svg" alt="Rust 1.98.0"/>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <img src="https://img.shields.io/badge/version-0.1.6-blue.svg" alt="Version"/>
     <img src="https://img.shields.io/badge/license-GPL-green.svg" alt="License"/>
     <img src="https://img.shields.io/badge/Linux-4.4+-orange.svg" alt="Linux 4.4+"/>
-    <img src="https://img.shields.io/badge/Rust-1.88.0-red.svg" alt="Rust 1.88.0"/>
+    <img src="https://img.shields.io/badge/Rust-1.98.0-red.svg" alt="Rust 1.98.0"/>
   </p>
 
   <p>

--- a/bins/debuginfod-client/src/main.rs
+++ b/bins/debuginfod-client/src/main.rs
@@ -140,7 +140,7 @@ fn parse_build_id_hex(raw: &str) -> Result<Vec<u8>> {
     if raw.is_empty() {
         bail!("build-id must not be empty");
     }
-    if raw.len() % 2 != 0 {
+    if !raw.len().is_multiple_of(2) {
         bail!("build-id hex must contain an even number of digits");
     }
 

--- a/bins/dwarf-tool/src/main.rs
+++ b/bins/dwarf-tool/src/main.rs
@@ -558,8 +558,8 @@ async fn load_analyzer_with_breakdown(
 
 async fn load_analyzer_and_execute(cli: Cli) -> Result<std::time::Duration> {
     if !cli.command.quiet() && !cli.command.json() {
-        if cli.pid.is_some() {
-            println!("Loading modules from PID {}...", cli.pid.unwrap());
+        if let Some(pid) = cli.pid {
+            println!("Loading modules from PID {pid}...");
         } else if let Some(ref target) = cli.target {
             println!("Loading target file {target}...");
         }

--- a/docker/base-build/Dockerfile
+++ b/docker/base-build/Dockerfile
@@ -97,7 +97,7 @@ rm -rf /tmp/llvm /tmp/llvm-build /tmp/llvm.tar.xz
 SHELL
 
 # Install Rust toolchain in image to avoid per-run bootstrap downloads
-ARG RUST_TOOLCHAIN=1.88.0
+ARG RUST_TOOLCHAIN=1.98.0
 RUN <<SHELL
 set -eux
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none

--- a/docker/dwarf-perf-builder/Dockerfile
+++ b/docker/dwarf-perf-builder/Dockerfile
@@ -10,7 +10,7 @@ ENV DWARF_PERF_WORKDIR=/workspace
 ENV DWARF_PERF_DEBUG_PREFIX_MAP=-fdebug-prefix-map=/workspace=/workspace
 
 ARG LLVM_MAJOR=18
-ARG RUST_TOOLCHAIN=1.88.0
+ARG RUST_TOOLCHAIN=1.98.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \

--- a/docker/fixture-compiler/Dockerfile
+++ b/docker/fixture-compiler/Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
 ARG LLVM_MAJOR=18
-ARG RUST_TOOLCHAIN=1.88.0
+ARG RUST_TOOLCHAIN=1.98.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Rust 1.88.0 (enforced via `rust-toolchain.toml`)
+- Rust 1.98.0 (enforced via `rust-toolchain.toml`)
 - Linux kernel 4.4+
 - LLVM 22 (including Polly library: `libpolly-22-dev`)
 

--- a/docs/zh/development.md
+++ b/docs/zh/development.md
@@ -2,7 +2,7 @@
 
 ## 前置要求
 
-- Rust 1.88.0（通过 `rust-toolchain.toml` 强制指定）
+- Rust 1.98.0（通过 `rust-toolchain.toml` 强制指定）
 - Linux 内核 4.4+
 - LLVM 22（包括 Polly 库：`libpolly-22-dev`）
 

--- a/ghostscope-compiler/src/ebpf/codegen/format/indirect.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/format/indirect.rs
@@ -426,11 +426,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                         "sequence element DWARF size {element_stride} does not fit this host"
                     ))
                 })?;
-                let payload_elements = if stride == 0 {
-                    max_elements
-                } else {
-                    capture_capacity / stride
-                };
+                let payload_elements = capture_capacity.checked_div(stride).unwrap_or(max_elements);
                 (stride, max_elements.min(payload_elements))
             }
         };

--- a/ghostscope-compiler/src/ebpf/codegen/statements.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/statements.rs
@@ -71,14 +71,13 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
                             bytes.push(0); // NUL terminate for display convenience
                             self.set_string_variable_bytes(name, bytes);
                         }
-                        crate::script::Expr::Variable(ref nm) => {
+                        crate::script::Expr::Variable(ref nm)
                             if self
                                 .get_variable_type(nm)
-                                .is_some_and(|t| matches!(t, crate::script::VarType::String))
-                            {
-                                if let Some(b) = self.get_string_variable_bytes(nm).cloned() {
-                                    self.set_string_variable_bytes(name, b);
-                                }
+                                .is_some_and(|t| matches!(t, crate::script::VarType::String)) =>
+                        {
+                            if let Some(b) = self.get_string_variable_bytes(nm).cloned() {
+                                self.set_string_variable_bytes(name, b);
                             }
                         }
                         _ => {}

--- a/ghostscope-compiler/src/ebpf/codegen/value_capture/layout.rs
+++ b/ghostscope-compiler/src/ebpf/codegen/value_capture/layout.rs
@@ -298,13 +298,12 @@ pub(in crate::ebpf::codegen) fn sequence_capture_limits(
             "sequence element DWARF size {element_stride} does not fit this host"
         ))
     })?;
-    let (max_elements, max_len) = if stride == 0 {
+    let (max_elements, max_len) = if let Some(max_elements) = cap.checked_div(stride) {
+        (max_elements, max_elements * stride)
+    } else {
         // A byte cap cannot bound a ZST payload, so use the configured value
         // as its logical element-count cap.
         (cap, 0)
-    } else {
-        let max_elements = cap / stride;
-        (max_elements, max_elements * stride)
     };
     let data_len = ghostscope_protocol::INDIRECT_SEQUENCE_HEADER_SIZE.saturating_add(max_len);
     Ok((max_elements, max_len, data_len))

--- a/ghostscope-compiler/src/ebpf/expression/casts.rs
+++ b/ghostscope-compiler/src/ebpf/expression/casts.rs
@@ -678,10 +678,7 @@ impl<'ctx, 'dw> EbpfContext<'ctx, 'dw> {
         let mut index = index;
         let mut visited = std::collections::HashSet::new();
 
-        loop {
-            let Expr::Variable(name) = &base else {
-                break;
-            };
+        while let Expr::Variable(name) = &base {
             if !self.alias_variable_exists(name) {
                 break;
             }

--- a/ghostscope-dwarf/src/binary/debuglink.rs
+++ b/ghostscope-dwarf/src/binary/debuglink.rs
@@ -675,7 +675,7 @@ mod tests {
         note.extend_from_slice(&object::elf::NT_GNU_BUILD_ID.to_le_bytes());
         note.extend_from_slice(b"GNU\0");
         note.extend_from_slice(build_id);
-        while note.len() % 4 != 0 {
+        while !note.len().is_multiple_of(4) {
             note.push(0);
         }
         note
@@ -684,7 +684,7 @@ mod tests {
     fn debuglink_section(filename: &str, crc: u32) -> Vec<u8> {
         let mut data = filename.as_bytes().to_vec();
         data.push(0);
-        while data.len() % 4 != 0 {
+        while !data.len().is_multiple_of(4) {
             data.push(0);
         }
         data.extend_from_slice(&crc.to_le_bytes());

--- a/ghostscope-dwarf/src/core/plan.rs
+++ b/ghostscope-dwarf/src/core/plan.rs
@@ -185,6 +185,7 @@ fn implicit_value_display(bytes: &[u8]) -> String {
 }
 
 /// A memory read requested by a future runtime lowering pass.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct UserMemoryRead {
     pub address: AddressExpr,

--- a/ghostscope-dwarf/src/dwarf_expr/lower/mod.rs
+++ b/ghostscope-dwarf/src/dwarf_expr/lower/mod.rs
@@ -817,7 +817,7 @@ impl ExpressionEvaluator {
                     },
                 ));
             }
-            if size_in_bits % 8 != 0 {
+            if !size_in_bits.is_multiple_of(8) {
                 return Err(anyhow::anyhow!(
                     "DW_OP_piece size {size_in_bits} is not byte-aligned"
                 ));

--- a/ghostscope-dwarf/src/index/line_mapping.rs
+++ b/ghostscope-dwarf/src/index/line_mapping.rs
@@ -299,8 +299,8 @@ impl LineMappingTable {
         let capacity = compact_entries.len() + self.incremental_entry_count;
         let mut compact_entries = compact_entries.into_iter().peekable();
         let mut incremental_entries = std::mem::take(&mut self.incremental_entries)
-            .into_iter()
-            .flat_map(|(_, entries)| entries)
+            .into_values()
+            .flatten()
             .peekable();
         let mut merged = Vec::with_capacity(capacity);
 

--- a/ghostscope-dwarf/src/index/native_gdb_index.rs
+++ b/ghostscope-dwarf/src/index/native_gdb_index.rs
@@ -429,16 +429,16 @@ impl GdbIndex {
         if layout.constant_pool > length {
             anyhow::bail!(".gdb_index constant pool is outside the section");
         }
-        if (layout.type_cu_list - layout.cu_list) % CU_RECORD_SIZE != 0 {
+        if !(layout.type_cu_list - layout.cu_list).is_multiple_of(CU_RECORD_SIZE) {
             anyhow::bail!(".gdb_index CU list has a partial record");
         }
-        if (layout.address_area - layout.type_cu_list) % TYPE_CU_RECORD_SIZE != 0 {
+        if !(layout.address_area - layout.type_cu_list).is_multiple_of(TYPE_CU_RECORD_SIZE) {
             anyhow::bail!(".gdb_index type CU list has a partial record");
         }
-        if (layout.symbol_table - layout.address_area) % ADDRESS_RECORD_SIZE != 0 {
+        if !(layout.symbol_table - layout.address_area).is_multiple_of(ADDRESS_RECORD_SIZE) {
             anyhow::bail!(".gdb_index address area has a partial record");
         }
-        if (layout.shortcut_table - layout.symbol_table) % SYMBOL_SLOT_SIZE != 0 {
+        if !(layout.shortcut_table - layout.symbol_table).is_multiple_of(SYMBOL_SLOT_SIZE) {
             anyhow::bail!(".gdb_index symbol table has a partial slot");
         }
         if version == 9 && layout.constant_pool - layout.shortcut_table < SYMBOL_SLOT_SIZE {

--- a/ghostscope-dwarf/src/language/rust/plan.rs
+++ b/ghostscope-dwarf/src/language/rust/plan.rs
@@ -432,7 +432,7 @@ impl BTreePlanner<'_> {
         else {
             return Ok(None);
         };
-        if edge_count != node_capacity.checked_add(1).unwrap_or(u64::MAX) {
+        if edge_count != node_capacity.saturating_add(1) {
             return Ok(None);
         }
         let edges_offset = member_projection_offset(&edges)?;

--- a/ghostscope-dwarf/src/language/rust/value/tests/mod.rs
+++ b/ghostscope-dwarf/src/language/rust/value/tests/mod.rs
@@ -110,11 +110,11 @@ fn rust_c_str_type_64(
     } else {
         byte
     };
-    *target_type = Box::new(TypeInfo::StructType {
+    **target_type = TypeInfo::StructType {
         name: "CStr".to_string(),
         size: 0,
         members: vec![member("inner", storage, 0)],
-    });
+    };
     current
 }
 
@@ -140,9 +140,9 @@ fn rust_path_ref_type_64(name: &str, language: SourceLanguage) -> ResolvedType {
     let TypeInfo::PointerType { target_type, .. } = &mut members[0].member_type else {
         unreachable!("test Path data_ptr is a pointer")
     };
-    *target_type = Box::new(TypeInfo::UnknownType {
+    **target_type = TypeInfo::UnknownType {
         name: "Path".to_string(),
-    });
+    };
     current
 }
 
@@ -154,11 +154,11 @@ fn rust_slice_type_64(name: &str, language: SourceLanguage) -> ResolvedType {
     let TypeInfo::PointerType { target_type, .. } = &mut members[0].member_type else {
         unreachable!("test slice data_ptr is a pointer")
     };
-    *target_type = Box::new(TypeInfo::BaseType {
+    **target_type = TypeInfo::BaseType {
         name: "i32".to_string(),
         size: 4,
         encoding: gimli::DW_ATE_signed.0 as u16,
-    });
+    };
     current
 }
 

--- a/ghostscope-dwarf/src/language/rust/value/tests/sequences.rs
+++ b/ghostscope-dwarf/src/language/rust/value/tests/sequences.rs
@@ -146,9 +146,9 @@ fn recognizes_c_str_references_and_boxes_across_dwarf_generations() {
     let TypeInfo::PointerType { target_type, .. } = &mut members[0].member_type else {
         unreachable!("test CStr data_ptr is a pointer")
     };
-    *target_type = Box::new(TypeInfo::UnknownType {
+    **target_type = TypeInfo::UnknownType {
         name: "CStr".to_string(),
-    });
+    };
     assert!(resolve_value_layout(&opaque, None).is_some());
 }
 

--- a/ghostscope-dwarf/src/parser/detailed_parser.rs
+++ b/ghostscope-dwarf/src/parser/detailed_parser.rs
@@ -782,7 +782,7 @@ impl DetailedParser {
                                     if avail > 0 {
                                         let elem_sz = element_type.size();
                                         let mut new_count: Option<u64> = None;
-                                        if elem_sz > 0 && avail % elem_sz == 0 {
+                                        if elem_sz > 0 && avail.is_multiple_of(elem_sz) {
                                             new_count = Some(avail / elem_sz);
                                         }
                                         m.member_type = TypeInfo::ArrayType {

--- a/ghostscope-dwarf/src/semantics/type_context.rs
+++ b/ghostscope-dwarf/src/semantics/type_context.rs
@@ -198,13 +198,14 @@ impl SemanticType {
 
 /// Identity for a type that may combine an exact DWARF DIE with script-created
 /// pointer, array, or qualifier wrappers.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum TypeIdentity {
     Dwarf(TypeId),
     Synthetic {
         kind: SyntheticTypeKind,
         inner: Box<TypeIdentity>,
     },
+    #[default]
     Unknown,
 }
 
@@ -281,12 +282,6 @@ impl TypeIdentity {
                 VariableAccessSegment::Field(_) | VariableAccessSegment::TupleIndex(_) => None,
             },
         }
-    }
-}
-
-impl Default for TypeIdentity {
-    fn default() -> Self {
-        Self::Unknown
     }
 }
 

--- a/ghostscope-platform/src/tls.rs
+++ b/ghostscope-platform/src/tls.rs
@@ -71,7 +71,7 @@ pub fn current_task_fsbase_offset() -> Result<u64, TlsLayoutError> {
     let task_thread_bits = find_member_bit_offset(&records, "task_struct", "thread")?;
     let thread_fsbase_bits = find_member_bit_offset(&records, "thread_struct", "fsbase")?;
 
-    if task_thread_bits % 8 != 0 || thread_fsbase_bits % 8 != 0 {
+    if !task_thread_bits.is_multiple_of(8) || !thread_fsbase_bits.is_multiple_of(8) {
         return Err(TlsLayoutError::Invalid(
             "task_struct.thread.fsbase is not byte-aligned",
         ));

--- a/ghostscope-process/src/sysmon/runtime_loop.rs
+++ b/ghostscope-process/src/sysmon/runtime_loop.rs
@@ -238,6 +238,6 @@ pub(super) fn run_sysmon_loop(
             );
         }
     } else {
-        return Err(anyhow::anyhow!("No sysmon events map found (ringbuf/perf)"));
+        Err(anyhow::anyhow!("No sysmon events map found (ringbuf/perf)"))
     }
 }

--- a/ghostscope-protocol/src/format_printer.rs
+++ b/ghostscope-protocol/src/format_printer.rs
@@ -918,8 +918,7 @@ impl FormatPrinter {
                     return "<INVALID_NESTED_SEQUENCE_PAYLOAD>".to_string();
                 };
                 let minimum_slot = NESTED_VALUE_CHILD_HEADER_SIZE
-                    .checked_add(usize::try_from(element.payload_len).unwrap_or(usize::MAX))
-                    .unwrap_or(usize::MAX);
+                    .saturating_add(usize::try_from(element.payload_len).unwrap_or(usize::MAX));
                 if slot_stride < minimum_slot {
                     return "<INVALID_NESTED_SEQUENCE_PAYLOAD>".to_string();
                 }

--- a/ghostscope-ui/src/components/command_panel/response_formatter.rs
+++ b/ghostscope-ui/src/components/command_panel/response_formatter.rs
@@ -825,7 +825,7 @@ impl ResponseFormatter {
 
         response.push_str("\n📊 File Type Summary:\n");
         let mut sorted_types: Vec<_> = file_types.into_iter().collect();
-        sorted_types.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted_types.sort_by_key(|a| std::cmp::Reverse(a.1));
 
         for (ext, count) in sorted_types.into_iter().take(10) {
             let icon = UISymbols::get_file_icon(&ext, use_ascii);

--- a/ghostscope-ui/src/components/source_panel/navigation.rs
+++ b/ghostscope-ui/src/components/source_panel/navigation.rs
@@ -185,7 +185,7 @@ impl SourceNavigation {
                         }
                     } else {
                         // Stay at end of last line
-                        state.cursor_col = chars.len().saturating_sub(1).max(0);
+                        state.cursor_col = chars.len().saturating_sub(1);
                     }
                 } else {
                     state.cursor_col = pos;
@@ -686,8 +686,7 @@ impl SourceNavigation {
             // Ensure we don't scroll beyond reasonable bounds if line is shorter
             if line_char_count <= available_width && state.horizontal_scroll_offset > 0 {
                 // Line fits entirely but we have scrolled - only allow minimal scroll for short lines
-                let max_scroll_for_short_line =
-                    line_char_count.saturating_sub(available_width / 2).max(0);
+                let max_scroll_for_short_line = line_char_count.saturating_sub(available_width / 2);
                 state.horizontal_scroll_offset = state
                     .horizontal_scroll_offset
                     .min(max_scroll_for_short_line);

--- a/ghostscope-ui/src/events/debug_info.rs
+++ b/ghostscope-ui/src/events/debug_info.rs
@@ -168,7 +168,7 @@ impl ModuleDebugInfo {
         let mut result = String::new();
 
         // Module header with full path and source info
-        result.push_str(&format!("📦 {}", &self.binary_path));
+        result.push_str(&format!("📦 {}", self.binary_path));
 
         // Add source information if available
         if let Some(ref file) = source_file {

--- a/ghostscope-ui/tests/app_integration_test.rs
+++ b/ghostscope-ui/tests/app_integration_test.rs
@@ -87,15 +87,15 @@ impl TestableApp {
                     state.command_input.pop();
                 }
             }
-            KeyCode::Enter => {
-                if state.current_panel == PanelType::Command && !state.command_input.is_empty() {
-                    // Process command
-                    let _cmd = state.command_input.clone();
-                    state.command_input.clear();
+            KeyCode::Enter
+                if state.current_panel == PanelType::Command && !state.command_input.is_empty() =>
+            {
+                // Process command
+                let _cmd = state.command_input.clone();
+                state.command_input.clear();
 
-                    // Send as RuntimeCommand (mock)
-                    // In real implementation, this would parse and send the actual command
-                }
+                // Send as RuntimeCommand (mock)
+                // In real implementation, this would parse and send the actual command
             }
             _ => {}
         }

--- a/ghostscope/src/core/session.rs
+++ b/ghostscope/src/core/session.rs
@@ -171,8 +171,8 @@ impl GhostSession {
             } else {
                 info!("Sysmon started (-p map-change mode)");
             }
-        } else if s.target_binary.is_some() {
-            let tpath = PathBuf::from(s.target_binary.as_ref().unwrap());
+        } else if let Some(target_binary) = &s.target_binary {
+            let tpath = PathBuf::from(target_binary);
             if config.ebpf_config.enable_sysmon_for_target {
                 let cfg = SysmonConfig {
                     target_module: Some(tpath.clone()),

--- a/ghostscope/src/trace/backtrace.rs
+++ b/ghostscope/src/trace/backtrace.rs
@@ -416,7 +416,7 @@ impl BacktraceRenderer {
         }
 
         let resolved = analyzer
-            .and_then(|analyzer| module.as_ref().map(|module| (analyzer, module)))
+            .zip(module.as_ref())
             .and_then(|(analyzer, module)| {
                 let lookup_pc = if index == 0 {
                     module.pc
@@ -507,7 +507,7 @@ impl BacktraceRenderer {
         }
 
         let resolved = analyzer
-            .and_then(|analyzer| module.as_ref().map(|module| (analyzer, module)))
+            .zip(module.as_ref())
             .and_then(|(analyzer, module)| {
                 let lookup_pc = if index == 0 {
                     module.pc

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- upgrade the project toolchain and MSRV from Rust 1.88 to 1.98
- align CI, Docker images, badges, and development docs with Rust 1.98.0
- address Rust 1.98 Clippy lints without changing runtime behavior
- keep pinned legacy toolchains used by compatibility tests unchanged

## Testing

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings -D clippy::undocumented_unsafe_blocks`
- `cargo test --no-run --all-features`
- `cargo build -p dwarf-tool`
- `GHOSTSCOPE_REQUIRE_RUST_COMPAT_TOOLCHAINS=1 RUST_BACKTRACE=1 cargo test --all-features`
- standard e2e runner job `35255af8dcc0`: all build stages passed; the run stopped in `backtrace_execution` after 30/31 tests because one load-sensitive dlopen backtrace case failed following trace-reader queue drops
- targeted runner retry `f7bb85ad6dec`: the failed case passed

Container-topology e2e was not run because this change does not affect container, PID namespace, sandbox, or topology behavior.