### PR TITLE
fix: prevent exponential block path traversal

### DIFF
--- a/e2e-tests/tests/cpp_script_execution.rs
+++ b/e2e-tests/tests/cpp_script_execution.rs
@@ -5,6 +5,7 @@ mod common;
 use common::{init, FIXTURES};
 
 const CPP_NESTED_MEMBER_TRACE_LINE: u32 = 44;
+const CPP_SIBLING_BLOCK_MEMBER_TRACE_LINE: u32 = 72;
 
 async fn compile_cpp_complex_script(
     script: &str,
@@ -95,6 +96,35 @@ trace {}:{CPP_NESTED_MEMBER_TRACE_LINE} {{
             "expected at least one failed target for invalid o.shadow access"
         );
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cpp_member_access_after_many_sibling_blocks_compiles() -> anyhow::Result<()> {
+    init();
+
+    let binary_path = FIXTURES.get_test_binary("cpp_complex_program")?;
+    let source_path = binary_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("cpp_complex_program has no parent directory"))?
+        .join("main.cpp");
+    let script = format!(
+        r#"
+trace {}:{CPP_SIBLING_BLOCK_MEMBER_TRACE_LINE} {{
+    print "m={{}}", b.m;
+}}
+"#,
+        source_path.display()
+    );
+
+    let result = compile_cpp_complex_script(&script).await?;
+    assert!(
+        !result.uprobe_configs.is_empty(),
+        "expected b.m in the last sibling block to compile; target_info={} failed_targets={:?}",
+        result.target_info,
+        result.failed_targets
+    );
 
     Ok(())
 }

--- a/e2e-tests/tests/fixtures/cpp_complex_program/main.cpp
+++ b/e2e-tests/tests/fixtures/cpp_complex_program/main.cpp
@@ -45,6 +45,35 @@ __attribute__((noinline)) int nested_member_probe(int v) {
     return (int)sink;
 }
 
+struct BlockPathBox { int m; };
+volatile int block_path_sink;
+
+__attribute__((noinline)) int sibling_block_member_probe(int x) {
+    { int v0  = x; block_path_sink = v0;  }
+    { int v1  = x; block_path_sink = v1;  }
+    { int v2  = x; block_path_sink = v2;  }
+    { int v3  = x; block_path_sink = v3;  }
+    { int v4  = x; block_path_sink = v4;  }
+    { int v5  = x; block_path_sink = v5;  }
+    { int v6  = x; block_path_sink = v6;  }
+    { int v7  = x; block_path_sink = v7;  }
+    { int v8  = x; block_path_sink = v8;  }
+    { int v9  = x; block_path_sink = v9;  }
+    { int v10 = x; block_path_sink = v10; }
+    { int v11 = x; block_path_sink = v11; }
+    { int v12 = x; block_path_sink = v12; }
+    { int v13 = x; block_path_sink = v13; }
+    { int v14 = x; block_path_sink = v14; }
+    { int v15 = x; block_path_sink = v15; }
+    { int v16 = x; block_path_sink = v16; }
+    { int v17 = x; block_path_sink = v17; }
+    {
+        BlockPathBox b{x};
+        block_path_sink = b.m;
+    }
+    return block_path_sink;
+}
+
 // Variables purposely ending with ::h and ::h264 to validate demangled leaf handling
 int h = 5;
 int h264 = 7;
@@ -64,6 +93,7 @@ int main() {
         acc += ns1::add(i, i+1);
         acc += ns1::add(1.5, 2.5);
         acc += ns1::nested_member_probe(i);
+        acc += ns1::sibling_block_member_probe(i);
         touch_globals();
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }

--- a/ghostscope-dwarf/src/index/block_index.rs
+++ b/ghostscope-dwarf/src/index/block_index.rs
@@ -129,34 +129,35 @@ impl FunctionBlocks {
 
     /// Return node indices from root to the innermost block containing PC
     pub fn block_path_for_pc(&self, pc: u64) -> Vec<usize> {
-        let mut path = vec![0usize];
         if self.nodes[0].children.is_empty() {
-            return path;
+            return vec![0];
         }
 
-        let mut stack = vec![(0usize, 0usize)]; // (node, child_iter_index)
-        let mut best_path = path.clone();
-        while let Some((node_idx, mut child_idx)) = stack.pop() {
-            // Try children depth-first
-            while child_idx < self.nodes[node_idx].children.len() {
-                let child = self.nodes[node_idx].children[child_idx];
-                child_idx += 1;
-                // Push back current with advanced iterator
-                stack.push((node_idx, child_idx));
-                // Descend into child
+        let mut parents = vec![None; self.nodes.len()];
+        let mut stack = vec![(0usize, 0usize)]; // (node, depth)
+        let mut innermost = (0usize, 0usize);
+
+        while let Some((node_idx, depth)) = stack.pop() {
+            for &child in self.nodes[node_idx].children.iter().rev() {
                 if self.nodes[child].contains_pc(pc) {
-                    // Extend path
-                    let mut cur = path.clone();
-                    cur.push(child);
-                    path = cur.clone();
-                    best_path = path.clone();
-                    // Descend further from this child
-                    stack.push((child, 0));
-                    break;
+                    let child_depth = depth + 1;
+                    parents[child] = Some(node_idx);
+                    if child_depth > innermost.1 {
+                        innermost = (child, child_depth);
+                    }
+                    stack.push((child, child_depth));
                 }
             }
         }
-        best_path
+
+        let mut path = Vec::with_capacity(innermost.1 + 1);
+        let mut current = Some(innermost.0);
+        while let Some(node_idx) = current {
+            path.push(node_idx);
+            current = parents[node_idx];
+        }
+        path.reverse();
+        path
     }
 
     /// Enumerate all VarRefs visible at PC with their lexical path depth.
@@ -651,6 +652,52 @@ mod tests {
     };
     use gimli::{BigEndian, Format, LittleEndian, Register};
     use std::sync::Arc;
+
+    #[test]
+    fn block_path_for_pc_ignores_non_containing_siblings() {
+        const PC: u64 = 0x2000;
+        const NON_MATCHING_SIBLINGS: usize = 8;
+
+        let mut function = FunctionBlocks::new(gimli::DebugInfoOffset(0), gimli::UnitOffset(0));
+        for index in 0..NON_MATCHING_SIBLINGS {
+            let mut sibling = BlockNode::new();
+            let start = 0x1000 + index as u64 * 2;
+            sibling.ranges.push((start, start + 1));
+            function.nodes.push(sibling);
+            function.nodes[0].children.push(index + 1);
+        }
+
+        let mut matching_sibling = BlockNode::new();
+        matching_sibling.ranges.push((PC, PC + 1));
+        function.nodes.push(matching_sibling);
+        let matching_index = function.nodes.len() - 1;
+        function.nodes[0].children.push(matching_index);
+
+        assert_eq!(function.block_path_for_pc(PC), vec![0, matching_index]);
+    }
+
+    #[test]
+    fn block_path_for_pc_selects_the_deepest_overlapping_branch() {
+        const PC: u64 = 0x2000;
+
+        let mut function = FunctionBlocks::new(gimli::DebugInfoOffset(0), gimli::UnitOffset(0));
+        let mut shallow = BlockNode::new();
+        shallow.ranges.push((PC, PC + 1));
+        function.nodes.push(shallow);
+        function.nodes[0].children.push(1);
+
+        let mut outer = BlockNode::new();
+        outer.ranges.push((PC, PC + 1));
+        function.nodes.push(outer);
+        function.nodes[0].children.push(2);
+
+        let mut inner = BlockNode::new();
+        inner.ranges.push((PC, PC + 1));
+        function.nodes.push(inner);
+        function.nodes[2].children.push(3);
+
+        assert_eq!(function.block_path_for_pc(PC), vec![0, 2, 3]);
+    }
 
     fn build_call_site_fixture(
         call_site_tag: gimli::DwTag,


### PR DESCRIPTION
## Summary

- visit each lexical block at most once when resolving the block path for a PC
- reconstruct the deepest containing path through parent links
- add unit coverage for non-matching siblings and overlapping branches
- add a C++ e2e reproducer that evaluates b.m after 18 sibling lexical blocks

## Reproduction

Before the fix, the 18-sibling reproducer did not finish within an 8-second timeout. After the fix, the same dwarf-tool source-line query completed in 0.00 seconds.

The old traversal queued a continuation for every checked sibling, including siblings that did not contain the PC. Those continuations repeatedly rescanned the remaining siblings and grew exponentially.

## Testing

- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p ghostscope-dwarf
- focused host-to-host e2e: test_cpp_member_access_after_many_sibling_blocks_compiles
- full host-to-host e2e: all 5 C++ script tests passed, including the new regression test

The full e2e run was not completely green because 16 unrelated Rust script tests failed. The isolated test_rust_script_print_string_values failure reproduced with the same read_user error on an unchanged origin/main worktree, confirming it is a baseline or environment issue rather than a regression from this patch.

Container-topology e2e was intentionally skipped because this change does not affect containers, PID namespaces, or topology handling.