### PR TITLE
fix: report partial script compilation failures on stderr

### DIFF
--- a/e2e-tests/tests/script_execution.rs
+++ b/e2e-tests/tests/script_execution.rs
@@ -10,6 +10,36 @@
 
 mod common;
 
+#[tokio::test]
+async fn test_partial_compilation_failures_are_visible_without_logging() -> anyhow::Result<()> {
+    init();
+    let target = common::targets::TargetLauncher::sample_program_with_opt(OptimizationLevel::Debug)
+        .spawn()
+        .await?;
+    let (code, stdout, stderr) = common::runner::GhostscopeRunner::new()
+        .with_script(
+            r#"
+trace process_record { print "PARTIAL_GOOD"; }
+trace no_such_partial_failure_target { print "PARTIAL_BAD"; }
+"#,
+        )
+        .attach_to(&target)
+        .with_cli_args(["--no-log", "--no-status"])
+        .timeout_secs(3)
+        .run()
+        .await?;
+    target.terminate().await?;
+    assert_eq!(code, 0, "stderr={stderr} stdout={stdout}");
+    assert!(stdout.contains("PARTIAL_GOOD"), "{stdout}");
+    assert!(!stdout.contains("PARTIAL_BAD"), "{stdout}");
+    assert!(
+        stderr.contains("no_such_partial_failure_target"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("failed to compile"), "{stderr}");
+    Ok(())
+}
+
 use common::{init, OptimizationLevel, FIXTURES};
 use lazy_static::lazy_static;
 use std::collections::HashMap;

--- a/ghostscope/src/script/cli.rs
+++ b/ghostscope/src/script/cli.rs
@@ -45,6 +45,21 @@ pub fn compile_script_for_cli(
                 failed.target_name, failed.pc_address, failed.error_message
             );
         }
+        // Partial success still produces a runnable script. These diagnostics
+        // must remain visible when script mode disables logging and status UI.
+        if !compilation_result.uprobe_configs.is_empty() {
+            eprintln!(
+                "Warning: {} trace target(s) failed to compile; {} probe(s) compiled successfully:",
+                compilation_result.failed_targets.len(),
+                compilation_result.uprobe_configs.len()
+            );
+            for failed in &compilation_result.failed_targets {
+                eprintln!(
+                    "  {} at 0x{:x}: {}",
+                    failed.target_name, failed.pc_address, failed.error_message
+                );
+            }
+        }
     }
 
     Ok(compilation_result)


### PR DESCRIPTION
A script containing both valid and invalid trace targets could keep tracing the valid targets while hiding the failed targets when logging and status output were disabled.

Report partial compilation failures on stderr independently of those settings. Keep the successful probe configurations and existing attachment and exit-code behavior. Complete failures continue through the existing error path.

Rebased onto main at `f28b207`; one commit, two files. `git range-diff` confirms the original patch is unchanged.

Validation on `f418dcf`:
- Formatting check and full workspace Clippy with CI warning settings passed.
- All 955 non-e2e tests passed locally, with the same test-name list as GitHub Test Suite.
- Full standard e2e passed locally and in GitHub: 348 tests, including the new `--no-log --no-status` regression.
- A temporary base/head CLI matrix passed 12 scenarios (24 invocations): missing targets in either order, body compilation failures, all-success/all-failure cases, and syntax errors in live and dry-run modes. Partial runs gained stderr diagnostics while valid tracing, dry-run stdout, and exit behavior remained consistent.
- All nine applicable GitHub checks passed, including three full container topologies and host-PID smoke. Local container runs were omitted because this change does not alter container behavior.
